### PR TITLE
LINK-324, LINK-325, LINK-326 LINK-328, LINK-330, LINK-332 | Small improvements

### DIFF
--- a/src/common/components/errorTemplate/__tests__/__snapshots__/ErrorTemplate.test.tsx.snap
+++ b/src/common/components/errorTemplate/__tests__/__snapshots__/ErrorTemplate.test.tsx.snap
@@ -68,7 +68,7 @@ exports[`should render component 1`] = `
         <span
           class="Button-module_label__a4np1 button_hds-button__label__2EQa-"
         >
-          Anna palautetta ja vaikuta
+          Anna palautetta
         </span>
         <div
           aria-hidden="true"

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -20,7 +20,8 @@ export const OIDC_API_TOKEN_ENDPOINT = `${process.env.REACT_APP_OIDC_AUTHORITY}/
 // Supported languages
 export enum SUPPORTED_LANGUAGES {
   FI = 'fi',
-  SV = 'sv',
+  // TODO: Add Swedish to supported languages when UI texts has been translated
+  // SV = 'sv',
   EN = 'en',
 }
 

--- a/src/domain/app/footer/__tests__/__snapshots__/Footer.test.tsx.snap
+++ b/src/domain/app/footer/__tests__/__snapshots__/Footer.test.tsx.snap
@@ -96,7 +96,7 @@ exports[`matches snapshot 1`] = `
         href="https://www.hel.fi/helsinki/sv/stad-och-forvaltning/delta/feedback/"
       >
         <span>
-          Ge respons och påverka
+          Ge respons
         </span>
       </a>
       <button

--- a/src/domain/app/header/__tests__/Header.test.tsx
+++ b/src/domain/app/header/__tests__/Header.test.tsx
@@ -21,14 +21,18 @@ const renderComponent = (store?: Store<StoreState, AnyAction>, route = '/fi') =>
 
 const findComponent = (
   key:
+    | 'enOption'
     | 'languageSelector'
     | 'menuButton'
     | 'navigation'
     | 'signInButton'
     | 'signOutLink'
-    | 'svOption'
 ) => {
   switch (key) {
+    case 'enOption':
+      return screen.findByRole('link', {
+        name: translations.navigation.languages.en,
+      });
     case 'languageSelector':
       return screen.findByRole('button', {
         name: translations.navigation.languageSelectorAriaLabel,
@@ -43,10 +47,6 @@ const findComponent = (
       return screen.findByRole('button', { name: translations.common.signIn });
     case 'signOutLink':
       return screen.findByRole('link', { name: translations.common.signOut });
-    case 'svOption':
-      return screen.findByRole('link', {
-        name: translations.navigation.languages.sv,
-      });
   }
 };
 
@@ -55,7 +55,8 @@ beforeEach(() => {
   i18n.changeLanguage('fi');
 });
 
-test('matches snapshot', async () => {
+// TODO: Skip this test because SV UI language is temporarily disabled
+test.skip('matches snapshot', async () => {
   i18n.changeLanguage('sv');
   const { container } = renderComponent(undefined, '/sv');
 
@@ -107,10 +108,10 @@ test('should change language', async () => {
   const languageSelectorButton = await findComponent('languageSelector');
   userEvent.click(languageSelectorButton);
 
-  const svOption = await findComponent('svOption');
-  userEvent.click(svOption);
+  const enOption = await findComponent('enOption');
+  userEvent.click(enOption);
 
-  expect(history.location.pathname).toBe('/sv');
+  expect(history.location.pathname).toBe('/en');
 });
 
 test('should start log in process', async () => {

--- a/src/domain/app/i18n/en.json
+++ b/src/domain/app/i18n/en.json
@@ -47,7 +47,7 @@
       }
     },
     "feedback": {
-      "text": "Give feedback and make an impact",
+      "text": "Give feedback",
       "url": "https://www.hel.fi/helsinki/en/administration/participate/feedback/"
     },
     "goToHome": "To home page",

--- a/src/domain/app/i18n/en.json
+++ b/src/domain/app/i18n/en.json
@@ -498,7 +498,6 @@
       "titleOfferDescription": "Description of price information",
       "titleOfferInfoUrl": "Link to ticket sales or registration",
       "titleOfferPrice": "Price",
-      "titlePersonsInCharge": "Person(s) in charge",
       "titlePriceInfo": {
         "course": "Course price information",
         "event": "Event price information"

--- a/src/domain/app/i18n/en.json
+++ b/src/domain/app/i18n/en.json
@@ -712,7 +712,7 @@
     "warningNoRightsToUpload": "You have insufficient rights to add images."
   },
   "landingPage": {
-    "heroTitle": "Check out the new service"
+    "heroTitle": "Events and hobbies in Helsinki"
   },
   "logoutPage": {
     "pageTitle": "You are logged out",

--- a/src/domain/app/i18n/fi.json
+++ b/src/domain/app/i18n/fi.json
@@ -497,7 +497,6 @@
       "titleOfferDescription": "Hintatietojen kuvaus",
       "titleOfferInfoUrl": "Linkki lipunmyyntiin tai ilmoittautumiseen",
       "titleOfferPrice": "Hinta",
-      "titlePersonsInCharge": "Vastuuhenkilöt",
       "titlePriceInfo": {
         "course": "Kurssin hintatiedot",
         "event": "Tapahtuman hintatiedot"

--- a/src/domain/app/i18n/fi.json
+++ b/src/domain/app/i18n/fi.json
@@ -713,7 +713,7 @@
     "warningNoRightsToUpload": "Sinulla ei ole oikeuksia lisätä kuvia"
   },
   "landingPage": {
-    "heroTitle": "Tutustu uuteen palveluun"
+    "heroTitle": "Helsingin tapahtumat ja harrastukset"
   },
   "logoutPage": {
     "pageTitle": "Olet kirjautunut ulos",

--- a/src/domain/app/i18n/fi.json
+++ b/src/domain/app/i18n/fi.json
@@ -47,7 +47,7 @@
       }
     },
     "feedback": {
-      "text": "Anna palautetta ja vaikuta",
+      "text": "Anna palautetta",
       "url": "https://www.hel.fi/helsinki/fi/kaupunki-ja-hallinto/osallistu-ja-vaikuta/palaute/anna-palautetta"
     },
     "goToHome": "Etusivulle",

--- a/src/domain/app/i18n/i18nInit.ts
+++ b/src/domain/app/i18n/i18nInit.ts
@@ -31,7 +31,8 @@ i18n
     whitelist: [
       SUPPORTED_LANGUAGES.EN,
       SUPPORTED_LANGUAGES.FI,
-      SUPPORTED_LANGUAGES.SV,
+      // TODO: Add Swedish to supported languages when UI texts has been translated
+      // SUPPORTED_LANGUAGES.SV,
     ],
     resources: {
       en: {

--- a/src/domain/app/i18n/sv.json
+++ b/src/domain/app/i18n/sv.json
@@ -497,7 +497,6 @@
       "titleOfferDescription": "Beskrivning av prisinformation",
       "titleOfferInfoUrl": "Länk till biljettförsäljning eller registrering",
       "titleOfferPrice": "Pris",
-      "titlePersonsInCharge": "Ansvariga person(er)",
       "titlePriceInfo": {
         "course": "Prisinformation för kurs",
         "event": "Prisinformation för evenemang"

--- a/src/domain/app/i18n/sv.json
+++ b/src/domain/app/i18n/sv.json
@@ -712,7 +712,7 @@
     "warningNoRightsToUpload": "You have insufficient rights to add images."
   },
   "landingPage": {
-    "heroTitle": "Kolla in den nya tjänsten"
+    "heroTitle": "Evenemang och hobbyer i Helsingfors"
   },
   "logoutPage": {
     "pageTitle": "Du är utloggad",

--- a/src/domain/app/i18n/sv.json
+++ b/src/domain/app/i18n/sv.json
@@ -47,7 +47,7 @@
       }
     },
     "feedback": {
-      "text": "Ge respons och påverka",
+      "text": "Ge respons",
       "url": "https://www.hel.fi/helsinki/sv/stad-och-forvaltning/delta/feedback/"
     },
     "goToHome": "Till startsidan",

--- a/src/domain/event/formSections/priceSection/Offer.tsx
+++ b/src/domain/event/formSections/priceSection/Offer.tsx
@@ -14,13 +14,19 @@ import FieldWithButton from '../../layout/FieldWithButton';
 type Props = {
   offerPath: string;
   onDelete: () => void;
+  showInstructions?: boolean;
   type: string;
 };
 
 const getFieldName = (offerPath: string, field: string) =>
   `${offerPath}.${field}`;
 
-const Offer: React.FC<Props> = ({ offerPath, onDelete, type }) => {
+const Offer: React.FC<Props> = ({
+  offerPath,
+  onDelete,
+  showInstructions,
+  type,
+}) => {
   const { t } = useTranslation();
 
   const [{ value: eventInfoLanguages }] = useField({
@@ -32,14 +38,16 @@ const Offer: React.FC<Props> = ({ offerPath, onDelete, type }) => {
       <h3>{t('event.form.titleOfferPrice')}</h3>
       <FieldRow
         notification={
-          <Notification
-            className={styles.notification}
-            label={t(`event.form.notificationTitleOffers`)}
-            type="info"
-          >
-            <p>{t(`event.form.infoTextOffers1.${type}`)}</p>
-            <p>{t(`event.form.infoTextOffers2.${type}`)}</p>
-          </Notification>
+          showInstructions ? (
+            <Notification
+              className={styles.notification}
+              label={t(`event.form.notificationTitleOffers`)}
+              type="info"
+            >
+              <p>{t(`event.form.infoTextOffers1.${type}`)}</p>
+              <p>{t(`event.form.infoTextOffers2.${type}`)}</p>
+            </Notification>
+          ) : undefined
         }
       >
         <FieldWithButton

--- a/src/domain/event/formSections/priceSection/Offers.tsx
+++ b/src/domain/event/formSections/priceSection/Offers.tsx
@@ -33,6 +33,7 @@ const Offers = () => {
                 key={index}
                 offerPath={getOfferPath(index)}
                 onDelete={() => arrayHelpers.remove(index)}
+                showInstructions={!index}
                 type={type}
               />
             );

--- a/src/domain/event/formSections/responsibilitiesSection/ResponsibilitiesSection.tsx
+++ b/src/domain/event/formSections/responsibilitiesSection/ResponsibilitiesSection.tsx
@@ -61,27 +61,6 @@ const ResponsibilitiesSection: React.FC<ResponsibilitiesSectionProps> = ({
         notification={
           <Notification
             className={styles.notification}
-            label={t('event.form.notificationTitleProvider')}
-            type="info"
-          >
-            <p>{t('event.form.infoTextProvider')}</p>
-          </Notification>
-        }
-      >
-        <FieldColumn>
-          <MultiLanguageField
-            labelKey={`event.form.labelProvider.${type}`}
-            languages={eventInfoLanguages}
-            name={EVENT_FIELDS.PROVIDER}
-            placeholder={t(`event.form.placeholderProvider.${type}`)}
-          />
-        </FieldColumn>
-      </FieldRow>
-
-      <FieldRow
-        notification={
-          <Notification
-            className={styles.notification}
             label={t('event.form.notificationTitlePublisher')}
             type="info"
           >
@@ -96,6 +75,27 @@ const ResponsibilitiesSection: React.FC<ResponsibilitiesSectionProps> = ({
             name={EVENT_FIELDS.PUBLISHER}
             component={PublisherSelectorField}
             publisher={savedEvent?.publisher}
+          />
+        </FieldColumn>
+      </FieldRow>
+
+      <FieldRow
+        notification={
+          <Notification
+            className={styles.notification}
+            label={t('event.form.notificationTitleProvider')}
+            type="info"
+          >
+            <p>{t('event.form.infoTextProvider')}</p>
+          </Notification>
+        }
+      >
+        <FieldColumn>
+          <MultiLanguageField
+            labelKey={`event.form.labelProvider.${type}`}
+            languages={eventInfoLanguages}
+            name={EVENT_FIELDS.PROVIDER}
+            placeholder={t(`event.form.placeholderProvider.${type}`)}
           />
         </FieldColumn>
       </FieldRow>

--- a/src/domain/event/formSections/responsibilitiesSection/ResponsibilitiesSection.tsx
+++ b/src/domain/event/formSections/responsibilitiesSection/ResponsibilitiesSection.tsx
@@ -57,7 +57,6 @@ const ResponsibilitiesSection: React.FC<ResponsibilitiesSectionProps> = ({
 
   return (
     <>
-      <h3>{t('event.form.titlePersonsInCharge')}</h3>
       <FieldRow
         notification={
           <Notification

--- a/src/domain/event/formSections/videoSection/Video.tsx
+++ b/src/domain/event/formSections/videoSection/Video.tsx
@@ -14,6 +14,7 @@ import FieldWithButton from '../../layout/FieldWithButton';
 type Props = {
   canDelete: boolean;
   onDelete: () => void;
+  showInstructions?: boolean;
   type: string;
   videoPath: string;
 };
@@ -21,7 +22,13 @@ type Props = {
 const getFieldName = (videoPath: string, field: string) =>
   `${videoPath}.${field}`;
 
-const Video: React.FC<Props> = ({ canDelete, onDelete, type, videoPath }) => {
+const Video: React.FC<Props> = ({
+  canDelete,
+  onDelete,
+  showInstructions,
+  type,
+  videoPath,
+}) => {
   const { t } = useTranslation();
 
   const fieldNames = React.useMemo(
@@ -54,14 +61,16 @@ const Video: React.FC<Props> = ({ canDelete, onDelete, type, videoPath }) => {
       <h3>{t(`event.form.titleVideo.${type}`)}</h3>
       <FieldRow
         notification={
-          <Notification
-            className={styles.notification}
-            label={t(`event.form.notificationTitleVideo.${type}`)}
-            type="info"
-          >
-            <p>{t(`event.form.infoTextVideo1.${type}`)}</p>
-            <p>{t(`event.form.infoTextVideo2`)}</p>
-          </Notification>
+          showInstructions ? (
+            <Notification
+              className={styles.notification}
+              label={t(`event.form.notificationTitleVideo.${type}`)}
+              type="info"
+            >
+              <p>{t(`event.form.infoTextVideo1.${type}`)}</p>
+              <p>{t(`event.form.infoTextVideo2`)}</p>
+            </Notification>
+          ) : undefined
         }
       >
         <FieldWithButton

--- a/src/domain/event/formSections/videoSection/VideoSection.tsx
+++ b/src/domain/event/formSections/videoSection/VideoSection.tsx
@@ -32,6 +32,7 @@ const VideoSection = () => {
                 key={index}
                 canDelete={videos.length > 1}
                 onDelete={() => arrayHelpers.remove(index)}
+                showInstructions={!index}
                 type={type}
                 videoPath={getVideoPath(index)}
               />


### PR DESCRIPTION
## Description
Remove unnecessary "Vastuuhenkilöt" headline
Swap order of "provided" and "publisher" fields
Show instruction texts for videos and prices only once
Update landing page title
Update "Give feedback" link text
Disable Swedish from UI languages

## Closes
[LINK-324](https://helsinkisolutionoffice.atlassian.net/browse/LINK-324)
[LINK-325](https://helsinkisolutionoffice.atlassian.net/browse/LINK-325)
[LINK-326](https://helsinkisolutionoffice.atlassian.net/browse/LINK-326)
[LINK-328](https://helsinkisolutionoffice.atlassian.net/browse/LINK-328)
[LINK-330](https://helsinkisolutionoffice.atlassian.net/browse/LINK-330)
[LINK-332](https://helsinkisolutionoffice.atlassian.net/browse/LINK-332)