### PR TITLE
Limit file name length to 200 characters

### DIFF
--- a/src/common/components/imageUploader/imageDropzone/ImageDropzone.tsx
+++ b/src/common/components/imageUploader/imageDropzone/ImageDropzone.tsx
@@ -6,6 +6,7 @@ import { toast } from 'react-toastify';
 
 import {
   ACCEPTED_IMAGE_TYPES,
+  MAX_IMAGE_FILE_NAME_LENGTH,
   MIN_IMAGE_HEIGHT,
   MIN_IMAGE_WIDTH,
   testIds,
@@ -34,6 +35,15 @@ const ImageDropzone: React.FC<ImageDropzoneProps> = ({
       toast.error(t('common.imageUploader.notAllowedFileFormat'));
       return;
     }
+
+    if (!validateImageFileNameLength(file)) {
+      toast.error(
+        t('common.imageUploader.tooLongFileName', {
+          maxLength: MAX_IMAGE_FILE_NAME_LENGTH,
+        })
+      );
+      return;
+    }
     /* istanbul ignore next */
     if (!isTestEnv && !(await validateImageMinDimensions(file))) {
       toast.error(t('common.imageUploader.belowMinDimensions'));
@@ -45,6 +55,9 @@ const ImageDropzone: React.FC<ImageDropzoneProps> = ({
 
   const validateImageFileType = (file: File): boolean =>
     ACCEPTED_IMAGE_TYPES.includes(file.type);
+
+  const validateImageFileNameLength = (file: File): boolean =>
+    file.name.length <= MAX_IMAGE_FILE_NAME_LENGTH;
 
   /* istanbul ignore next */
   const validateImageMinDimensions = async (file: File): Promise<boolean> => {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -144,6 +144,7 @@ export enum FORM_NAMES {
 export const ACCEPTED_IMAGE_TYPES = ['image/jpeg', 'image/gif', 'image/png'];
 export const COMPRESSABLE_IMAGE_TYPES = ['image/jpeg', 'image/png'];
 export const MAX_IMAGE_SIZE_MB = 2;
+export const MAX_IMAGE_FILE_NAME_LENGTH = 200;
 export const MIN_IMAGE_HEIGHT = 200;
 export const MIN_IMAGE_WIDTH = 300;
 export const MIN_UPSCALED_IMAGE_HEIGHT = 400;

--- a/src/domain/app/i18n/en.json
+++ b/src/domain/app/i18n/en.json
@@ -127,6 +127,7 @@
       "buttonRemoveImage": "Remove image",
       "notAllowedFileFormat": "File format is not supported",
       "titleCropImage": "Crop image",
+      "tooLongFileName": "File name is too long. Maximum length is {{maxLength}} characters.",
       "tooLargeFileSize": "File size is too large. The maximum file size is {{maxSize}} MB"
     },
     "leaflet": {

--- a/src/domain/app/i18n/fi.json
+++ b/src/domain/app/i18n/fi.json
@@ -128,6 +128,7 @@
       "buttonRemoveImage": "Poista kuva",
       "notAllowedFileFormat": "Tiedostomuoto ei ole sallittu",
       "titleCropImage": "Rajaa kuva",
+      "tooLongFileName": "Tiedoston nimi on liian pitkä. Nimi voi olla enintään {{maxLength}} merkkiä.",
       "tooLargeFileSize": "Tiedostokoko on liian suuri. Tiedoston maksimikoko on {{maxSize}} Mt"
     },
     "leaflet": {

--- a/src/domain/app/i18n/sv.json
+++ b/src/domain/app/i18n/sv.json
@@ -128,6 +128,7 @@
       "buttonRemoveImage": "Ta bort bild",
       "notAllowedFileFormat": "Filformatet stöds inte",
       "titleCropImage": "Beskära bild",
+      "tooLongFileName": "Filnamnet är för långt. Maximalt antal tecken är {{maxLength}}.",
       "tooLargeFileSize": "Filstorleken är för stor. Största tillåtna storlek är {{maxSize}} MB"
     },
     "leaflet": {


### PR DESCRIPTION
Backend max file name length will be increased to 255. However, during processing, the filename will increase in length. BE will add prefix folder path to the file name that gets stored in the DB and also a unique suffix identifier if the file name already exists. So we leave 55 characters as wiggle room.

https://helsinkisolutionoffice.atlassian.net/browse/LINK-991

