### PR TITLE
LINK-291 | Update only editable sub-events when cancelling/deleting//postponing/…

### DIFF
--- a/src/domain/app/i18n/en.json
+++ b/src/domain/app/i18n/en.json
@@ -161,7 +161,9 @@
       "buttonCancel": "Cancel event",
       "text1": "This action cancels the event. You can also postpone the event, or delete an event that you entered accidentally.",
       "text2": "The following events will be cancelled:",
+      "textPastEventAreNotUpdated": "Please also note that the changes only apply to future events in the series. Past events in the series are not cancelled when cancelling the umbrella event.",
       "title": "Cancel event",
+      "titlePastEventAreNotUpdated": "Past events in the series will not be cancelled",
       "warning": "Remember that instead of canceling, you can also host the event remotely online. In this case, use the edit form to select Internet as the venue. You can also postpone the event to the future."
     },
     "deleteEventModal": {
@@ -607,7 +609,9 @@
       "buttonPostpone": "Postpone event",
       "text1": "This function postpones the event to the future. After postponing, you can later enter a new time for the event.",
       "text2": "The following events will be postponed:",
-      "title": "Postpone event"
+      "textPastEventAreNotUpdated": "Please also note that the changes only apply to future events in the series. Past events in the series are not postponed when postponing the roof event.",
+      "title": "Postpone event",
+      "titlePastEventAreNotUpdated": "Past events in the series will not be postponed"
     },
     "publicationStatus": {
       "draft": "Draft",
@@ -624,7 +628,9 @@
     "updateEventModal": {
       "text1": "Data is stored for all events in this series. Changes to these events will be lost. Are you sure you want to continue?",
       "text2": "The data is updated in the following events",
-      "title": "Save event"
+      "textPastEventAreNotUpdated": "Please also note that the changes only apply to future events in the series. Past events in the series are not edited when editing the umbrella event.",
+      "title": "Save event",
+      "titlePastEventAreNotUpdated": "Past events in the series will not be edited"
     }
   },
   "eventSavedPage": {

--- a/src/domain/app/i18n/fi.json
+++ b/src/domain/app/i18n/fi.json
@@ -161,7 +161,9 @@
       "buttonCancel": "Peruuta tapahtuma",
       "text1": "Tämä toiminto peruuttaa tapahtuman. Voit myös lykätä tapahtuman tulevaisuuteen, tai poistaa sellaisen tapahtuman, jonka syötit vahingossa.",
       "text2": "Seuraavat tapahtumat peruutetaan:",
+      "textPastEventAreNotUpdated": "Huomioithan myös, että muutokset pätevät vain sarjan tuleviin tapahtumiin. Sarjan menneitä tapahtumia ei peruta kattotapahtumaa peruttaessa.",
       "title": "Varmista tapahtuman peruminen",
+      "titlePastEventAreNotUpdated": "Sarjan menneitä tapahtumia ei peruta",
       "warning": "Muistathan, että perumisen sijaan voit myös järjestää tapahtuman etänä internetissä. Valitse tällöin muokkauslomakkeella tapahtumapaikaksi Internet. Voit myös lykätä tapahtuman tulevaisuuteen."
     },
     "deleteEventModal": {
@@ -606,7 +608,9 @@
       "buttonPostpone": "Lykkää tapahtumaa",
       "text1": "Tämä toiminto lykkää tapahtuman tulevaisuuteen. Lykättyäsi voit myöhemmin syöttää tapahtumalle uuden ajankohdan.",
       "text2": "Seuraavat tapahtumat lykätään:",
-      "title": "Varmista tapahtuman lykkääminen"
+      "textPastEventAreNotUpdated": "Huomioithan myös, että muutokset pätevät vain sarjan tuleviin tapahtumiin. Sarjan menneitä tapahtumia ei lykätä kattotapahtumaa lykätessä.",
+      "title": "Varmista tapahtuman lykkääminen",
+      "titlePastEventAreNotUpdated": "Sarjan menneitä tapahtumia ei lykätä"
     },
     "publicationStatus": {
       "draft": "Luonnos",
@@ -624,7 +628,9 @@
     "updateEventModal": {
       "text1": "Tiedot tallennetaan kaikkiin tapahtumiin tässä sarjassa. Näihin tapahtumiin tehdyt muutokset menetetään. Oletko varma että haluat jatkaa?",
       "text2": "Tiedot tallennetaan seuraaviin tapahtumiin:",
-      "title": "Varmista tapahtuman tallentaminen"
+      "textPastEventAreNotUpdated": "Huomioithan myös, että muutokset pätevät vain sarjan tuleviin tapahtumiin. Sarjan menneitä tapahtumia ei muokata kattotapahtumaa muokatessa.",
+      "title": "Varmista tapahtuman tallentaminen",
+      "titlePastEventAreNotUpdated": "Sarjan menneitä tapahtumia ei muokata"
     }
   },
   "eventSavedPage": {

--- a/src/domain/app/i18n/sv.json
+++ b/src/domain/app/i18n/sv.json
@@ -161,7 +161,9 @@
       "buttonCancel": "Avbryt evenemanget",
       "text1": "Denna åtgärd avbryter evenemanget. Du kan också skjuta upp evenemanget eller ta bort en händelse du angav av misstag.",
       "text2": "Följande evenemangen kommer att avbrytas:",
+      "textPastEventAreNotUpdated": "Observera också att ändringarna endast gäller framtida evenemang i serien. Tidigare evenemang i serien avbryts inte när paraplyevenemang avbryts.",
       "title": "Avbryt evenemanget",
+      "titlePastEventAreNotUpdated": "Tidigare evenemang i serien kommer inte att avbrytas",
       "warning": "Kom ihåg att istället för att avbryta kan du också vara värd för evenemanget på distans online. I så fall använder du redigeringsformuläret för att välja Internet som plats. Du kan också skjuta upp evenemanget till framtiden."
     },
     "deleteEventModal": {
@@ -606,7 +608,9 @@
       "buttonPostpone": "Skjuta upp evenemanget",
       "text1": "Denna funktion skjuter upp evenemanget till framtiden. Efter att ha skjutit upp kan du senare ange en ny tid för evenemanget.",
       "text2": "Följande evenemang kommer att skjutas upp:",
-      "title": "Skjuta upp evenemanget"
+      "textPastEventAreNotUpdated": "Observera också att ändringarna endast gäller framtida evenemang i serien. Tidigare evenemang i serien skjuts inte upp när paraplyevenemang skjuts upp.",
+      "title": "Skjuta upp evenemanget",
+      "titlePastEventAreNotUpdated": "Tidigare evenemang i serien kommer inte att skjutas upp"
     },
     "publicationStatus": {
       "draft": "Förslag",
@@ -624,7 +628,9 @@
     "updateEventModal": {
       "text1": "Data lagras för alla evenemang i denna serie. Ändringar av dessa evenemang kommer att gå förlorade. Är du säker på att du vill fortsätta?",
       "text2": "Uppgifterna lagras i följande evenemangen",
-      "title": "Spara evenemanget"
+      "textPastEventAreNotUpdated": "Observera också att ändringarna endast gäller framtida evenemang i serien. Tidigare evenemang i serien redigeras inte när du redigerar paraplyevenemang.",
+      "title": "Spara evenemanget",
+      "titlePastEventAreNotUpdated": "Tidigare evenemang i serien kommer inte att redigeras"
     }
   },
   "eventSavedPage": {

--- a/src/domain/app/layout/__tests__/MainContent.test.tsx
+++ b/src/domain/app/layout/__tests__/MainContent.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { scroller } from 'react-scroll';
 
 import { MAIN_CONTENT_ID } from '../../../../constants';
-import { actWait, render, screen, waitFor } from '../../../../utils/testUtils';
+import { render, screen, waitFor } from '../../../../utils/testUtils';
 import MainContent from '../MainContent';
 
 const renderComponent = (

--- a/src/domain/event/__tests__/CreateEventPage.test.tsx
+++ b/src/domain/event/__tests__/CreateEventPage.test.tsx
@@ -35,8 +35,6 @@ import { testId } from '../../../common/components/loadingSpinner/LoadingSpinner
 import { FORM_NAMES } from '../../../constants';
 import { fakeAuthenticatedStoreState } from '../../../utils/mockStoreUtils';
 import {
-  act,
-  actWait,
   configure,
   getMockReduxStore,
   render,

--- a/src/domain/event/editButtonPanel/__tests__/EditButtonPanel.test.tsx
+++ b/src/domain/event/editButtonPanel/__tests__/EditButtonPanel.test.tsx
@@ -8,7 +8,6 @@ import {
 } from '../../__mocks__/editEventPage';
 import { EventStatus, PublicationStatus } from '../../../../generated/graphql';
 import { StoreState } from '../../../../types';
-import { fakeEvent } from '../../../../utils/mockDataUtils';
 import { fakeAuthenticatedStoreState } from '../../../../utils/mockStoreUtils';
 import {
   configure,

--- a/src/domain/event/eventHierarchy/EventHierarchyRow.tsx
+++ b/src/domain/event/eventHierarchy/EventHierarchyRow.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next';
 import { EventFieldsFragment } from '../../../generated/graphql';
 import useLocale from '../../../hooks/useLocale';
 import formatDate from '../../../utils/formatDate';
+import useEventOrganizationAncestors from '../hooks/useEventOrganizationAncestors';
 import SuperEventTypeTag from '../tags/SuperEventTypeTag';
 import { getEventFields } from '../utils';
 import styles from './eventHierarchy.module.scss';
@@ -32,6 +33,10 @@ const EventHierarchyRow: React.FC<Props> = ({
   const { t } = useTranslation();
   const locale = useLocale();
   const { id, name, startTime, superEventType } = getEventFields(event, locale);
+
+  // Organization ancestors per sub-event are checked when saving recurring events,
+  // so fetch organization ancestors for each sub-event to make saving more performant
+  useEventOrganizationAncestors(event);
 
   const handleToggle = () => {
     toggle(id);

--- a/src/domain/event/modals/ConfirmCancelModal.tsx
+++ b/src/domain/event/modals/ConfirmCancelModal.tsx
@@ -53,6 +53,16 @@ const ConfirmCancelModal: React.FC<ConfirmCancelModalProps> = ({
       <p>{t('event.cancelEventModal.text1')}</p>
       <p>{t('event.cancelEventModal.text2')}</p>
       <EventHierarchy event={event} />
+      {Boolean(event.superEventType) && (
+        <p>
+          <strong>
+            {t('event.cancelEventModal.titlePastEventAreNotUpdated')}
+          </strong>
+          <br />
+          {t('event.cancelEventModal.textPastEventAreNotUpdated')}
+        </p>
+      )}
+
       <div className={styles.modalButtonWrapper}>
         <Button
           iconLeft={

--- a/src/domain/event/modals/ConfirmPostponeModal.tsx
+++ b/src/domain/event/modals/ConfirmPostponeModal.tsx
@@ -50,6 +50,16 @@ const ConfirmPostponeModal: React.FC<ConfirmPostponeModalProps> = ({
       <p>{t('event.postponeEventModal.text1')}</p>
       <p>{t('event.postponeEventModal.text2')}</p>
       <EventHierarchy event={event} />
+      {Boolean(event.superEventType) && (
+        <p>
+          <strong>
+            {t('event.postponeEventModal.titlePastEventAreNotUpdated')}
+          </strong>
+          <br />
+          {t('event.postponeEventModal.textPastEventAreNotUpdated')}
+        </p>
+      )}
+
       <div className={styles.modalButtonWrapper}>
         <Button
           iconLeft={

--- a/src/domain/event/modals/ConfirmUpdateModal.tsx
+++ b/src/domain/event/modals/ConfirmUpdateModal.tsx
@@ -47,6 +47,13 @@ const ConfirmUpdateModal: React.FC<ConfirmUpdateModalProps> = ({
       <p>{t('event.updateEventModal.text1')}</p>
       <p>{t('event.updateEventModal.text2')}</p>
       <EventHierarchy event={event} />
+      <p>
+        <strong>
+          {t('event.updateEventModal.titlePastEventAreNotUpdated')}
+        </strong>
+        <br />
+        {t('event.updateEventModal.textPastEventAreNotUpdated')}
+      </p>
       <div className={styles.modalButtonWrapper}>
         <Button
           iconLeft={

--- a/src/domain/event/modals/__mocks__/constants.ts
+++ b/src/domain/event/modals/__mocks__/constants.ts
@@ -1,30 +1,64 @@
-import { EventsDocument, SuperEventType } from '../../../../generated/graphql';
-import { fakeEvent, fakeEvents } from '../../../../utils/mockDataUtils';
+import { MockedResponse } from '@apollo/react-testing';
 
-export const subSubEventNames = ['Event 1', 'Event 2'];
+import { MAX_PAGE_SIZE } from '../../../../constants';
+import {
+  EventsDocument,
+  OrganizationsDocument,
+  SuperEventType,
+} from '../../../../generated/graphql';
+import {
+  fakeEvent,
+  fakeEvents,
+  fakeOrganizations,
+} from '../../../../utils/mockDataUtils';
+
+const publisherId = 'publisher:1';
+
+const organizationsVariables = {
+  child: publisherId,
+  createPath: undefined,
+  pageSize: MAX_PAGE_SIZE,
+};
+const organizationsResponse = {
+  data: {
+    organizations: fakeOrganizations(0),
+  },
+};
+const mockedOrganizationsResponse: MockedResponse = {
+  request: {
+    query: OrganizationsDocument,
+    variables: organizationsVariables,
+  },
+  result: organizationsResponse,
+};
+
+const subSubEventNames = ['Event 1', 'Event 2'];
 const subSubEvents = fakeEvents(
   subSubEventNames.length,
   subSubEventNames.map((name) => ({
     name: { fi: name },
+    publisher: publisherId,
   }))
 );
 
 const subEventId = 'subevent:1';
-export const subEventName = 'Recurring event name';
+const subEventName = 'Recurring event name';
 const subEvents = fakeEvents(1, [
   {
     id: subEventId,
     name: { fi: subEventName },
+    publisher: publisherId,
     subEvents: subSubEvents.data,
     superEventType: SuperEventType.Recurring,
   },
 ]);
 
 const eventId = 'event:1';
-export const eventName = 'Umbrella event name';
-export const event = fakeEvent({
+const eventName = 'Umbrella event name';
+const event = fakeEvent({
   id: eventId,
   name: { fi: eventName },
+  publisher: publisherId,
   subEvents: subEvents.data,
   superEventType: SuperEventType.Umbrella,
 });
@@ -49,7 +83,8 @@ const subSubEventsVariables = {
 const subEventsResponse = { data: { events: subEvents } };
 const subSubEventsResponse = { data: { events: subSubEvents } };
 
-export const mocks = [
+const mocks = [
+  mockedOrganizationsResponse,
   {
     request: {
       query: EventsDocument,
@@ -65,3 +100,5 @@ export const mocks = [
     result: subSubEventsResponse,
   },
 ];
+
+export { event, eventName, mocks, subEventName, subSubEventNames };

--- a/src/domain/event/utils.ts
+++ b/src/domain/event/utils.ts
@@ -50,6 +50,8 @@ import {
   LocalisedObject,
   Maybe,
   OrganizationFieldsFragment,
+  OrganizationsDocument,
+  OrganizationsQuery,
   PublicationStatus,
   SuperEventType,
   UserFieldsFragment,
@@ -68,6 +70,7 @@ import {
 import { VALIDATION_MESSAGE_KEYS } from '../app/i18n/constants';
 import { EVENT_SORT_OPTIONS } from '../events/constants';
 import { eventsPathBuilder } from '../events/utils';
+import { organizationPathBuilder } from '../organization/utils';
 import {
   ADD_IMAGE_FIELDS,
   AUHENTICATION_NOT_NEEDED,
@@ -1356,6 +1359,29 @@ export const getRelatedEvents = async ({
   allRelatedEvents.push(...subEvents);
 
   return allRelatedEvents;
+};
+
+export const getOrganizationAncestors = async ({
+  event,
+  apolloClient,
+}: {
+  apolloClient: ApolloClient<object>;
+  event: EventFieldsFragment;
+}): Promise<OrganizationFieldsFragment[]> => {
+  try {
+    const { data } = await apolloClient.query<OrganizationsQuery>({
+      query: OrganizationsDocument,
+      variables: {
+        child: event.publisher as string,
+        createPath: getPathBuilder(organizationPathBuilder),
+        pageSize: MAX_PAGE_SIZE,
+      },
+    });
+
+    return data.organizations.data as OrganizationFieldsFragment[];
+  } catch (e) {
+    return [];
+  }
 };
 
 export const checkCanUserDoAction = ({


### PR DESCRIPTION
## Description
Update only editable sub-events when cancelling/deleting//postponing/updating super event

## Closes
[LINK-291](https://helsinkisolutionoffice.atlassian.net/browse/LINK-291)

## Screenshots
<img width="587" alt="Screenshot 2021-04-05 at 22 39 42" src="https://user-images.githubusercontent.com/24706814/113618590-9540a280-9660-11eb-89e0-cf6edb441a27.png">

<img width="593" alt="Screenshot 2021-04-05 at 22 39 59" src="https://user-images.githubusercontent.com/24706814/113618604-983b9300-9660-11eb-8027-1ba703558db5.png">

<img width="574" alt="Screenshot 2021-04-05 at 22 40 12" src="https://user-images.githubusercontent.com/24706814/113618615-9b368380-9660-11eb-84de-e36c1505c951.png">
