### PR TITLE
LINK-1244 | Increase header z-index to prevent map to hide header

### DIFF
--- a/src/domain/app/header/header.module.scss
+++ b/src/domain/app/header/header.module.scss
@@ -1,6 +1,8 @@
 @import '../../../assets/styles/breakpoints';
 
 .navigation {
+  --header-z-index: 101;
+
   z-index: var(--header-z-index);
   left: 0;
   position: sticky !important;


### PR DESCRIPTION
## Description :sparkles:
Increase header z-index to prevent map to hide header

## Issues :bug:

### Closes :no_good_woman:
[LINK-1244](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1244)

## Testing
Fix can be tested locally at http://localhost:3000/fi/administration/places/create

## Screenshots :camera_flash:
<img width="1723" alt="Screenshot 2023-03-23 at 16 52 53" src="https://user-images.githubusercontent.com/24706814/227244338-3dab7783-be82-4e59-b02b-418302997445.png">



[LINK-1244]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1244?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ