### PR TITLE
LINK-553 | Wider width for the description field

### DIFF
--- a/src/domain/event/formSections/descriptionSection/DescriptionSection.tsx
+++ b/src/domain/event/formSections/descriptionSection/DescriptionSection.tsx
@@ -134,23 +134,21 @@ const DescriptionSection: React.FC<DescriptionSectionProps> = ({
                       required={true}
                     />
                   </FormGroup>
-                  <FormGroup>
-                    <Field
-                      component={TextEditorField}
-                      label={t(`event.form.labelDescription.${type}`, {
-                        langText,
-                      })}
-                      name={`${EVENT_FIELDS.DESCRIPTION}.${selectedLanguage}`}
-                      placeholder={t(
-                        `event.form.placeholderDescription.${type}`
-                      )}
-                      sanitizeAfterChange={sanitizeDescriptionAfterChange}
-                      maxLength={CHARACTER_LIMITS.LONG_STRING}
-                      required={true}
-                    />
-                  </FormGroup>
                 </FieldColumn>
               </FieldRow>
+              <FormGroup>
+                <Field
+                  component={TextEditorField}
+                  label={t(`event.form.labelDescription.${type}`, {
+                    langText,
+                  })}
+                  name={`${EVENT_FIELDS.DESCRIPTION}.${selectedLanguage}`}
+                  placeholder={t(`event.form.placeholderDescription.${type}`)}
+                  sanitizeAfterChange={sanitizeDescriptionAfterChange}
+                  maxLength={CHARACTER_LIMITS.LONG_STRING}
+                  required={true}
+                />
+              </FormGroup>
             </TabPanel>
           );
         })}


### PR DESCRIPTION
## Description
Use full container width for the description

## Closes
[LINK-553](https://helsinkisolutionoffice.atlassian.net/browse/LINK-553)

## Screenshot
<img width="973" alt="Screenshot 2021-08-18 at 12 45 42" src="https://user-images.githubusercontent.com/24706814/129879429-0c29a5a4-8cc6-44ed-84df-fad7647092a9.png">
