### PR TITLE
Use free_text in KeywordSelector

### DIFF
--- a/src/common/components/keywordSelector/KeywordSelector.tsx
+++ b/src/common/components/keywordSelector/KeywordSelector.tsx
@@ -72,7 +72,7 @@ const KeywordSelector: React.FC<KeywordSelectorProps> = ({
       createPath: getPathBuilder(keywordsPathBuilder),
       dataSource: ['yso', 'helsinki'],
       showAllKeywords: true,
-      text: debouncedSearch,
+      freeText: debouncedSearch,
     },
   });
 

--- a/src/common/components/keywordSelector/__mocks__/keywordSelector.ts
+++ b/src/common/components/keywordSelector/__mocks__/keywordSelector.ts
@@ -32,7 +32,7 @@ const keywordsVariables = {
   createPath: undefined,
   dataSource: ['yso', 'helsinki'],
   showAllKeywords: true,
-  text: '',
+  freeText: '',
 };
 const keywordsResponse = { data: { keywords } };
 const mockedKeywordsResponse = {

--- a/src/domain/event/formSections/classificationSection/__mocks__/classificationSection.ts
+++ b/src/domain/event/formSections/classificationSection/__mocks__/classificationSection.ts
@@ -82,7 +82,7 @@ const keywordsVariables = {
   createPath: undefined,
   dataSource: ['yso', 'helsinki'],
   showAllKeywords: true,
-  text: '',
+  freeText: '',
 };
 const keywordsResponse = { data: { keywords: eventTopics } };
 const mockedKeywordsResponse = {


### PR DESCRIPTION
free_text uses trigram similarity to filter and sort results. This is 50% slower, but allows for more accurate results with exact matches automatically ranked on top.

[LINK-1242](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1242)


[LINK-1242]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1242?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ