### PR TITLE
LINK-559 | Registrations list page with mock data

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,6 +3,7 @@
     "react-app",
     "plugin:@typescript-eslint/recommended",
     "plugin:prettier/recommended",
+    "plugin:testcafe/recommended",
     "plugin:import/errors",
     "plugin:import/warnings",
     "plugin:import/typescript",

--- a/browser-tests/footer/footer.components.ts
+++ b/browser-tests/footer/footer.components.ts
@@ -30,6 +30,9 @@ export const findFooter = async (t: TestController) => {
       eventSearchLink() {
         return withinFooter().findByRole('link', { name: /etsi tapahtumia/i });
       },
+      registrationsLink() {
+        return withinFooter().findByRole('link', { name: /ilmoittautuminen/i });
+      },
       supportLink() {
         return withinFooter().findByRole('link', { name: /tuki/i });
       },
@@ -51,6 +54,11 @@ export const findFooter = async (t: TestController) => {
           .expect(selectors.eventSearchLink().exists)
           .ok(await getErrorMessage(t));
       },
+      async registrationsPageLinkIsVisible() {
+        await t
+          .expect(selectors.registrationsLink().exists)
+          .ok(await getErrorMessage(t));
+      },
       async supportPageLinkIsVisible() {
         await t
           .expect(selectors.supportLink().exists)
@@ -67,6 +75,9 @@ export const findFooter = async (t: TestController) => {
       },
       async clickEventSearchPageLink() {
         await t.click(selectors.eventSearchLink());
+      },
+      async clickRegistrationsPageLink() {
+        await t.click(selectors.registrationsLink());
       },
       async clickSupportPageLink() {
         await t.click(selectors.supportLink());

--- a/browser-tests/footer/footer.testcafe.ts
+++ b/browser-tests/footer/footer.testcafe.ts
@@ -31,6 +31,10 @@ test('Footer links work', async (t) => {
   await urlUtils.actions.navigateToLandingPage();
   await footerLinks.actions.clickEventSearchPageLink();
   await urlUtils.expectations.urlChangedToEventSearchPage();
+  // Registrations page
+  await urlUtils.actions.navigateToLandingPage();
+  await footerLinks.actions.clickRegistrationsPageLink();
+  await urlUtils.expectations.urlChangedToRegistrationsPage();
   // Support page
   await urlUtils.actions.navigateToLandingPage();
   await footerLinks.actions.clickSupportPageLink();

--- a/browser-tests/header/header.components.ts
+++ b/browser-tests/header/header.components.ts
@@ -75,7 +75,11 @@ export const findHeader = async (
           name: getTranslations(currentLang).navigation.tabs.events,
         });
       },
-
+      registrationsTab() {
+        return withinHeader().findByRole('link', {
+          name: getTranslations(currentLang).navigation.tabs.registrations,
+        });
+      },
       supportTab() {
         return withinHeader().findByRole('link', {
           name: getTranslations(currentLang).navigation.tabs.help,
@@ -89,7 +93,11 @@ export const findHeader = async (
           .expect(selectors.eventsTab().exists)
           .ok(await getErrorMessage(t));
       },
-
+      async registrationsPageTabIsVisible() {
+        await t
+          .expect(selectors.registrationsTab().exists)
+          .ok(await getErrorMessage(t));
+      },
       async supportPageTabIsVisible() {
         await t
           .expect(selectors.supportTab().exists)
@@ -101,7 +109,9 @@ export const findHeader = async (
       async clickEventsPageTab() {
         await t.click(selectors.eventsTab());
       },
-
+      async clickRegistrationsPageTab() {
+        await t.click(selectors.registrationsTab());
+      },
       async clickSupportPageTab() {
         await t.click(selectors.supportTab());
       },

--- a/browser-tests/header/header.testcafe.ts
+++ b/browser-tests/header/header.testcafe.ts
@@ -44,6 +44,10 @@ test('Header tabs and search input field work', async (t) => {
   // Events page
   await headerTabs.actions.clickEventsPageTab();
   await urlUtils.expectations.urlChangedToEventsPage();
+  // Registrations page
+  await urlUtils.actions.navigateToLandingPage();
+  await headerTabs.actions.clickRegistrationsPageTab();
+  await urlUtils.expectations.urlChangedToRegistrationsPage();
   // Support page
   await urlUtils.actions.navigateToLandingPage();
   await headerTabs.actions.clickSupportPageTab();

--- a/browser-tests/utils/url.utils.ts
+++ b/browser-tests/utils/url.utils.ts
@@ -98,6 +98,11 @@ export const getUrlUtils = (t: TestController) => {
         .expect(getPathname())
         .eql(`/fi/help/instructions/platform`, await getErrorMessage(t));
     },
+    async urlChangedToRegistrationsPage() {
+      await t
+        .expect(getPathname())
+        .eql(`/fi/registrations`, await getErrorMessage(t));
+    },
     async urlChangedToSourceCodePage() {
       await t
         .expect(getPathname())

--- a/schema.js
+++ b/schema.js
@@ -88,6 +88,7 @@ module.exports = buildSchema(/* GraphQL */ `
       sort: String
       text: String
     ): PlacesResponse!
+    registrations: RegistrationsResponse!
     user(id: ID!): User!
   }
 
@@ -520,5 +521,32 @@ module.exports = buildSchema(/* GraphQL */ `
     altText: String
     name: String
     url: String
+  }
+
+  type RegistrationsResponse {
+    meta: Meta!
+    data: [Registration!]!
+  }
+
+  type Registration {
+    id: ID
+    createdAt: String
+    currentAttendeeCount: Int
+    currentWaitingListCount: Int
+    enrolmentEndTime: String
+    enrolmentStartTime: String
+    eventId: ID
+    maximumAttendeeCount: Int
+    maximumWaitingListCount: Int
+    minimumAttendeeCount: Int
+    name: LocalisedObject
+    publisher: String
+    updatedAt: String
+    # @id is renamed as atId so it's usable on GraphQl
+    atId: String!
+    # @context is renamed as atContext so it's usable on GraphQl
+    atContext: String
+    # @type is renamed as atType so it's usable on GraphQl
+    atType: String
   }
 `);

--- a/src/assets/theme/theme.ts
+++ b/src/assets/theme/theme.ts
@@ -216,7 +216,7 @@ const theme: Theme = {
       'var(--color-coat-of-arms)',
     '--event-search-panel-button-background-color-hover-focus':
       'var(--color-coat-of-arms-dark)',
-    '--event-search-panel-button-border-color': 'var(--color-white)',
+    '--event-search-panel-button-border-color': 'var(--color-coat-of-arms)',
     '--event-search-panel-button-color': 'var(--color-white)',
     '--event-search-panel-button-focus-outline-color': 'var(--color-white)',
   },
@@ -400,6 +400,23 @@ const theme: Theme = {
     '--focus-outline-color': 'var(--color-coat-of-arms)',
     '--label-color': 'var(--color-black-90)',
     '--label-color-disabled': 'var(--color-black-40)',
+  },
+  registrationSearchPanel: {
+    '--registration-search-panel-background-color': 'var(--color-coat-of-arms)',
+    '--registration-search-panel-label-color': 'var(--color-white)',
+    '--registration-search-panel-button-background-color':
+      'var(--color-coat-of-arms)',
+    '--registration-search-panel-button-background-color-hover':
+      'var(--color-coat-of-arms-dark)',
+    '--registration-search-panel-button-background-color-focus':
+      'var(--color-coat-of-arms)',
+    '--registration-search-panel-button-background-color-hover-focus':
+      'var(--color-coat-of-arms-dark)',
+    '--registration-search-panel-button-border-color':
+      'var(--color-coat-of-arms)',
+    '--registration-search-panel-button-color': 'var(--color-coat-of-arms)',
+    '--registration-search-panel-button-focus-outline-color':
+      'var(--color-white)',
   },
   root: {
     '--focus-outline-color': 'var(--color-coat-of-arms)',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -21,7 +21,9 @@ export enum DEPRECATED_ROUTES {
 export enum ROUTES {
   CALLBACK = '/callback',
   CREATE_EVENT = '/events/create',
+  CREATE_REGISTRATION = '/registrations/create',
   EDIT_EVENT = '/events/edit/:id',
+  EDIT_REGISTRATION = '/registrations/edit/:id',
   EVENT_SAVED = '/events/completed/:id',
   EVENTS = '/events',
   FEATURES = '/help/features',
@@ -33,6 +35,8 @@ export enum ROUTES {
   INSTRUCTIONS_GENERAL = '/help/instructions/general',
   INSTRUCTIONS_PLATFORM = '/help/instructions/platform',
   LOGOUT = '/logout',
+  REGISTRATIONS = '/registrations',
+  REGISTRATION_PARTICIPANTS = '/registrations/:registrationId/participants',
   SEARCH = '/search',
   SILENT_CALLBACK = '/silent-callback',
   SUPPORT = '/help/support',
@@ -123,6 +127,10 @@ export const NAVIGATION_ITEMS = [
     url: ROUTES.EVENTS,
   },
   {
+    labelKey: 'navigation.tabs.registrations',
+    url: ROUTES.REGISTRATIONS,
+  },
+  {
     labelKey: 'navigation.tabs.help',
     url: ROUTES.HELP,
   },
@@ -136,6 +144,10 @@ export const FOOTER_NAVIGATION_ITEMS = [
   {
     labelKey: 'navigation.searchEvents',
     url: ROUTES.SEARCH,
+  },
+  {
+    labelKey: 'navigation.tabs.registrations',
+    url: ROUTES.REGISTRATIONS,
   },
   {
     labelKey: 'navigation.tabs.help',

--- a/src/domain/app/cookieConsent/__tests__/CookieConsentModal.test.tsx
+++ b/src/domain/app/cookieConsent/__tests__/CookieConsentModal.test.tsx
@@ -45,7 +45,7 @@ const getElement = (
     case 'englishOption':
       return screen.getByRole('link', { name: /in english/i });
     case 'languageMenuButton':
-      return screen.getByRole('button', { name: /suomi \- kielivalikko/i });
+      return screen.getByRole('button', { name: /suomi - kielivalikko/i });
     case 'onlyRequiredButton':
       return screen.getByRole('button', { name: /vain välttämättömät/i });
   }

--- a/src/domain/app/footer/__tests__/Footer.test.tsx
+++ b/src/domain/app/footer/__tests__/Footer.test.tsx
@@ -7,6 +7,7 @@ import {
   render,
   screen,
   userEvent,
+  waitFor,
 } from '../../../../utils/testUtils';
 import translations from '../../../app/i18n/fi.json';
 import Footer from '../Footer';
@@ -41,18 +42,21 @@ test('should show navigation links and should route to correct page after clicki
       url: `/fi${ROUTES.SEARCH}`,
     },
     {
+      name: translations.navigation.tabs.registrations,
+      url: `/fi${ROUTES.REGISTRATIONS}`,
+    },
+    {
       name: translations.navigation.tabs.help,
       url: `/fi${ROUTES.HELP}`,
     },
   ];
-
-  links.forEach(({ name, url }) => {
+  for (const { name, url } of links) {
     const link = screen.getByRole('link', { name });
 
     userEvent.click(link);
 
-    expect(history.location.pathname).toBe(url);
-  });
+    await waitFor(() => expect(history.location.pathname).toBe(url));
+  }
 });
 
 test('should show feedback link and link should have correct href', async () => {

--- a/src/domain/app/header/__tests__/Header.test.tsx
+++ b/src/domain/app/header/__tests__/Header.test.tsx
@@ -91,7 +91,7 @@ test.skip('matches snapshot', () => {
   expect(container.firstChild).toMatchSnapshot();
 });
 
-test('should show navigation links and should route to correct page after clicking link', () => {
+test('should show navigation links and should route to correct page after clicking link', async () => {
   const { history } = renderComponent();
   const links = [
     {
@@ -99,17 +99,21 @@ test('should show navigation links and should route to correct page after clicki
       url: `/fi${ROUTES.EVENTS}`,
     },
     {
+      name: translations.navigation.tabs.registrations,
+      url: `/fi${ROUTES.REGISTRATIONS}`,
+    },
+    {
       name: translations.navigation.tabs.help,
       url: `/fi${ROUTES.HELP}`,
     },
   ];
 
-  links.forEach(({ name, url }) => {
+  for (const { name, url } of links) {
     const link = screen.getAllByRole('link', { name })[0];
 
     userEvent.click(link);
-    expect(history.location.pathname).toBe(url);
-  });
+    await waitFor(() => expect(history.location.pathname).toBe(url));
+  }
 });
 
 test('should show mobile menu', async () => {

--- a/src/domain/app/i18n/en.json
+++ b/src/domain/app/i18n/en.json
@@ -22,6 +22,7 @@
     "betweenDates": "{{startDate}} – {{endDate}}",
     "betweenTimes": "{{startTime}} – {{endTime}}",
     "buttonAddEvent": "Add new event",
+    "buttonAddRegistration": "Add new",
     "cancel": "Undo",
     "close": "Close",
     "combobox": {
@@ -1089,7 +1090,8 @@
     "skipToContentLabel": "Skip to content",
     "tabs": {
       "events": "Events",
-      "help": "Support"
+      "help": "Support",
+      "registrations": "Registration"
     }
   },
   "notFound": {
@@ -1098,6 +1100,41 @@
   },
   "notSigned": {
     "text": "You must be logged in to view this content. Log in or return to the home page."
+  },
+  "registrationsPage": {
+    "actionButtons": {
+      "copy": "Copy as a template",
+      "delete": "Delete registration",
+      "edit": "Edit",
+      "showParticipants": "Show participants"
+    },
+    "buttonClearFilters": "Clear filters",
+    "count": "{{count}} registration",
+    "count_plural": "{{count}} registrations",
+    "pageTitle": "Registration",
+    "registrationTableCaption": "Registrations, sorted by {{sort}}",
+    "registrationsTableColumns": {
+      "enrolmentEndTime": "Ends",
+      "enrolmentStartTime": "Starts",
+      "name": "Name",
+      "participants": "Participants",
+      "publisher": "Publisher",
+      "waitingList": "Waiting list"
+    },
+    "searchPanel": {
+      "buttonClear": "Clear",
+      "buttonRemoveFilter": "Remove filter: {{name}}",
+      "buttonSearch": "Search registrations",
+      "labelEventType": "Type",
+      "labelPlace": "Search venue",
+      "labelSearch": "Search registrations",
+      "placeholderSearch": "Search registrations"
+    },
+    "sortOptions": {
+      "lastModifiedTime": "Last modified, ascending",
+      "lastModifiedTimeDesc": "Last modified, descending"
+    },
+    "title": "Registration"
   },
   "serverError": {
     "endTimeInPast": "End time cannot be in the past. Please set a future end time.",

--- a/src/domain/app/i18n/fi.json
+++ b/src/domain/app/i18n/fi.json
@@ -22,6 +22,7 @@
     "betweenDates": "{{startDate}} – {{endDate}}",
     "betweenTimes": "{{startTime}} – {{endTime}}",
     "buttonAddEvent": "Lisää uusi tapahtuma",
+    "buttonAddRegistration": "Lisää uusi",
     "cancel": "Peruuta",
     "close": "Sulje",
     "combobox": {
@@ -1089,7 +1090,8 @@
     "skipToContentLabel": "Siirry sisältöön",
     "tabs": {
       "events": "Tapahtumat",
-      "help": "Tuki"
+      "help": "Tuki",
+      "registrations": "Ilmoittautuminen"
     }
   },
   "notFound": {
@@ -1098,6 +1100,41 @@
   },
   "notSigned": {
     "text": "Sinun täytyy olla kirjautuneena sisään tarkastellaksesi tätä sisältöä. Kirjaudu sisään tai palaa etusivulle."
+  },
+  "registrationsPage": {
+    "actionButtons": {
+      "copy": "Kopioi pohjaksi",
+      "delete": "Poista ilmoittautuminen",
+      "edit": "Muokkaa",
+      "showParticipants": "Näytä ilmoittautuneet"
+    },
+    "buttonClearFilters": "Tyhjennä hakuehdot",
+    "count": "{{count}} ilmoittautuminen",
+    "count_plural": "{{count}} ilmoittautumista",
+    "pageTitle": "Ilmoittautuminen",
+    "registrationsTableCaption": "Ilmoittautumiset, järjestys {{sort}}",
+    "registrationsTableColumns": {
+      "enrolmentEndTime": "Loppuu",
+      "enrolmentStartTime": "Alkaa",
+      "name": "Nimi",
+      "participants": "Osallistujia",
+      "publisher": "Julkaisija",
+      "waitingList": "Jono"
+    },
+    "searchPanel": {
+      "buttonClear": "Tyhjennä",
+      "buttonRemoveFilter": "Poista suodatusehto: {{name}}",
+      "buttonSearch": "Etsi ilmoittautumisia",
+      "labelEventType": "Tyyppi",
+      "labelPlace": "Etsi tapahtumapaikkaa",
+      "labelSearch": "Hae ilmoittautumisia",
+      "placeholderSearch": "Hae ilmoittautumisia"
+    },
+    "sortOptions": {
+      "lastModifiedTime": "Viimeksi muokattu, nouseva",
+      "lastModifiedTimeDesc": "Viimeksi muokattu, laskeva"
+    },
+    "title": "Ilmoittautuminen"
   },
   "serverError": {
     "endTimeInPast": "Lopetusaika ei voi olla menneisyydessä. Määritä tuleva päättymisaika.",

--- a/src/domain/app/i18n/sv.json
+++ b/src/domain/app/i18n/sv.json
@@ -22,6 +22,7 @@
     "betweenDates": "{{startDate}} – {{endDate}}",
     "betweenTimes": "{{startTime}} – {{endTime}}",
     "buttonAddEvent": "Lägg till evenemang",
+    "buttonAddRegistration": "Lägg till",
     "cancel": "Ångra",
     "close": "Stäng",
     "combobox": {
@@ -1089,7 +1090,8 @@
     "skipToContentLabel": "Gå till innehållet",
     "tabs": {
       "events": "Evenemang",
-      "help": "Stöd"
+      "help": "Stöd",
+      "registrations": "Registrering"
     }
   },
   "notFound": {
@@ -1098,6 +1100,41 @@
   },
   "notSigned": {
     "text": "Du måste vara inloggad för att se detta innehåll. Logga in eller gå tillbaka till startsidan."
+  },
+  "registrationsPage": {
+    "actionButtons": {
+      "copy": "Kopiera som mall",
+      "delete": "Radera registrering",
+      "edit": "Redigera",
+      "showParticipants": "Visa deltagare"
+    },
+    "buttonClearFilters": "Töm sökfilter",
+    "count": "{{count}} registrering",
+    "count_plural": "{{count}} registreringar",
+    "pageTitle": "Registrering",
+    "registrationsTableCaption": "Registreringar, sorterade efter {{sort}}",
+    "registrationsTableColumns": {
+      "enrolmentEndTime": "Slutar",
+      "enrolmentStartTime": "Börjar",
+      "name": "Namn",
+      "participants": "Deltagarna",
+      "publisher": "Utgivare",
+      "waitingList": "Väntelista"
+    },
+    "searchPanel": {
+      "buttonClear": "Klar",
+      "buttonRemoveFilter": "Ta bort filtret: {{name}}",
+      "buttonSearch": "Sök efter registreringar",
+      "labelEventType": "Typ",
+      "labelPlace": "Sök plats",
+      "labelSearch": "Sök efter registreringar",
+      "placeholderSearch": "Sök efter registreringar"
+    },
+    "sortOptions": {
+      "lastModifiedTime": "Senast ändrad, stigande",
+      "lastModifiedTimeDesc": "Senast ändrad, fallande"
+    },
+    "title": "Registrering"
   },
   "serverError": {
     "endTimeInPast": "Sluttiden kan inte vara tidigare. Ange en framtida sluttid.",

--- a/src/domain/app/routes/LocaleRoutes.tsx
+++ b/src/domain/app/routes/LocaleRoutes.tsx
@@ -20,6 +20,9 @@ const EventSearchPage = React.lazy(
   () => import('../../eventSearch/EventSearchPage')
 );
 const HelpPageRoutes = React.lazy(() => import('./HelpPageRoutes'));
+const RegistrationsPage = React.lazy(
+  () => import('.././../registrations/RegistrationsPage')
+);
 
 interface Params {
   locale: Language;
@@ -90,6 +93,11 @@ const LocaleRoutes: React.FC<Props> = ({
             exact
             path={getLocalePath(ROUTES.EVENTS)}
             component={EventsPage}
+          />
+          <Route
+            exact
+            path={getLocalePath(ROUTES.REGISTRATIONS)}
+            component={RegistrationsPage}
           />
           <Route
             exact

--- a/src/domain/app/theme/Theme.tsx
+++ b/src/domain/app/theme/Theme.tsx
@@ -305,6 +305,18 @@ type RadioButtonCSSProperties = {
   '--label-color-disabled'?: string;
 };
 
+type RegistrationSearchPanelCSSProperties = {
+  '--registration-search-panel-background-color'?: string;
+  '--registration-search-panel-label-color'?: string;
+  '--registration-search-panel-button-background-color'?: string;
+  '--registration-search-panel-button-background-color-hover'?: string;
+  '--registration-search-panel-button-background-color-focus'?: string;
+  '--registration-search-panel-button-background-color-hover-focus'?: string;
+  '--registration-search-panel-button-border-color'?: string;
+  '--registration-search-panel-button-color'?: string;
+  '--registration-search-panel-button-focus-outline-color'?: string;
+};
+
 type RootCSSProperties = {
   '--focus-outline-color'?: string;
   '--focus-outline-width'?: string;
@@ -456,6 +468,7 @@ export type Theme = {
   pagination: PaginationCSSProperties;
   publicationStatus: PublicationStatusCSSProperties;
   radioButton: RadioButtonCSSProperties;
+  registrationSearchPanel: RegistrationSearchPanelCSSProperties;
   root: RootCSSProperties;
   select: SelectCSSProperties;
   sideNavigation: SideNavigationCSSProperties;
@@ -491,6 +504,7 @@ const defaultTheme: Theme = {
   pagination: {},
   publicationStatus: {},
   radioButton: {},
+  registrationSearchPanel: {},
   root: {},
   select: {},
   sideNavigation: {},

--- a/src/domain/event/constants.tsx
+++ b/src/domain/event/constants.tsx
@@ -261,6 +261,7 @@ export enum EVENT_EDIT_ACTIONS {
   UPDATE_DRAFT = 'updateDraft',
   UPDATE_PUBLIC = 'updatePublic',
 }
+
 export const SUB_EVENTS_VARIABLES: EventsQueryVariables = {
   createPath: getPathBuilder(eventsPathBuilder),
   include: EVENT_LIST_INCLUDES,

--- a/src/domain/event/formSections/descriptionSection/__tests__/DescriptionSection.test.tsx
+++ b/src/domain/event/formSections/descriptionSection/__tests__/DescriptionSection.test.tsx
@@ -4,7 +4,6 @@ import React from 'react';
 import {
   configure,
   mockString,
-  pasteToTextEditor,
   render,
   screen,
   userEvent,

--- a/src/domain/eventSearch/constants.ts
+++ b/src/domain/eventSearch/constants.ts
@@ -1,3 +1,5 @@
+export const REGISTRATIONS_PAGE_SIZE = 10;
+
 export enum EVENT_SEARCH_PARAMS {
   END = 'end',
   PAGE = 'page',

--- a/src/domain/eventSearch/searchPanel/searchPanel.module.scss
+++ b/src/domain/eventSearch/searchPanel/searchPanel.module.scss
@@ -14,7 +14,7 @@
   --event-search-panel-button-background-color-hover-focus: var(
     --color-coat-of-arms-dark
   );
-  --event-search-panel-button-border-color: var(--color-white);
+  --event-search-panel-button-border-color: var(--color-coat-of-arms);
   --event-search-panel-button-color: var(--color-white);
   --event-search-panel-button-focus-outline-color: var(--color-white);
 

--- a/src/domain/events/eventCard/__tests__/__snapshots__/TextWithIcon.test.tsx.snap
+++ b/src/domain/events/eventCard/__tests__/__snapshots__/TextWithIcon.test.tsx.snap
@@ -24,7 +24,11 @@ exports[`should match snapshot 1`] = `
         />
       </g>
     </svg>
-    Text
+    <span
+      class="text"
+    >
+      Text
+    </span>
   </div>
 </div>
 `;

--- a/src/domain/registrations/RegistrationsPage.tsx
+++ b/src/domain/registrations/RegistrationsPage.tsx
@@ -1,0 +1,77 @@
+import { Button, IconPlus } from 'hds-react';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { useHistory } from 'react-router';
+
+import LoadingSpinner from '../../common/components/loadingSpinner/LoadingSpinner';
+import { ROUTES } from '../../constants';
+import { UserFieldsFragment } from '../../generated/graphql';
+import useLocale from '../../hooks/useLocale';
+import Container from '../app/layout/Container';
+import MainContent from '../app/layout/MainContent';
+import PageWrapper from '../app/layout/PageWrapper';
+import NotSigned from '../notSigned/NotSigned';
+import useUser from '../user/hooks/useUser';
+import FilterSummary from './filterSummary/FilterSummary';
+import RegistrationList from './registrationList/RegistrationList';
+import styles from './registrations.module.scss';
+import SearchPanel from './searchPanel/SearchPanel';
+
+interface Props {
+  user: UserFieldsFragment;
+}
+
+const RegistrationsPage: React.FC<Props> = ({ user }) => {
+  const { t } = useTranslation();
+  const history = useHistory();
+  const locale = useLocale();
+
+  const goToCreateRegistrationPage = () => {
+    // clearRegistrationFormData();
+    history.push(`/${locale}${ROUTES.CREATE_REGISTRATION}`);
+  };
+
+  return (
+    <div className={styles.registrationsPage}>
+      <Container withOffset={true}>
+        <div className={styles.titleRow}>
+          <h1 className={styles.title}>{t('registrationsPage.title')}</h1>
+          <div className={styles.addButtonWrapper}>
+            <Button
+              className={styles.addButton}
+              fullWidth={true}
+              iconLeft={<IconPlus />}
+              onClick={goToCreateRegistrationPage}
+              variant="secondary"
+            >
+              {t('common.buttonAddRegistration')}
+            </Button>
+          </div>
+        </div>
+
+        <SearchPanel />
+        <FilterSummary className={styles.filterSummary} />
+      </Container>
+      <RegistrationList />
+    </div>
+  );
+};
+
+const RegistrationsPageWrapper: React.FC = () => {
+  const { loading: loadingUser, user } = useUser();
+
+  return (
+    <PageWrapper
+      backgroundColor={user ? 'gray' : 'white'}
+      title="registrationsPage.pageTitle"
+    >
+      <MainContent>
+        <LoadingSpinner isLoading={loadingUser}>
+          {user ? <RegistrationsPage user={user} /> : <NotSigned />}
+        </LoadingSpinner>
+      </MainContent>
+    </PageWrapper>
+  );
+};
+
+export default RegistrationsPageWrapper;

--- a/src/domain/registrations/__mocks__/registrationsPage.mock.ts
+++ b/src/domain/registrations/__mocks__/registrationsPage.mock.ts
@@ -1,0 +1,39 @@
+import range from 'lodash/range';
+
+import { TEST_USER_ID } from '../../../constants';
+import { UserDocument } from '../../../generated/graphql';
+import { fakeRegistrations, fakeUser } from '../../../utils/mockDataUtils';
+import { REGISTRATIONS_PAGE_SIZE } from '../../eventSearch/constants';
+
+const publisher = 'publisher:1';
+const registrationNames = range(1, REGISTRATIONS_PAGE_SIZE + 1).map(
+  (n) => `Registration name ${n}`
+);
+
+const registrations = fakeRegistrations(
+  REGISTRATIONS_PAGE_SIZE,
+  registrationNames.map((name) => ({
+    name: { fi: name },
+  }))
+);
+
+const registrationsResponse = { registrations };
+
+// User mocks
+const user = fakeUser({
+  organization: publisher,
+  adminOrganizations: [publisher],
+});
+const userVariables = { createPath: undefined, id: TEST_USER_ID };
+const userResponse = { data: { user } };
+const mockedUserResponse = {
+  request: { query: UserDocument, variables: userVariables },
+  result: userResponse,
+};
+
+export {
+  mockedUserResponse,
+  registrationNames,
+  registrations,
+  registrationsResponse,
+};

--- a/src/domain/registrations/__tests__/RegistrationsPage.test.tsx
+++ b/src/domain/registrations/__tests__/RegistrationsPage.test.tsx
@@ -1,0 +1,122 @@
+import { MockedResponse } from '@apollo/client/testing';
+import React from 'react';
+
+import { TEST_USER_ID } from '../../../constants';
+import { UserDocument } from '../../../generated/graphql';
+import { fakeUser } from '../../../utils/mockDataUtils';
+import { fakeAuthenticatedStoreState } from '../../../utils/mockStoreUtils';
+import {
+  configure,
+  getMockReduxStore,
+  loadingSpinnerIsNotInDocument,
+  render,
+  screen,
+  userEvent,
+  waitFor,
+} from '../../../utils/testUtils';
+import RegistrationsPage from '../RegistrationsPage';
+
+configure({ defaultHidden: true });
+
+const storeState = fakeAuthenticatedStoreState();
+
+const adminOrganization = 'helsinki';
+const userData = fakeUser({ adminOrganizations: [adminOrganization] });
+const userResponse = { data: { user: userData } };
+const mockedUserResponse: MockedResponse = {
+  request: {
+    query: UserDocument,
+    variables: { id: TEST_USER_ID, createPath: undefined },
+  },
+  result: userResponse,
+};
+
+const mocks = [mockedUserResponse];
+
+beforeEach(() => jest.clearAllMocks());
+
+const getElement = (key: 'createRegistrationButton' | 'table') => {
+  switch (key) {
+    case 'createRegistrationButton':
+      return screen.getByRole('button', { name: /lisää uusi/i });
+    case 'table':
+      return screen.getByRole('table', {
+        name: /ilmoittautumiset, järjestys viimeksi muokattu, laskeva/i,
+        hidden: true,
+      });
+  }
+};
+
+test('should show correct title, description and keywords', async () => {
+  const pageTitle = 'Ilmoittautuminen - Linked Events';
+
+  render(<RegistrationsPage />);
+
+  await waitFor(() => expect(document.title).toEqual(pageTitle));
+
+  const head = document.querySelector('head');
+  const ogTitle = head?.querySelector('[property="og:title"]');
+
+  expect(ogTitle).toHaveAttribute('content', pageTitle);
+});
+
+test('should render events page', async () => {
+  const store = getMockReduxStore(storeState);
+  render(<RegistrationsPage />, { mocks, store });
+
+  await loadingSpinnerIsNotInDocument();
+
+  getElement('createRegistrationButton');
+  getElement('table');
+});
+
+test('should open create event page', async () => {
+  const store = getMockReduxStore(storeState);
+  const { history } = render(<RegistrationsPage />, { mocks, store });
+
+  await loadingSpinnerIsNotInDocument();
+
+  const createRegistrationButton = getElement('createRegistrationButton');
+  userEvent.click(createRegistrationButton);
+
+  expect(history.location.pathname).toBe('/fi/registrations/create');
+});
+
+// it('scrolls to event table row and calls history.replace correctly (deletes eventId from state)', async () => {
+//   const storeState = fakeAuthenticatedStoreState();
+//   storeState.events.listOptions = fakeEventsListOptionsState({
+//     tab: EVENTS_PAGE_TABS.WAITING_APPROVAL,
+//   });
+//   const store = getMockReduxStore(storeState);
+//   const route = '/fi/events';
+//   const history = createMemoryHistory();
+//   const historyObject = {
+//     search: '?dateTypes=tomorrow,this_week',
+//     state: { eventId: waitingApprovalEvents.data[0].id },
+//     pathname: route,
+//   };
+//   history.push(historyObject);
+
+//   const replaceSpy = jest.spyOn(history, 'replace');
+
+//   render(<EventsPage />, {
+//     history,
+//     mocks,
+//     routes: [route],
+//     store,
+//   });
+
+//   await loadingSpinnerIsNotInDocument();
+
+//   expect(replaceSpy).toHaveBeenCalledWith(
+//     expect.objectContaining({
+//       search: historyObject.search,
+//       pathname: historyObject.pathname,
+//     })
+//   );
+
+//   const eventRowButton = screen.getByRole('button', {
+//     name: waitingApprovalEvents.data[0].name.fi,
+//   });
+//   await waitFor(() => expect(eventRowButton).toHaveFocus());
+// });

--- a/src/domain/registrations/__tests__/utils.test.ts
+++ b/src/domain/registrations/__tests__/utils.test.ts
@@ -1,0 +1,164 @@
+import { ROUTES } from '../../../constants';
+import { fakeRegistration } from '../../../utils/mockDataUtils';
+import { EVENT_TYPE } from '../../event/constants';
+import {
+  REGISTRATION_SEARCH_PARAMS,
+  REGISTRATION_SORT_OPTIONS,
+} from '../constants';
+import { RegistrationSearchParam, RegistrationSearchParams } from '../types';
+import {
+  addParamsToRegistrationQueryString,
+  getRegistrationFields,
+  getRegistrationParamValue,
+  getRegistrationSearchQuery,
+  replaceParamsToRegistrationQueryString,
+} from '../utils';
+
+describe('addParamsToRegistrationQueryString function', () => {
+  const cases: [Partial<RegistrationSearchParams>, string][] = [
+    [{ eventType: [EVENT_TYPE.Volunteering] }, '?eventType=volunteering'],
+    [{ eventType: [] }, ''],
+    [{ page: 3 }, '?page=3'],
+    [
+      { returnPath: `/fi${ROUTES.REGISTRATIONS}` },
+      '?returnPath=%2Fregistrations',
+    ],
+    [
+      { sort: REGISTRATION_SORT_OPTIONS.LAST_MODIFIED_TIME },
+      '?sort=last_modified_time',
+    ],
+    [{ text: 'search' }, '?text=search'],
+  ];
+
+  it.each(cases)(
+    'should add %p params to search, returns %p',
+    (params, expectedResult) => {
+      expect(addParamsToRegistrationQueryString('', params)).toBe(
+        expectedResult
+      );
+    }
+  );
+});
+
+describe('getRegistrationParamValue function', () => {
+  it('should get returnPath without locale', () => {
+    expect(
+      getRegistrationParamValue({
+        param: REGISTRATION_SEARCH_PARAMS.RETURN_PATH,
+        value: `/fi${ROUTES.REGISTRATIONS}`,
+      })
+    ).toBe(ROUTES.REGISTRATIONS);
+  });
+
+  it('should throw an error when trying to add unsupported param', () => {
+    expect(() =>
+      getRegistrationParamValue({
+        param: 'unsupported' as RegistrationSearchParam,
+        value: 'value',
+      })
+    ).toThrowError();
+  });
+});
+
+describe('getRegistrationSearchQuery function', () => {
+  const defaultParams = {
+    [REGISTRATION_SEARCH_PARAMS.TEXT]: 'text',
+  };
+  const cases: [string, RegistrationSearchParams, string][] = [
+    ['', defaultParams, 'text=text'],
+    [
+      '',
+      { ...defaultParams, eventType: [EVENT_TYPE.Volunteering] },
+      'text=text&eventType=volunteering',
+    ],
+    ['', { ...defaultParams, page: 2 }, 'text=text&page=2'],
+    [
+      '',
+      { ...defaultParams, returnPath: `/fi${ROUTES.REGISTRATIONS}` },
+      'text=text&returnPath=%2Ffi%2Fregistrations',
+    ],
+    [
+      '?sort=last_modified_time',
+      { ...defaultParams },
+      'text=text&sort=last_modified_time',
+    ],
+    [undefined, { ...defaultParams, text: 'search' }, 'text=search'],
+  ];
+
+  it.each(cases)(
+    'should get search query %p with params %p, returns %p',
+    (search, params, expectedSearch) => {
+      expect(getRegistrationSearchQuery(params, search)).toBe(expectedSearch);
+    }
+  );
+});
+
+describe('replaceParamsToRegistrationQueryString', () => {
+  const cases: [Partial<RegistrationSearchParams>, string, string][] = [
+    [
+      { eventType: [EVENT_TYPE.Volunteering, EVENT_TYPE.Course] },
+      '?eventType=volunteering',
+      '?eventType=volunteering&eventType=course',
+    ],
+    [{ page: 2 }, '?page=3', '?page=2'],
+    [
+      { returnPath: `/fi${ROUTES.REGISTRATIONS}` },
+      '?returnPath=%2Fsearch',
+      '?returnPath=%2Fregistrations',
+    ],
+    [
+      { sort: REGISTRATION_SORT_OPTIONS.LAST_MODIFIED_TIME },
+      '?sort=-name',
+      '?sort=last_modified_time',
+    ],
+    [{ text: 'search' }, '?text=text1', '?text=search'],
+  ];
+
+  it.each(cases)(
+    'should replace %p params to search %p, returns %p',
+    (params, search, expectedResult) => {
+      expect(replaceParamsToRegistrationQueryString(search, params)).toBe(
+        expectedResult
+      );
+    }
+  );
+});
+
+describe('getRegistrationFields function', () => {
+  it('should return default values if value is not set', () => {
+    const {
+      currentAttendeeCount,
+      currentWaitingListCount,
+      enrolmentEndTime,
+      enrolmentStartTime,
+      id,
+      atId,
+      maximumAttendeeCount,
+      maximumWaitingListCount,
+      publisher,
+    } = getRegistrationFields(
+      fakeRegistration({
+        currentAttendeeCount: null,
+        currentWaitingListCount: null,
+        enrolmentEndTime: '',
+        enrolmentStartTime: '',
+        id: null,
+        atId: null,
+        maximumAttendeeCount: null,
+        maximumWaitingListCount: null,
+        publisher: '',
+      }),
+      'fi'
+    );
+
+    expect(currentAttendeeCount).toBe(0);
+    expect(currentWaitingListCount).toBe(0);
+    expect(enrolmentEndTime).toBe(null);
+    expect(enrolmentStartTime).toBe(null);
+    expect(id).toBe('');
+    expect(atId).toBe('');
+    expect(maximumAttendeeCount).toBe(0);
+    expect(maximumWaitingListCount).toBe(0);
+    expect(publisher).toBe(null);
+  });
+});

--- a/src/domain/registrations/actionsDropdown/ActionsDropdown.tsx
+++ b/src/domain/registrations/actionsDropdown/ActionsDropdown.tsx
@@ -1,0 +1,106 @@
+import { IconMenuDots } from 'hds-react';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { useHistory, useLocation } from 'react-router';
+
+import MenuDropdown from '../../../common/components/menuDropdown/MenuDropdown';
+import { MenuItemOptionProps } from '../../../common/components/menuDropdown/MenuItem';
+import { ROUTES } from '../../../constants';
+import { Registration } from '../../../generated/graphql';
+import useLocale from '../../../hooks/useLocale';
+import { REGISTRATION_EDIT_ACTIONS } from '../constants';
+import {
+  addParamsToRegistrationQueryString,
+  getEditButtonProps,
+  getRegistrationFields,
+} from '../utils';
+import styles from './actionsDropdown.module.scss';
+
+export interface ActionsDropdownProps {
+  className?: string;
+  registration: Registration;
+}
+
+const ActionsDropdown = React.forwardRef<HTMLDivElement, ActionsDropdownProps>(
+  ({ className, registration }, ref) => {
+    const { t } = useTranslation();
+    const locale = useLocale();
+    const history = useHistory();
+    const { pathname, search } = useLocation();
+    const { id, registrationUrl } = getRegistrationFields(registration, locale);
+
+    const goToEditRegistrationPage = () => {
+      const queryString = addParamsToRegistrationQueryString(search, {
+        returnPath: pathname,
+      });
+      const registrationUrlWithReturnPath = `${registrationUrl}${queryString}`;
+      history.push(registrationUrlWithReturnPath);
+    };
+
+    const goToRegistrationParticipantsPage = () => {
+      const queryString = addParamsToRegistrationQueryString(search, {
+        returnPath: pathname,
+      });
+
+      history.push({
+        pathname: `/${locale}${ROUTES.REGISTRATION_PARTICIPANTS.replace(
+          ':registrationId',
+          id
+        )}`,
+        search: queryString,
+      });
+    };
+
+    const getActionItemProps = ({
+      action,
+      onClick,
+    }: {
+      action: REGISTRATION_EDIT_ACTIONS;
+      onClick: () => void;
+    }): MenuItemOptionProps | null => {
+      return getEditButtonProps({
+        action,
+        onClick,
+        t,
+      });
+    };
+
+    const actionItems: MenuItemOptionProps[] = [
+      getActionItemProps({
+        action: REGISTRATION_EDIT_ACTIONS.EDIT,
+        onClick: goToEditRegistrationPage,
+      }),
+      getActionItemProps({
+        action: REGISTRATION_EDIT_ACTIONS.SHOW_PARTICIPANTS,
+        onClick: goToRegistrationParticipantsPage,
+      }),
+      getActionItemProps({
+        action: REGISTRATION_EDIT_ACTIONS.COPY,
+        onClick: () => alert('TODO: Copy registration'),
+      }),
+      getActionItemProps({
+        action: REGISTRATION_EDIT_ACTIONS.DELETE,
+        onClick: () => alert('TODO: Delete registration'),
+      }),
+    ].filter((i) => i) as MenuItemOptionProps[];
+
+    return (
+      <div ref={ref}>
+        <MenuDropdown
+          button={
+            <button className={styles.toggleButton}>
+              <IconMenuDots aria-hidden={true} />
+            </button>
+          }
+          buttonLabel={t('event.form.buttonActions')}
+          className={className}
+          closeOnItemClick={true}
+          fixedPosition={true}
+          items={actionItems}
+        />
+      </div>
+    );
+  }
+);
+
+export default ActionsDropdown;

--- a/src/domain/registrations/actionsDropdown/__tests__/ActionsDropdown.test.tsx
+++ b/src/domain/registrations/actionsDropdown/__tests__/ActionsDropdown.test.tsx
@@ -1,0 +1,166 @@
+import { MockedResponse } from '@apollo/client/testing';
+import { AnyAction, Store } from '@reduxjs/toolkit';
+import React from 'react';
+
+import { ROUTES } from '../../../../constants';
+import { StoreState } from '../../../../types';
+import { fakeRegistration } from '../../../../utils/mockDataUtils';
+import { fakeAuthenticatedStoreState } from '../../../../utils/mockStoreUtils';
+import {
+  act,
+  configure,
+  getMockReduxStore,
+  render,
+  screen,
+  userEvent,
+  waitFor,
+} from '../../../../utils/testUtils';
+import { mockedUserResponse } from '../../__mocks__/registrationsPage.mock';
+import ActionsDropdown, { ActionsDropdownProps } from '../ActionsDropdown';
+
+configure({ defaultHidden: true });
+
+const registration = fakeRegistration();
+
+const defaultProps: ActionsDropdownProps = {
+  registration,
+};
+
+const defaultMocks = [mockedUserResponse];
+
+const state = fakeAuthenticatedStoreState();
+const store = getMockReduxStore(state);
+
+const renderComponent = ({
+  mocks = defaultMocks,
+  props,
+  store,
+}: {
+  mocks?: MockedResponse[];
+  props?: Partial<ActionsDropdownProps>;
+  store?: Store<StoreState, AnyAction>;
+} = {}) =>
+  render(<ActionsDropdown {...defaultProps} {...props} />, {
+    mocks,
+    routes: [`/fi${ROUTES.REGISTRATIONS}`],
+    store,
+  });
+
+const findElement = (key: 'delete' | 'edit' | 'showParticipants') => {
+  switch (key) {
+    case 'delete':
+      return screen.findByRole('button', { name: 'Poista ilmoittautuminen' });
+    case 'edit':
+      return screen.findByRole('button', { name: 'Muokkaa' });
+    case 'showParticipants':
+      return screen.findByRole('button', { name: /näytä ilmoittautuneet/i });
+  }
+};
+
+const getElement = (
+  key: 'copy' | 'delete' | 'edit' | 'menu' | 'showParticipants' | 'toggle'
+) => {
+  switch (key) {
+    case 'copy':
+      return screen.getByRole('button', { name: 'Kopioi pohjaksi' });
+    case 'delete':
+      return screen.getByRole('button', { name: 'Poista ilmoittautuminen' });
+    case 'edit':
+      return screen.getByRole('button', { name: 'Muokkaa' });
+    case 'menu':
+      return screen.getByRole('region', { name: /valinnat/i });
+    case 'showParticipants':
+      return screen.getByRole('button', { name: /näytä ilmoittautuneet/i });
+    case 'toggle':
+      return screen.getByRole('button', { name: /valinnat/i });
+  }
+};
+
+const openMenu = () => {
+  const toggleButton = getElement('toggle');
+  userEvent.click(toggleButton);
+  getElement('menu');
+
+  return toggleButton;
+};
+
+test('should toggle menu by clicking actions button', () => {
+  renderComponent({ store });
+
+  const toggleButton = openMenu();
+  userEvent.click(toggleButton);
+  expect(
+    screen.queryByRole('region', { name: /valinnat/i })
+  ).not.toBeInTheDocument();
+});
+
+test('should render correct buttons', async () => {
+  renderComponent({ store });
+
+  openMenu();
+
+  getElement('copy');
+  await findElement('delete');
+  getElement('edit');
+  getElement('showParticipants');
+});
+
+test('should route to edit registration page when clicking edit button', async () => {
+  const { history } = renderComponent();
+
+  openMenu();
+
+  const editButton = await findElement('edit');
+  act(() => userEvent.click(editButton));
+
+  await waitFor(() =>
+    expect(history.location.pathname).toBe(
+      `/fi/registrations/edit/${registration.id}`
+    )
+  );
+  expect(history.location.search).toBe('?returnPath=%2Fregistrations');
+});
+
+test('should route to participants page when clicking show participants button', async () => {
+  const { history } = renderComponent();
+
+  openMenu();
+
+  const editButton = await findElement('showParticipants');
+  act(() => userEvent.click(editButton));
+
+  await waitFor(() =>
+    expect(history.location.pathname).toBe(
+      `/fi/registrations/${registration.id}/participants`
+    )
+  );
+  expect(history.location.search).toBe('?returnPath=%2Fregistrations');
+});
+
+test('should open alert dialog when clicking copy button', async () => {
+  global.alert = jest.fn();
+  renderComponent();
+
+  openMenu();
+
+  const copyButton = getElement('copy');
+  act(() => userEvent.click(copyButton));
+
+  await waitFor(() =>
+    expect(global.alert).toBeCalledWith('TODO: Copy registration')
+  );
+});
+
+test('should open alert dialog when clicking delete button', async () => {
+  global.alert = jest.fn();
+  renderComponent();
+
+  openMenu();
+
+  const deleteButton = getElement('delete');
+  act(() => userEvent.click(deleteButton));
+
+  await waitFor(() =>
+    expect(global.alert).toBeCalledWith('TODO: Delete registration')
+  );
+});

--- a/src/domain/registrations/actionsDropdown/actionsDropdown.module.scss
+++ b/src/domain/registrations/actionsDropdown/actionsDropdown.module.scss
@@ -1,0 +1,12 @@
+@import 'mixins';
+
+.toggleButton {
+  padding: 0;
+  display: flex;
+
+  @include focus-outline(0px);
+
+  svg {
+    transform: rotate(90deg);
+  }
+}

--- a/src/domain/registrations/constants.tsx
+++ b/src/domain/registrations/constants.tsx
@@ -1,0 +1,39 @@
+import { IconCalendarPlus, IconCogwheel, IconCross, IconEye } from 'hds-react';
+
+export enum REGISTRATION_EDIT_ACTIONS {
+  COPY = 'copy',
+  DELETE = 'delete',
+  EDIT = 'edit',
+  SHOW_PARTICIPANTS = 'showParticipants',
+}
+
+export enum REGISTRATION_SEARCH_PARAMS {
+  EVENT_TYPE = 'eventType',
+  PAGE = 'page',
+  RETURN_PATH = 'returnPath',
+  SORT = 'sort',
+  TEXT = 'text',
+}
+
+export enum REGISTRATION_SORT_OPTIONS {
+  LAST_MODIFIED_TIME = 'last_modified_time',
+  LAST_MODIFIED_TIME_DESC = '-last_modified_time',
+}
+
+export const REGISTRATION_EDIT_ICONS = {
+  [REGISTRATION_EDIT_ACTIONS.COPY]: <IconCalendarPlus />,
+  [REGISTRATION_EDIT_ACTIONS.DELETE]: <IconCross />,
+  [REGISTRATION_EDIT_ACTIONS.EDIT]: <IconCogwheel />,
+  [REGISTRATION_EDIT_ACTIONS.SHOW_PARTICIPANTS]: <IconEye />,
+};
+
+export const REGISTRATION_EDIT_LABEL_KEYS = {
+  [REGISTRATION_EDIT_ACTIONS.COPY]: 'registrationsPage.actionButtons.copy',
+  [REGISTRATION_EDIT_ACTIONS.DELETE]: 'registrationsPage.actionButtons.delete',
+  [REGISTRATION_EDIT_ACTIONS.EDIT]: 'registrationsPage.actionButtons.edit',
+  [REGISTRATION_EDIT_ACTIONS.SHOW_PARTICIPANTS]:
+    'registrationsPage.actionButtons.showParticipants',
+};
+
+export const DEFAULT_REGISTRATION_SORT =
+  REGISTRATION_SORT_OPTIONS.LAST_MODIFIED_TIME_DESC;

--- a/src/domain/registrations/filterSummary/EventTypeFilterTag.tsx
+++ b/src/domain/registrations/filterSummary/EventTypeFilterTag.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+import useEventTypeOptions from '../../event/hooks/useEventTypeOptions';
+import FilterTag, { FilterTagProps } from './FilterTag';
+
+type Props = Omit<FilterTagProps, 'text' | 'type'>;
+
+const EventTypeFilterTag: React.FC<Props> = ({ value, ...rest }) => {
+  const eventTypeOptions = useEventTypeOptions();
+
+  return (
+    <FilterTag
+      {...rest}
+      text={
+        eventTypeOptions.find((item) => item.value === value)?.label ||
+        /* istanbul ignore next */ '-'
+      }
+      type="eventType"
+      value={value}
+    />
+  );
+};
+
+export default EventTypeFilterTag;

--- a/src/domain/registrations/filterSummary/FilterSummary.tsx
+++ b/src/domain/registrations/filterSummary/FilterSummary.tsx
@@ -1,0 +1,84 @@
+import classNames from 'classnames';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { useHistory, useLocation } from 'react-router';
+
+import { RegistrationFilterType } from '../types';
+import {
+  getRegistrationSearchInitialValues,
+  replaceParamsToRegistrationQueryString,
+} from '../utils';
+import EventTypeFilterTag from './EventTypeFilterTag';
+import styles from './filterSummary.module.scss';
+import FilterTag from './FilterTag';
+
+interface Props {
+  className?: string;
+}
+
+const FilterSummary: React.FC<Props> = ({ className }) => {
+  const { t } = useTranslation();
+  const history = useHistory();
+  const { pathname, search } = useLocation();
+  const { eventType, text } = getRegistrationSearchInitialValues(search);
+
+  const clearFilters = () => {
+    history.push({
+      pathname,
+      search: replaceParamsToRegistrationQueryString(search, {
+        eventType: [],
+        text: '',
+      }),
+    });
+  };
+
+  const removeFilter = ({
+    value,
+    type,
+  }: {
+    value: string;
+    type: RegistrationFilterType;
+  }) => {
+    const newSearch = replaceParamsToRegistrationQueryString(search, {
+      eventType:
+        type === 'eventType'
+          ? eventType.filter((item) => item !== value)
+          : eventType,
+      text: type === 'text' ? '' : text,
+    });
+
+    history.push({ pathname, search: newSearch });
+  };
+
+  const hasFilters = Boolean(eventType.length || text);
+
+  if (!hasFilters) return null;
+
+  return (
+    <div className={classNames(styles.filterSummary, className)}>
+      {text && (
+        <FilterTag
+          text={text}
+          onDelete={removeFilter}
+          type="text"
+          value={text}
+        />
+      )}
+      {eventType.map((type) => {
+        return (
+          <EventTypeFilterTag key={type} onDelete={removeFilter} value={type} />
+        );
+      })}
+
+      <button
+        className={styles.clearButton}
+        onClick={clearFilters}
+        type="button"
+      >
+        {t('registrationsPage.buttonClearFilters')}
+      </button>
+    </div>
+  );
+};
+
+export default FilterSummary;

--- a/src/domain/registrations/filterSummary/FilterTag.tsx
+++ b/src/domain/registrations/filterSummary/FilterTag.tsx
@@ -1,0 +1,38 @@
+import { Tag } from 'hds-react';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { RegistrationFilterType } from '../types';
+
+export interface FilterTagProps {
+  onDelete: (options: { type: RegistrationFilterType; value: string }) => void;
+  text: string;
+  type: RegistrationFilterType;
+  value: string;
+}
+
+const FilterTag: React.FC<FilterTagProps> = ({
+  onDelete,
+  text,
+  type,
+  value,
+}) => {
+  const { t } = useTranslation();
+  const deleteFilter = () => {
+    onDelete({ type, value });
+  };
+
+  return (
+    <Tag
+      deleteButtonAriaLabel={t(
+        'registrationsPage.searchPanel.buttonRemoveFilter',
+        { name: text }
+      )}
+      onDelete={deleteFilter}
+    >
+      {text}
+    </Tag>
+  );
+};
+
+export default FilterTag;

--- a/src/domain/registrations/filterSummary/__tests__/FilterSummary.test.tsx
+++ b/src/domain/registrations/filterSummary/__tests__/FilterSummary.test.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+
+import { ROUTES } from '../../../../constants';
+import { render, screen, userEvent } from '../../../../utils/testUtils';
+import { EVENT_TYPE } from '../../../event/constants';
+import FilterSummary from '../FilterSummary';
+
+const text = 'Search word';
+const type = EVENT_TYPE.General;
+
+const renderComponent = (route = `/fi${ROUTES.REGISTRATIONS}`) =>
+  render(<FilterSummary />, { routes: [route] });
+
+test('should render and remove text filter', async () => {
+  const { history } = renderComponent(
+    `/fi${ROUTES.REGISTRATIONS}?text=${text}`
+  );
+
+  const deleteFilterButton = screen.getByRole('button', {
+    name: `Poista suodatusehto: ${text}`,
+  });
+  userEvent.click(deleteFilterButton);
+
+  expect(history.location.pathname).toBe('/fi/registrations');
+  expect(history.location.search).toBe('');
+});
+
+test('should render and remove event type filter', async () => {
+  const { history } = renderComponent(
+    `/fi${ROUTES.REGISTRATIONS}?eventType=${type}`
+  );
+
+  const deleteFilterButton = screen.getByRole('button', {
+    name: `Poista suodatusehto: Tapahtuma`,
+  });
+  userEvent.click(deleteFilterButton);
+
+  expect(history.location.pathname).toBe('/fi/registrations');
+  expect(history.location.search).toBe('');
+});
+
+test('should remove all filters with clear button', async () => {
+  const { history } = renderComponent(
+    `/fi${ROUTES.REGISTRATIONS}?eventType=${type}&text=${text}`
+  );
+
+  screen.getByRole('button', { name: `Poista suodatusehto: ${text}` });
+
+  screen.getByRole('button', { name: `Poista suodatusehto: Tapahtuma` });
+
+  const clearButton = screen.getByRole('button', {
+    name: 'Tyhjennä hakuehdot',
+  });
+  userEvent.click(clearButton);
+
+  expect(history.location.pathname).toBe('/fi/registrations');
+  expect(history.location.search).toBe('');
+});

--- a/src/domain/registrations/filterSummary/filterSummary.module.scss
+++ b/src/domain/registrations/filterSummary/filterSummary.module.scss
@@ -1,0 +1,27 @@
+@import 'mixins';
+
+.filterSummary {
+  --filter-summary-color: var(--color-white);
+
+  display: flex;
+  flex-wrap: wrap;
+  margin-bottom: var(--spacing-xs);
+  margin-top: var(--spacing-m);
+  grid-gap: var(--spacing-xs);
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+
+  .clearButton {
+    padding: 0;
+    color: var(--filter-summary-color);
+    font-size: var(--fontsize-body-m);
+    font-weight: 500;
+    border: 2px solid transparent;
+    text-decoration: underline;
+    text-align: left;
+
+    @include focus-outline(0px);
+  }
+}

--- a/src/domain/registrations/hooks/useRegistrationSortOptions.ts
+++ b/src/domain/registrations/hooks/useRegistrationSortOptions.ts
@@ -1,0 +1,24 @@
+import camelCase from 'lodash/camelCase';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { OptionType } from '../../../types';
+import { REGISTRATION_SORT_OPTIONS } from '../constants';
+
+const useRegistrationSortOptions = (): OptionType[] => {
+  const { t } = useTranslation();
+  const sortOptions = React.useMemo(
+    () =>
+      Object.keys(REGISTRATION_SORT_OPTIONS).map((key) => ({
+        label: t(`registrationsPage.sortOptions.${camelCase(key)}`),
+        value: (
+          REGISTRATION_SORT_OPTIONS as Record<string, REGISTRATION_SORT_OPTIONS>
+        )[key],
+      })),
+    [t]
+  );
+
+  return sortOptions;
+};
+
+export default useRegistrationSortOptions;

--- a/src/domain/registrations/registrationList/RegistrationList.tsx
+++ b/src/domain/registrations/registrationList/RegistrationList.tsx
@@ -1,0 +1,92 @@
+import uniqueId from 'lodash/uniqueId';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+import FeedbackButton from '../../../common/components/feedbackButton/FeedbackButton';
+import LoadingSpinner from '../../../common/components/loadingSpinner/LoadingSpinner';
+import { EventsQueryVariables, Registration } from '../../../generated/graphql';
+import Container from '../../app/layout/Container';
+import { registrationsResponse } from '../__mocks__/registrationsPage.mock';
+import {
+  DEFAULT_REGISTRATION_SORT,
+  REGISTRATION_SORT_OPTIONS,
+} from '../constants';
+import useRegistrationSortOptions from '../hooks/useRegistrationSortOptions';
+import RegistrationsTable from '../registrationsTable/RegistrationsTable';
+import styles from './registrationList.module.scss';
+
+export interface EventListContainerProps {
+  baseVariables: EventsQueryVariables;
+}
+
+export const testIds = {
+  resultList: 'registration-result-list',
+};
+
+type RegistrationListProps = {
+  registrations: Registration[];
+  sort: REGISTRATION_SORT_OPTIONS;
+};
+
+const RegistrationList: React.FC<RegistrationListProps> = ({
+  registrations,
+  sort,
+}) => {
+  const { t } = useTranslation();
+  const sortOptions = useRegistrationSortOptions();
+
+  const getTableCaption = () => {
+    return t(`registrationsPage.registrationsTableCaption`, {
+      sort: sortOptions.find((option) => option.value === sort)?.label,
+    });
+  };
+
+  return (
+    <div className={styles.contentWrapperTable}>
+      <Container withOffset={true}>
+        <div className={styles.table}>
+          <RegistrationsTable
+            caption={getTableCaption()}
+            registrations={registrations}
+          />
+        </div>
+        <FeedbackButton theme="black" />
+      </Container>
+    </div>
+  );
+};
+
+const RegistrationListContainer: React.FC = () => {
+  const [registrationListId] = React.useState(() =>
+    uniqueId('registration-list-')
+  );
+  const { t } = useTranslation();
+
+  /* istanbul ignore next */
+  const registrations = registrationsResponse?.registrations?.data || [];
+  /* istanbul ignore next */
+  const registrationsCount =
+    registrationsResponse?.registrations?.meta.count || 0;
+
+  return (
+    <div
+      id={registrationListId}
+      className={styles.registrationList}
+      data-testid={testIds.resultList}
+    >
+      <Container withOffset={true}>
+        <span className={styles.count}>
+          {t('registrationsPage.count', { count: registrationsCount })}
+        </span>
+      </Container>
+      <LoadingSpinner isLoading={false}>
+        <RegistrationList
+          registrations={registrations}
+          sort={DEFAULT_REGISTRATION_SORT}
+        />
+      </LoadingSpinner>
+    </div>
+  );
+};
+
+export default RegistrationListContainer;

--- a/src/domain/registrations/registrationList/registrationList.module.scss
+++ b/src/domain/registrations/registrationList/registrationList.module.scss
@@ -1,0 +1,31 @@
+@import 'breakpoints';
+
+.contentWrapperTable {
+  background-color: var(--color-white);
+  margin-top: var(--spacing-4-xl);
+}
+
+.table {
+  display: grid;
+  grid-gap: var(--spacing-m);
+  margin: var(--spacing-m) 0;
+}
+
+.table {
+  margin-top: calc(0px - var(--spacing-4-xl));
+  max-width: calc(100vw - 2 * var(--spacing-s));
+  overflow: auto;
+
+  @include medium-up {
+    max-width: calc(100vw - 2 * var(--spacing-m));
+  }
+}
+
+.count {
+  display: grid;
+  align-content: center;
+  min-height: var(--input-height);
+  font-size: var(--fontsize-heading-xs);
+  font-weight: 600;
+  margin-left: var(--spacing-s);
+}

--- a/src/domain/registrations/registrations.module.scss
+++ b/src/domain/registrations/registrations.module.scss
@@ -1,0 +1,45 @@
+@import 'breakpoints';
+@import 'widths';
+
+.registrationsPage {
+  display: flex;
+  height: 100%;
+  flex-direction: column;
+
+  .filterSummary {
+    --filter-summary-color: var(--color-black);
+
+    div {
+      --tag-background: var(--color-white);
+    }
+  }
+}
+
+.titleRow {
+  display: grid;
+  grid-gap: var(--spacing-m);
+
+  .addButtonWrapper {
+    margin-bottom: var(--spacing-m);
+  }
+
+  @include medium-up {
+    display: flex;
+
+    .title {
+      flex: 1 1 0%;
+    }
+
+    .addButtonWrapper {
+      align-self: center;
+      margin-bottom: unset;
+    }
+
+    .addButton {
+      @include min-width-column(2);
+      @include max-width-column(2);
+
+      white-space: nowrap;
+    }
+  }
+}

--- a/src/domain/registrations/registrationsTable/RegistrationsTable.tsx
+++ b/src/domain/registrations/registrationsTable/RegistrationsTable.tsx
@@ -1,0 +1,105 @@
+import classNames from 'classnames';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { useHistory, useLocation } from 'react-router';
+
+import NoDataRow from '../../../common/components/table/NoDataRow';
+import Table from '../../../common/components/table/Table';
+import { Registration } from '../../../generated/graphql';
+import useIsComponentFocused from '../../../hooks/useIsComponentFocused';
+import useLocale from '../../../hooks/useLocale';
+import { addParamsToEventQueryString } from '../../eventSearch/utils';
+import { getRegistrationFields } from '../utils';
+import styles from './registrationsTable.module.scss';
+import RegistrationsTableRow from './RegistrationsTableRow';
+
+export interface RegistrationsTableProps {
+  caption: string;
+  className?: string;
+  registrations: Registration[];
+}
+
+const RegistrationsTable: React.FC<RegistrationsTableProps> = ({
+  caption,
+  className,
+  registrations,
+}) => {
+  const { t } = useTranslation();
+  const location = useLocation();
+  const history = useHistory();
+  const locale = useLocale();
+
+  const table = React.useRef<HTMLTableElement>(null);
+  const [focused, setFocused] = React.useState(false);
+
+  const isComponentFocused = useIsComponentFocused(table);
+
+  const onDocumentFocusin = () => {
+    const isFocused = isComponentFocused();
+    if (isFocused !== focused) {
+      setFocused(isFocused);
+    }
+  };
+
+  React.useEffect(() => {
+    document.addEventListener('focusin', onDocumentFocusin);
+
+    return () => {
+      document.removeEventListener('focusin', onDocumentFocusin);
+    };
+  });
+
+  const handleRowClick = (registration: Registration) => {
+    const { registrationUrl } = getRegistrationFields(registration, locale);
+    const queryString = addParamsToEventQueryString(location.search, {
+      returnPath: location.pathname,
+    });
+    history.push({ pathname: registrationUrl, search: queryString });
+  };
+
+  return (
+    <Table ref={table} className={classNames(styles.eventsTable)}>
+      <caption aria-live={focused ? 'polite' : undefined}>{caption}</caption>
+      <thead>
+        <tr>
+          <th className={styles.nameColumn}>
+            {t('registrationsPage.registrationsTableColumns.name')}
+          </th>
+          <th className={styles.nameColumn}>
+            {t('registrationsPage.registrationsTableColumns.publisher')}
+          </th>
+          <th className={styles.participantsColumn}>
+            {t('registrationsPage.registrationsTableColumns.participants')}
+          </th>
+          <th className={styles.waitingListColumn}>
+            {t('registrationsPage.registrationsTableColumns.waitingList')}
+          </th>
+          <th className={styles.enrolmentStartTimeColumn}>
+            {t(
+              'registrationsPage.registrationsTableColumns.enrolmentStartTime'
+            )}
+          </th>
+          <th className={styles.enrolmentEndTimeColumn}>
+            {t('registrationsPage.registrationsTableColumns.enrolmentEndTime')}
+          </th>
+          <th className={styles.actionButtonsColumn}></th>
+        </tr>
+      </thead>
+      <tbody>
+        {registrations.map(
+          (registration) =>
+            registration && (
+              <RegistrationsTableRow
+                key={registration.id}
+                onRowClick={handleRowClick}
+                registration={registration}
+              />
+            )
+        )}
+        {!registrations.length && <NoDataRow colSpan={6} />}
+      </tbody>
+    </Table>
+  );
+};
+
+export default RegistrationsTable;

--- a/src/domain/registrations/registrationsTable/RegistrationsTableRow.tsx
+++ b/src/domain/registrations/registrationsTable/RegistrationsTableRow.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Registration } from '../../../generated/graphql';
+import useLocale from '../../../hooks/useLocale';
+import useTimeFormat from '../../../hooks/useTimeFormat';
+import formatDate from '../../../utils/formatDate';
+import PublisherName from '../../events/eventCard/PublisherName';
+import { getEventItemId } from '../../eventSearch/utils';
+import ActionsDropdown from '../actionsDropdown/ActionsDropdown';
+import { getRegistrationFields } from '../utils';
+import styles from './registrationsTable.module.scss';
+
+interface Props {
+  registration: Registration;
+  onRowClick: (registration: Registration) => void;
+}
+
+const RegistrationsTableRow: React.FC<Props> = ({
+  registration,
+  onRowClick,
+}) => {
+  const { t } = useTranslation();
+  const locale = useLocale();
+  const actionsDropdownRef = React.useRef<HTMLDivElement>(null);
+  const rowRef = React.useRef<HTMLTableRowElement>(null);
+  const timeFormat = useTimeFormat();
+
+  const {
+    currentAttendeeCount,
+    currentWaitingListCount,
+    enrolmentStartTime,
+    enrolmentEndTime,
+    id,
+    maximumAttendeeCount,
+    maximumWaitingListCount,
+    name,
+    publisher,
+  } = getRegistrationFields(registration, locale);
+
+  const handleRowClick = (ev: React.MouseEvent) => {
+    /* istanbul ignore else */
+    if (
+      ev.target instanceof Node &&
+      !actionsDropdownRef.current?.contains(ev.target)
+    ) {
+      onRowClick(registration);
+    }
+  };
+
+  const handleKeyDown = (ev: React.KeyboardEvent) => {
+    /* istanbul ignore else */
+    if (ev.key === 'Enter' && ev.target === rowRef.current) {
+      onRowClick(registration);
+    }
+  };
+
+  return (
+    <>
+      <tr
+        ref={rowRef}
+        role="button"
+        aria-label={name}
+        id={getEventItemId(id)}
+        onClick={handleRowClick}
+        onKeyDown={handleKeyDown}
+        tabIndex={0}
+      >
+        <td className={styles.nameColumn}>
+          <div className={styles.nameWrapper}>
+            <span className={styles.eventName} title={name}>
+              {name}
+            </span>
+          </div>
+        </td>
+        <td className={styles.publisherColumn}>
+          {publisher ? (
+            <PublisherName id={publisher} />
+          ) : (
+            /* istanbul ignore next */ '-'
+          )}
+        </td>
+        <td className={styles.participantsColumn}>
+          {currentAttendeeCount} / {maximumAttendeeCount}
+        </td>
+        <td className={styles.waitingListColumn}>
+          {currentWaitingListCount} / {maximumWaitingListCount}
+        </td>
+        <td className={styles.enrolmentStartTimeColumn}>
+          {enrolmentStartTime
+            ? t('eventsPage.datetime', {
+                date: formatDate(enrolmentStartTime),
+                time: formatDate(enrolmentStartTime, timeFormat, locale),
+              })
+            : /* istanbul ignore next */ '-'}
+        </td>
+        <td className={styles.enrolmentEndTimeColumn}>
+          {enrolmentEndTime
+            ? t('eventsPage.datetime', {
+                date: formatDate(enrolmentEndTime),
+                time: formatDate(enrolmentEndTime, timeFormat, locale),
+              })
+            : /* istanbul ignore next */ '-'}
+        </td>
+        <td className={styles.actionButtonsColumn}>
+          <ActionsDropdown
+            ref={actionsDropdownRef}
+            registration={registration}
+          />
+        </td>
+      </tr>
+    </>
+  );
+};
+
+export default RegistrationsTableRow;

--- a/src/domain/registrations/registrationsTable/__tests__/RegistrationsTable.test.tsx
+++ b/src/domain/registrations/registrationsTable/__tests__/RegistrationsTable.test.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+
+import {
+  act,
+  configure,
+  render,
+  screen,
+  userEvent,
+} from '../../../../utils/testUtils';
+import {
+  registrationNames,
+  registrations,
+} from '../../__mocks__/registrationsPage.mock';
+import RegistrationsTable, {
+  RegistrationsTableProps,
+} from '../RegistrationsTable';
+
+configure({ defaultHidden: true });
+
+const defaultProps: RegistrationsTableProps = {
+  caption: 'Registrations table',
+  registrations: [],
+};
+
+const renderComponent = (props?: Partial<RegistrationsTableProps>) =>
+  render(<RegistrationsTable {...defaultProps} {...props} />);
+
+test('should render registrations table', () => {
+  renderComponent();
+
+  const columnHeaders = [
+    'Nimi',
+    'Julkaisija',
+    'Osallistujia',
+    'Jono',
+    'Alkaa',
+    'Loppuu',
+  ];
+
+  for (const name of columnHeaders) {
+    screen.getByRole('columnheader', { name });
+  }
+  screen.getByText('Ei tuloksia');
+});
+
+test('should render all registrations', () => {
+  renderComponent({
+    registrations: registrations.data,
+  });
+
+  for (const name of registrationNames) {
+    screen.getByRole('button', { name });
+  }
+});
+
+test('should open event page by clicking event', () => {
+  const registrationName = registrations.data[0].name.fi;
+  const registrationId = registrations.data[0].id;
+  const { history } = renderComponent({
+    registrations: registrations.data,
+  });
+
+  act(() =>
+    userEvent.click(screen.getByRole('button', { name: registrationName }))
+  );
+
+  expect(history.location.pathname).toBe(
+    `/fi/registrations/edit/${registrationId}`
+  );
+});
+
+test('should open event page by pressing enter on row', () => {
+  const registrationName = registrations.data[0].name.fi;
+  const registrationId = registrations.data[0].id;
+  const { history } = renderComponent({
+    registrations: registrations.data,
+  });
+
+  act(() =>
+    userEvent.type(
+      screen.getByRole('button', { name: registrationName }),
+      '{enter}'
+    )
+  );
+
+  expect(history.location.pathname).toBe(
+    `/fi/registrations/edit/${registrationId}`
+  );
+});

--- a/src/domain/registrations/registrationsTable/registrationsTable.module.scss
+++ b/src/domain/registrations/registrationsTable/registrationsTable.module.scss
@@ -1,0 +1,57 @@
+@import 'mixins';
+
+.eventsTable {
+  tbody tr {
+    cursor: pointer;
+
+    &:focus {
+      outline: var(--focus-outline-width) solid var(--focus-outline-color);
+      outline-offset: calc(0px - var(--focus-outline-width));
+
+      &:not(:global(.focus-visible)) {
+        outline: none;
+      }
+    }
+
+    td {
+      white-space: nowrap;
+    }
+  }
+
+  button {
+    @include focus-outline(0px);
+  }
+
+  caption {
+    @include hidden-from-screen;
+  }
+}
+
+.nameColumn,
+.publisherColumn {
+  width: 50%;
+}
+
+.nameColumn {
+  max-width: 360px;
+}
+
+.publisherColumn {
+  max-width: 200px;
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+
+.nameWrapper {
+  display: flex;
+  align-items: center;
+
+  .eventName {
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+}
+
+.actionButtonsColumn {
+  padding: var(--focus-outline-width) !important;
+}

--- a/src/domain/registrations/searchPanel/SearchPanel.tsx
+++ b/src/domain/registrations/searchPanel/SearchPanel.tsx
@@ -1,0 +1,129 @@
+import { css } from '@emotion/css';
+import classNames from 'classnames';
+import { IconHeart, IconSearch } from 'hds-react';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { useHistory, useLocation } from 'react-router';
+
+import Button from '../../../common/components/button/Button';
+import MultiSelectDropdown from '../../../common/components/multiSelectDropdown/MultiSelectDropdown';
+import SearchInput from '../../../common/components/searchInput/SearchInput';
+import { ROUTES } from '../../../constants';
+import useLocale from '../../../hooks/useLocale';
+import { OptionType } from '../../../types';
+import { useTheme } from '../../app/theme/Theme';
+import { EVENT_TYPE } from '../../event/constants';
+import useEventTypeOptions from '../../event/hooks/useEventTypeOptions';
+import {
+  getRegistrationSearchInitialValues,
+  getRegistrationSearchQuery,
+} from '../utils';
+import styles from './searchPanel.module.scss';
+
+type SearchState = {
+  eventType: EVENT_TYPE[];
+  text: string;
+};
+
+const SearchPanel: React.FC = () => {
+  const { t } = useTranslation();
+  const { theme } = useTheme();
+  const history = useHistory();
+  const location = useLocation();
+  const locale = useLocale();
+
+  const eventTypeOptions = useEventTypeOptions();
+
+  const [searchState, setSearchState] = React.useReducer(
+    (prevState: SearchState, updatedProperty: Partial<SearchState>) => ({
+      ...prevState,
+      ...updatedProperty,
+    }),
+    { eventType: [], text: '' }
+  );
+
+  const handleChangeEventTypes = (newTypes: OptionType[]) => {
+    setSearchState({
+      eventType: newTypes.map((type) => type.value) as EVENT_TYPE[],
+    });
+  };
+
+  const handleChangeText = (text: string) => {
+    setSearchState({ text });
+  };
+
+  const handleSearch = () => {
+    history.push({
+      pathname: `/${locale}${ROUTES.REGISTRATIONS}`,
+      search: getRegistrationSearchQuery(searchState, location.search),
+    });
+  };
+
+  React.useEffect(() => {
+    const { eventType, text } = getRegistrationSearchInitialValues(
+      location.search
+    );
+    setSearchState({ eventType, text });
+  }, [location.search]);
+
+  return (
+    <div
+      className={classNames(
+        styles.searchPanel,
+        css(theme.registrationSearchPanel)
+      )}
+    >
+      <div className={styles.inputRow}>
+        <div className={styles.typeSelectorWrapper}>
+          <MultiSelectDropdown
+            icon={<IconHeart aria-hidden />}
+            onChange={handleChangeEventTypes}
+            options={eventTypeOptions}
+            showSearch={true}
+            toggleButtonLabel={t(
+              'registrationsPage.searchPanel.labelEventType'
+            )}
+            value={searchState.eventType
+              .map(
+                (type) =>
+                  eventTypeOptions.find(
+                    (item) => item.value === type
+                  ) as OptionType
+              )
+              .filter((o) => o)}
+          />
+        </div>
+        <div className={styles.searchInputWrapper}>
+          <SearchInput
+            className={styles.searchInput}
+            clearButtonAriaLabel={t(
+              'registrationsPage.searchPanel.buttonClear'
+            )}
+            hideLabel={true}
+            label={t('registrationsPage.searchPanel.labelSearch')}
+            onSearch={handleSearch}
+            placeholder={t('registrationsPage.searchPanel.placeholderSearch')}
+            searchButtonAriaLabel={t(
+              'registrationsPage.searchPanel.buttonSearch'
+            )}
+            setValue={handleChangeText}
+            value={searchState.text}
+          />
+        </div>
+        <div className={styles.buttonWrapper}>
+          <Button
+            className={styles.button}
+            fullWidth={true}
+            iconLeft={<IconSearch aria-hidden />}
+            onClick={handleSearch}
+            variant="success"
+          >
+            {t('registrationsPage.searchPanel.buttonSearch')}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SearchPanel;

--- a/src/domain/registrations/searchPanel/__tests__/SearchPanel.test.tsx
+++ b/src/domain/registrations/searchPanel/__tests__/SearchPanel.test.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+
+import { ROUTES } from '../../../../constants';
+import {
+  act,
+  configure,
+  render,
+  screen,
+  userEvent,
+  waitFor,
+} from '../../../../utils/testUtils';
+import translations from '../../../app/i18n/fi.json';
+import SearchPanel from '../SearchPanel';
+
+configure({ defaultHidden: true });
+
+const getElement = (key: 'eventTypeSelectorButton' | 'searchInput') => {
+  switch (key) {
+    case 'eventTypeSelectorButton':
+      return screen.getByRole('button', {
+        name: translations.registrationsPage.searchPanel.labelEventType,
+      });
+    case 'searchInput':
+      return screen.getByRole('searchbox', {
+        name: translations.registrationsPage.searchPanel.labelSearch,
+      });
+  }
+};
+
+const renderComponent = (route: string = ROUTES.EVENTS) =>
+  render(<SearchPanel />, { routes: [route] });
+
+test('should initialize search panel input', async () => {
+  const searchValue = 'search';
+  renderComponent(
+    `${ROUTES.REGISTRATIONS}?text=${searchValue}&eventType=general`
+  );
+
+  const searchInput = getElement('searchInput');
+  await waitFor(() => expect(searchInput).toHaveValue(searchValue));
+  screen.getByText(/tapahtuma/i);
+});
+
+test('should search events with correct search params', async () => {
+  const values = { text: 'search' };
+
+  const { history } = renderComponent();
+
+  // Text filtering
+  const searchInput = getElement('searchInput');
+  userEvent.type(searchInput, values.text);
+  await waitFor(() => expect(searchInput).toHaveValue(values.text));
+
+  // Event type filtering
+  const eventTypeSelectorButton = getElement('eventTypeSelectorButton');
+  userEvent.click(eventTypeSelectorButton);
+  const eventTypeCheckbox = screen.getByRole('checkbox', {
+    name: /tapahtuma/i,
+  });
+  userEvent.click(eventTypeCheckbox);
+
+  const searchButton = screen.getAllByRole('button', {
+    name: /etsi ilmoittautumisia/i,
+  })[1];
+  act(() => userEvent.click(searchButton));
+
+  expect(history.location.pathname).toBe('/fi/registrations');
+  expect(history.location.search).toBe('?eventType=general&text=search');
+});

--- a/src/domain/registrations/searchPanel/searchPanel.module.scss
+++ b/src/domain/registrations/searchPanel/searchPanel.module.scss
@@ -1,0 +1,64 @@
+@import 'breakpoints';
+@import 'widths';
+
+.searchPanel {
+  --registration-search-panel-button-background-color: var(
+    --color-coat-of-arms
+  );
+  --registration-search-panel-button-background-color-hover: var(
+    --color-coat-of-arms-dark
+  );
+  --registration-search-panel-button-background-color-focus: var(
+    --color-coat-of-arms
+  );
+  --registration-search-panel-button-background-color-hover-focus: var(
+    --color-coat-of-arms-dark
+  );
+  --registration-search-panel-button-border-color: var(--color-coat-of-arms);
+  --registration-search-panel-button-color: var(--color-white);
+
+  .inputRow {
+    display: grid;
+    grid-gap: var(--spacing-m);
+    margin-top: var(--spacing-m);
+    margin-bottom: var(--spacing-m);
+
+    @include medium-up {
+      display: flex;
+
+      .typeSelectorWrapper,
+      .buttonWrapper {
+        @include min-width-column(2);
+      }
+      .searchInputWrapper {
+        flex: 1 1 0%;
+      }
+    }
+  }
+
+  .button {
+    --background-color: var(
+      --registration-search-panel-button-background-color
+    );
+    --background-color-hover: var(
+      --registration-search-panel-button-background-color-hover
+    );
+    --background-color-focus: var(
+      --registration-search-panel-button-background-color-focus
+    );
+    --background-color-hover-focus: var(
+      --registration-search-panel-button-background-color-hover-focus
+    );
+    --border-color: var(--registration-search-panel-button-border-color);
+    --border-color-hover: var(--registration-search-panel-button-border-color);
+    --border-color-focus: var(--registration-search-panel-button-border-color);
+    --border-color-hover-focus: var(
+      --registration-search-panel-button-border-color
+    );
+    --color: var(--registration-search-panel-button-color);
+    --color-hover: var(--registration-search-panel-button-color);
+    --color-focus: var(--registration-search-panel-button-color);
+    --color-hover-focus: var(--registration-search-panel-button-color);
+    --focus-outline-color: var(--color-coat-of-arms);
+  }
+}

--- a/src/domain/registrations/types.ts
+++ b/src/domain/registrations/types.ts
@@ -1,0 +1,41 @@
+import { EVENT_TYPE } from '../event/constants';
+import {
+  REGISTRATION_SEARCH_PARAMS,
+  REGISTRATION_SORT_OPTIONS,
+} from './constants';
+
+export type RegistrationSearchParams = {
+  [REGISTRATION_SEARCH_PARAMS.EVENT_TYPE]?: EVENT_TYPE[];
+  [REGISTRATION_SEARCH_PARAMS.PAGE]?: number | null;
+  [REGISTRATION_SEARCH_PARAMS.RETURN_PATH]?: string | null;
+  [REGISTRATION_SEARCH_PARAMS.SORT]?: REGISTRATION_SORT_OPTIONS | null;
+  [REGISTRATION_SEARCH_PARAMS.TEXT]: string;
+};
+
+export type RegistrationSearchInitialValues = {
+  [REGISTRATION_SEARCH_PARAMS.EVENT_TYPE]: EVENT_TYPE[];
+  [REGISTRATION_SEARCH_PARAMS.PAGE]: number;
+  [REGISTRATION_SEARCH_PARAMS.SORT]: REGISTRATION_SORT_OPTIONS;
+  [REGISTRATION_SEARCH_PARAMS.TEXT]: string;
+};
+
+export type RegistrationFilterType = 'eventType' | 'text';
+export type RegistrationSearchParam = keyof RegistrationSearchParams;
+
+export type RegistrationsLocationState = {
+  registrationId: string;
+};
+
+export type RegistrationFields = {
+  id: string;
+  atId: string;
+  currentAttendeeCount: number;
+  currentWaitingListCount: number;
+  enrolmentEndTime: Date | null;
+  enrolmentStartTime: Date | null;
+  maximumAttendeeCount: number;
+  maximumWaitingListCount: number;
+  name: string;
+  publisher: string | null;
+  registrationUrl: string;
+};

--- a/src/domain/registrations/utils.ts
+++ b/src/domain/registrations/utils.ts
@@ -1,0 +1,172 @@
+import { TFunction } from 'i18next';
+
+import { MenuItemOptionProps } from '../../common/components/menuDropdown/MenuItem';
+import { ROUTES } from '../../constants';
+import { Registration } from '../../generated/graphql';
+import { Language } from '../../types';
+import getLocalisedString from '../../utils/getLocalisedString';
+import { getSearchQuery } from '../../utils/searchUtils';
+import stripLanguageFromPath from '../../utils/stripLanguageFromPath';
+import { assertUnreachable } from '../../utils/typescript';
+import { EVENT_TYPE } from '../event/constants';
+import {
+  DEFAULT_REGISTRATION_SORT,
+  REGISTRATION_EDIT_ACTIONS,
+  REGISTRATION_EDIT_ICONS,
+  REGISTRATION_EDIT_LABEL_KEYS,
+  REGISTRATION_SEARCH_PARAMS,
+  REGISTRATION_SORT_OPTIONS,
+} from './constants';
+import {
+  RegistrationFields,
+  RegistrationSearchInitialValues,
+  RegistrationSearchParam,
+  RegistrationSearchParams,
+} from './types';
+
+export const getRegistrationSearchInitialValues = (
+  search: string
+): RegistrationSearchInitialValues => {
+  const searchParams = new URLSearchParams(search);
+  const eventType = searchParams.getAll(
+    REGISTRATION_SEARCH_PARAMS.EVENT_TYPE
+  ) as EVENT_TYPE[];
+  const page = searchParams.get(REGISTRATION_SEARCH_PARAMS.PAGE);
+  const sort = searchParams.get(
+    REGISTRATION_SEARCH_PARAMS.SORT
+  ) as REGISTRATION_SORT_OPTIONS;
+  const text = searchParams.get(REGISTRATION_SEARCH_PARAMS.TEXT);
+
+  return {
+    eventType,
+    page: Number(page) || 1,
+    sort: Object.values(REGISTRATION_SORT_OPTIONS).includes(sort)
+      ? sort
+      : DEFAULT_REGISTRATION_SORT,
+    text: text || '',
+  };
+};
+
+export const getRegistrationSearchQuery = (
+  params: Omit<RegistrationSearchParams, 'sort'>,
+  search = ''
+): string => {
+  const { sort } = getRegistrationSearchInitialValues(search);
+
+  return getSearchQuery({
+    ...params,
+    sort: sort !== DEFAULT_REGISTRATION_SORT ? sort : null,
+  });
+};
+
+export const getRegistrationParamValue = ({
+  param,
+  value,
+}: {
+  param: RegistrationSearchParam;
+  value: string;
+}): string => {
+  switch (param) {
+    case REGISTRATION_SEARCH_PARAMS.EVENT_TYPE:
+    case REGISTRATION_SEARCH_PARAMS.PAGE:
+    case REGISTRATION_SEARCH_PARAMS.SORT:
+    case REGISTRATION_SEARCH_PARAMS.TEXT:
+      return value;
+    case REGISTRATION_SEARCH_PARAMS.RETURN_PATH:
+      return stripLanguageFromPath(value);
+    default:
+      return assertUnreachable(param, 'Unknown registration query parameter');
+  }
+};
+
+export const addParamsToRegistrationQueryString = (
+  queryString: string,
+  queryParams: Partial<RegistrationSearchParams>
+): string => {
+  const searchParams = new URLSearchParams(queryString);
+  Object.entries(queryParams).forEach(([key, values]) => {
+    const param = key as RegistrationSearchParam;
+    if (Array.isArray(values)) {
+      values.forEach((value) =>
+        searchParams.append(param, getRegistrationParamValue({ param, value }))
+      );
+    } /* istanbul ignore else */ else if (values) {
+      searchParams.append(
+        param,
+        getRegistrationParamValue({ param, value: values.toString() })
+      );
+    }
+  });
+
+  return searchParams.toString() ? `?${searchParams.toString()}` : '';
+};
+
+export const replaceParamsToRegistrationQueryString = (
+  queryString: string,
+  queryParams: Partial<RegistrationSearchParams>
+): string => {
+  const searchParams = new URLSearchParams(queryString);
+  Object.entries(queryParams).forEach(([key, values]) => {
+    const param = key as RegistrationSearchParam;
+    searchParams.delete(param);
+
+    if (Array.isArray(values)) {
+      values.forEach((value) =>
+        searchParams.append(param, getRegistrationParamValue({ param, value }))
+      );
+    } else if (values) {
+      searchParams.append(
+        param,
+        getRegistrationParamValue({ param, value: values.toString() })
+      );
+    }
+  });
+
+  return searchParams.toString() ? `?${searchParams.toString()}` : '';
+};
+
+export const getRegistrationFields = (
+  registration: Registration,
+  language: Language
+): RegistrationFields => {
+  const id = registration.id || '';
+
+  return {
+    id,
+    atId: registration.atId || '',
+    currentAttendeeCount: registration.currentAttendeeCount ?? 0,
+    currentWaitingListCount: registration.currentWaitingListCount ?? 0,
+    enrolmentEndTime: registration.enrolmentEndTime
+      ? new Date(registration.enrolmentEndTime)
+      : null,
+    enrolmentStartTime: registration.enrolmentStartTime
+      ? new Date(registration.enrolmentStartTime)
+      : null,
+    maximumAttendeeCount: registration.maximumAttendeeCount ?? 0,
+    maximumWaitingListCount: registration.maximumWaitingListCount ?? 0,
+    name: getLocalisedString(registration.name, language),
+    publisher: registration.publisher || null,
+    registrationUrl: `/${language}${ROUTES.EDIT_REGISTRATION.replace(
+      ':id',
+      id
+    )}`,
+  };
+};
+
+export const getEditButtonProps = ({
+  action,
+  onClick,
+  t,
+}: {
+  action: REGISTRATION_EDIT_ACTIONS;
+  onClick: () => void;
+  t: TFunction;
+}): MenuItemOptionProps | null => {
+  return {
+    disabled: false,
+    icon: REGISTRATION_EDIT_ICONS[action],
+    label: t(REGISTRATION_EDIT_LABEL_KEYS[action]),
+    onClick,
+    title: '',
+  };
+};

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -94,6 +94,7 @@ export type Query = {
   organizations: OrganizationsResponse;
   place: Place;
   places: PlacesResponse;
+  registrations: RegistrationsResponse;
   user: User;
 };
 
@@ -646,6 +647,32 @@ export type Video = {
   altText?: Maybe<Scalars['String']>;
   name?: Maybe<Scalars['String']>;
   url?: Maybe<Scalars['String']>;
+};
+
+export type RegistrationsResponse = {
+  __typename?: 'RegistrationsResponse';
+  meta: Meta;
+  data: Array<Registration>;
+};
+
+export type Registration = {
+  __typename?: 'Registration';
+  id?: Maybe<Scalars['ID']>;
+  createdAt?: Maybe<Scalars['String']>;
+  currentAttendeeCount?: Maybe<Scalars['Int']>;
+  currentWaitingListCount?: Maybe<Scalars['Int']>;
+  enrolmentEndTime?: Maybe<Scalars['String']>;
+  enrolmentStartTime?: Maybe<Scalars['String']>;
+  eventId?: Maybe<Scalars['ID']>;
+  maximumAttendeeCount?: Maybe<Scalars['Int']>;
+  maximumWaitingListCount?: Maybe<Scalars['Int']>;
+  minimumAttendeeCount?: Maybe<Scalars['Int']>;
+  name?: Maybe<LocalisedObject>;
+  publisher?: Maybe<Scalars['String']>;
+  updatedAt?: Maybe<Scalars['String']>;
+  atId: Scalars['String'];
+  atContext?: Maybe<Scalars['String']>;
+  atType?: Maybe<Scalars['String']>;
 };
 
 export type CreateEventMutationVariables = Exact<{

--- a/src/utils/mockDataUtils.ts
+++ b/src/utils/mockDataUtils.ts
@@ -26,6 +26,8 @@ import {
   Place,
   PlacesResponse,
   PublicationStatus,
+  Registration,
+  RegistrationsResponse,
   User,
   Video,
 } from '../generated/graphql';
@@ -296,6 +298,42 @@ export const fakePlace = (overrides?: Partial<Place>): Place => {
       position: null,
       divisions: [],
       __typename: 'Place',
+    },
+    overrides
+  );
+};
+
+export const fakeRegistrations = (
+  count = 1,
+  registrations?: Partial<Registration>[]
+): RegistrationsResponse => ({
+  data: generateNodeArray((i) => fakeRegistration(registrations?.[i]), count),
+  meta: fakeMeta(count),
+  __typename: 'RegistrationsResponse',
+});
+
+export const fakeRegistration = (
+  overrides?: Partial<Registration>
+): Registration => {
+  const id = overrides?.id || faker.datatype.uuid();
+
+  return merge<Registration, typeof overrides>(
+    {
+      id,
+      atId: generateAtId(id, 'registration'),
+      createdAt: null,
+      currentAttendeeCount: 0,
+      currentWaitingListCount: 0,
+      enrolmentEndTime: '2020-09-30T16:00:00.000000Z',
+      enrolmentStartTime: '2020-09-27T15:00:00.000000Z',
+      eventId: null,
+      maximumAttendeeCount: 0,
+      maximumWaitingListCount: 0,
+      minimumAttendeeCount: 0,
+      name: fakeLocalisedObject(faker.name.title()),
+      publisher: 'ahjo:u4804001050',
+      updatedAt: null,
+      __typename: 'Registration',
     },
     overrides
   );


### PR DESCRIPTION
## Description
Implement registration list page 
Registration table
Action dropdown inside registration table (don't implement copy as template and delete features)

## Closes
[LINK-559](https://helsinkisolutionoffice.atlassian.net/browse/LINK-559)

## Screenshot
<img width="1410" alt="Screenshot 2021-09-01 at 14 39 09" src="https://user-images.githubusercontent.com/24706814/131665149-545fc223-0107-4f72-a4b2-496545c99570.png">

<img width="1169" alt="Screenshot 2021-09-01 at 14 39 19" src="https://user-images.githubusercontent.com/24706814/131665165-a2a8dc32-8530-4d65-8c34-20e14ea795d0.png">

