### PR TITLE
LINK-1157 | Update GitHub actions to latest versions to fix deprecation warnings

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -100,7 +100,7 @@ jobs:
           node-version: '16'
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v3
         id: yarn-cache
         with:

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -98,16 +98,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '16'
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v3
-        id: yarn-cache
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          cache: 'yarn'
       - name: Install dependencies
         run: yarn --prefer-offline --frozen-lockfile --check-files --production=false
       - name: Run TestCafe tests

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Build
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Build
         uses: andersinno/kolga-build-action@v2
         env:
@@ -56,7 +56,7 @@ jobs:
     needs: build
     name: Production
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: andersinno/kolga-setup-action@v2
 
       - name: Deploy
@@ -93,15 +93,15 @@ jobs:
     needs: production
     name: Smoke tests for production
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Node.js environment
-        uses: actions/setup-node@v2.1.2
+        uses: actions/setup-node@v3
         with:
           node-version: '16'
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -124,7 +124,7 @@ jobs:
           TESTCAFE_SLACK_CHANNEL: '#linked-alerts'
           TESTCAFE_SLACK_USERNAME: TestCafé
       - name: Upload screenshots and videos of failed tests to artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: report
           path: report/

--- a/.github/workflows/production_scheduled_tests.yml
+++ b/.github/workflows/production_scheduled_tests.yml
@@ -12,15 +12,15 @@ jobs:
     name: Scheduled Acceptance tests against Production environment
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Node.js environment
-        uses: actions/setup-node@v2.1.2
+        uses: actions/setup-node@v3
         with:
           node-version: '16'
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -43,7 +43,7 @@ jobs:
           TESTCAFE_SLACK_CHANNEL: '#linked-alerts'
           TESTCAFE_SLACK_USERNAME: TestCafé
       - name: Upload screenshots and videos of failed tests to artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: report
           path: report/

--- a/.github/workflows/production_scheduled_tests.yml
+++ b/.github/workflows/production_scheduled_tests.yml
@@ -17,16 +17,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '16'
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v3
-        id: yarn-cache
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          cache: 'yarn'
       - name: Install dependencies
         run: yarn --prefer-offline --frozen-lockfile --check-files --production=false
       - name: Run Acceptance Tests (TestCafe Browser Tests)

--- a/.github/workflows/production_scheduled_tests.yml
+++ b/.github/workflows/production_scheduled_tests.yml
@@ -19,7 +19,7 @@ jobs:
           node-version: '16'
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v3
         id: yarn-cache
         with:

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -66,16 +66,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '16'
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v3
-        id: yarn-cache
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          cache: 'yarn'
       - name: Install dependencies
         run: yarn --prefer-offline --frozen-lockfile --check-files
       - name: Run Acceptance Tests (TestCafe Browser Tests)

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -68,7 +68,7 @@ jobs:
           node-version: '16'
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v3
         id: yarn-cache
         with:

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Build
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Build
         uses: andersinno/kolga-build-action@v2
         env:
@@ -43,7 +43,7 @@ jobs:
     needs: build
     name: Review
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: andersinno/kolga-setup-action@v2
 
       - name: Deploy
@@ -63,13 +63,13 @@ jobs:
           echo "BROWSER_TESTS_ENV_URL=https://$DEPLOY_URL" >> $GITHUB_ENV
         shell: bash
       - name: Setup Node.js environment
-        uses: actions/setup-node@v2.1.2
+        uses: actions/setup-node@v3
         with:
           node-version: '16'
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -90,7 +90,7 @@ jobs:
           TESTCAFE_SLACK_CHANNEL: '#linked-alerts'
           TESTCAFE_SLACK_USERNAME: TestCafé
       - name: Upload screenshots and videos of failed tests to artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: report

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -92,7 +92,7 @@ jobs:
           node-version: '16'
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v3
         id: yarn-cache
         with:

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -90,16 +90,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '16'
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v3
-        id: yarn-cache
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          cache: 'yarn'
       - name: Install dependencies
         run: yarn --prefer-offline --frozen-lockfile --check-files --production=false
       - name: Run TestCafe tests for https://linkedcomponents-ui.test.kuva.hel.ninja

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Build
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Build
         uses: andersinno/kolga-build-action@v2
         env:
@@ -55,7 +55,7 @@ jobs:
     needs: build
     name: Staging + Acceptance tests
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: andersinno/kolga-setup-action@v2
 
       - name: Deploy
@@ -87,13 +87,13 @@ jobs:
           SLACK_CHANNEL: linked-alerts
         if: failure()
       - name: Setup Node.js environment
-        uses: actions/setup-node@v2.1.2
+        uses: actions/setup-node@v3
         with:
           node-version: '16'
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -116,7 +116,7 @@ jobs:
           TESTCAFE_SLACK_CHANNEL: '#linked-alerts'
           TESTCAFE_SLACK_USERNAME: TestCafé
       - name: Upload screenshots and videos of failed tests to artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: report
           path: report/

--- a/.github/workflows/staging_scheduled_tests.yml
+++ b/.github/workflows/staging_scheduled_tests.yml
@@ -17,16 +17,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '16'
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v3
-        id: yarn-cache
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          cache: 'yarn'
       - name: Install dependencies
         run: yarn --prefer-offline --frozen-lockfile --check-files --production=false
       - name: Run TestCafe tests

--- a/.github/workflows/staging_scheduled_tests.yml
+++ b/.github/workflows/staging_scheduled_tests.yml
@@ -12,15 +12,15 @@ jobs:
     name: Scheduled Acceptance tests against Staging environment
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Node.js environment
-        uses: actions/setup-node@v2.1.2
+        uses: actions/setup-node@v3
         with:
           node-version: '16'
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -43,7 +43,7 @@ jobs:
           TESTCAFE_SLACK_CHANNEL: '#linked-alerts'
           TESTCAFE_SLACK_USERNAME: TestCafé
       - name: Upload screenshots and videos of failed tests to artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: report
           path: report/

--- a/.github/workflows/staging_scheduled_tests.yml
+++ b/.github/workflows/staging_scheduled_tests.yml
@@ -19,7 +19,7 @@ jobs:
           node-version: '16'
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v3
         id: yarn-cache
         with:


### PR DESCRIPTION
## Description :sparkles:
Fix GitHub Actions deprecations warnings by updating following actions:
- actions/cache@v2 -> actions/cache@v3
- actions/checkout@v2 -> actions/checkout@v3
- actions/setup-node@v2.1.2 -> actions/setup-node@v3
- actions/upload-artifact@v2->actions/upload-artifact@v3

## Issues :bug:

### Closes :no_good_woman:
[LINK-1157](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1157)

[LINK-1157]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Testing
You can see latest GitHub action run at https://github.com/City-of-Helsinki/linkedcomponents-ui/actions/runs/4162129527