### PR TITLE
LINK-130, LINK-348 | Support filtering images by text

### DIFF
--- a/src/common/components/imagePreview/ImagePreview.tsx
+++ b/src/common/components/imagePreview/ImagePreview.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import useMeasure from 'react-use-measure';
 
 import { testIds } from '../../../constants';
+import useShowPlaceholderImage from '../../../hooks/useShowPlaceholderImage';
 import styles from './imagePreview.module.scss';
 
 const RATIO = 2 / 3;
@@ -32,6 +33,9 @@ const ImagePreview: React.FC<ImagePreviewProps> = ({
     scroll: false,
     polyfill: ResizeObserver,
   });
+
+  const showPlaceholder = useShowPlaceholderImage(imageUrl);
+
   const containerStyles: ContainerStyles = React.useMemo(() => {
     const { width } = menuContainerSize;
     // the menu width should be at least 190px
@@ -67,16 +71,16 @@ const ImagePreview: React.FC<ImagePreviewProps> = ({
       style={containerStyles}
       tabIndex={0}
     >
-      {imageUrl ? (
+      {showPlaceholder ? (
+        <div className={styles.placeholderImage}>
+          <IconPhoto size="xl" />
+        </div>
+      ) : (
         <div
           data-testid={testIds.imagePreview.image}
           className={styles.image}
           style={{ backgroundImage: `url(${imageUrl})` }}
         />
-      ) : (
-        <div className={styles.placeholderImage}>
-          <IconPhoto size="xl" />
-        </div>
       )}
     </div>
   );

--- a/src/common/components/imageSelector/ImageSelector.tsx
+++ b/src/common/components/imageSelector/ImageSelector.tsx
@@ -1,17 +1,28 @@
 import { ClassNames } from '@emotion/react';
-import { IconEye } from 'hds-react';
+import { IconEye, IconPhoto } from 'hds-react';
 import xor from 'lodash/xor';
-import React from 'react';
+import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useDebounce } from 'use-debounce';
 
+import { COMBOBOX_DEBOUNCE_TIME_MS, testIds } from '../../../constants';
 import { useTheme } from '../../../domain/app/theme/Theme';
 import { imagesPathBuilder } from '../../../domain/image/utils';
-import { Image, useImagesQuery } from '../../../generated/graphql';
+import {
+  Image,
+  ImageFieldsFragment,
+  useImagesQuery,
+} from '../../../generated/graphql';
 import useIsComponentFocused from '../../../hooks/useIsComponentFocused';
+import useMountedState from '../../../hooks/useMountedState';
+import useShowPlaceholderImage from '../../../hooks/useShowPlaceholderImage';
 import getNextPage from '../../../utils/getNextPage';
 import getPathBuilder from '../../../utils/getPathBuilder';
 import getValue from '../../../utils/getValue';
+import skipFalsyType from '../../../utils/skipFalsyType';
 import Button from '../button/Button';
+import LoadingSpinner from '../loadingSpinner/LoadingSpinner';
+import SearchInput from '../searchInput/SearchInput';
 import { PAGE_SIZE } from './constants';
 import styles from './imageSelector.module.scss';
 
@@ -24,6 +35,49 @@ export interface ImageSelectorProps {
   publisher: string;
   value: string[];
 }
+
+export type ImageItemProps = {
+  checked: boolean;
+  disabled: boolean;
+  image: ImageFieldsFragment;
+  onClick: (image: ImageFieldsFragment) => void;
+  onDoubleClick: (image: ImageFieldsFragment) => void;
+};
+
+export const ImageItem: React.FC<ImageItemProps> = ({
+  checked,
+  disabled,
+  image,
+  onClick,
+  onDoubleClick,
+}) => {
+  const url = useMemo(() => getValue(image.url, ''), [image]);
+  const showPlaceholder = useShowPlaceholderImage(url);
+
+  return (
+    <ClassNames>
+      {({ cx }) => (
+        <button
+          className={cx(styles.image, {
+            [styles.checked]: checked,
+            [styles.showPlaceholder]: showPlaceholder,
+          })}
+          aria-label={getValue(image.name, '')}
+          disabled={disabled}
+          data-testid={`${testIds.imageSelector.imageItem}-${image.id}`}
+          style={{ backgroundImage: `url(${url})` }}
+          role="checkbox"
+          type="button"
+          aria-checked={checked}
+          onClick={() => onClick(image)}
+          onDoubleClick={() => onDoubleClick(image)}
+        >
+          {showPlaceholder && <IconPhoto size="xl" />}
+        </button>
+      )}
+    </ClassNames>
+  );
+};
 
 const ImageSelector: React.FC<ImageSelectorProps> = ({
   disabled = false,
@@ -42,6 +96,9 @@ const ImageSelector: React.FC<ImageSelectorProps> = ({
 
   const isComponentFocused = useIsComponentFocused(container);
 
+  const [search, setSearch] = useMountedState('');
+  const [debouncedSearch] = useDebounce(search, COMBOBOX_DEBOUNCE_TIME_MS);
+
   const {
     data: imagesData,
     loading,
@@ -52,6 +109,7 @@ const ImageSelector: React.FC<ImageSelectorProps> = ({
       mergePages: true,
       pageSize: PAGE_SIZE,
       publisher,
+      text: debouncedSearch,
     },
   });
 
@@ -66,11 +124,7 @@ const ImageSelector: React.FC<ImageSelectorProps> = ({
       try {
         setLoadingMore(true);
 
-        await fetchMoreImages({
-          variables: {
-            page: nextPage,
-          },
-        });
+        await fetchMoreImages({ variables: { page: nextPage } });
 
         setLoadingMore(false);
       } catch (e) /* istanbul ignore next */ {
@@ -79,7 +133,7 @@ const ImageSelector: React.FC<ImageSelectorProps> = ({
     }
   };
 
-  const handleChange = (image: Image) => () => {
+  const handleChange = (image: Image) => {
     if (multiple) {
       onChange(xor(value, [image.atId]));
     } else {
@@ -87,7 +141,7 @@ const ImageSelector: React.FC<ImageSelectorProps> = ({
     }
   };
 
-  const handleDoubleClick = (image: Image) => () => {
+  const handleDoubleClick = (image: Image) => {
     onDoubleClick && onDoubleClick(image);
   };
 
@@ -118,32 +172,36 @@ const ImageSelector: React.FC<ImageSelectorProps> = ({
           className={cx(styles.imageSelector, css(theme.imageSelector))}
           ref={container}
         >
+          <div className={styles.searchInputRow}>
+            <SearchInput
+              hideLabel
+              label={t('common.imageSelector.labelSearch')}
+              onChange={setSearch}
+              onSubmit={setSearch}
+              placeholder={getValue(t('common.imageSelector.labelSearch'), '')}
+              value={search}
+            />
+          </div>
           <div className={styles.imagesGrid}>
             {imagesData?.images.data.length ? (
-              imagesData?.images.data.map((image) => {
-                const checked = !!image && value.includes(image?.atId);
+              imagesData?.images.data.filter(skipFalsyType).map((image) => {
+                const checked = value.includes(image?.atId);
 
                 return (
-                  image?.url && (
-                    <button
-                      key={image.id}
-                      className={cx(styles.image, {
-                        [styles.checked]: checked,
-                      })}
-                      aria-label={getValue(image.name, undefined)}
-                      disabled={disabled}
-                      style={{ backgroundImage: `url(${image.url})` }}
-                      role="checkbox"
-                      type="button"
-                      aria-checked={checked}
-                      onClick={handleChange(image)}
-                      onDoubleClick={handleDoubleClick(image)}
-                    />
-                  )
+                  <ImageItem
+                    key={image.atId}
+                    checked={checked}
+                    disabled={disabled}
+                    image={image}
+                    onClick={handleChange}
+                    onDoubleClick={handleDoubleClick}
+                  />
                 );
               })
             ) : (
-              <div className={styles.noImages}>Ei kuvia</div>
+              <div className={styles.noImages}>
+                <LoadingSpinner isLoading={loading}>Ei kuvia</LoadingSpinner>
+              </div>
             )}
           </div>
           <div className={styles.buttonWrapper}>

--- a/src/common/components/imageSelector/__mocks__/imageSelector.ts
+++ b/src/common/components/imageSelector/__mocks__/imageSelector.ts
@@ -11,6 +11,7 @@ const imagesVariables = {
   mergePages: true,
   pageSize: PAGE_SIZE,
   publisher,
+  text: '',
 };
 
 const meta = {

--- a/src/common/components/imageSelector/__tests__/ImageSelector.test.tsx
+++ b/src/common/components/imageSelector/__tests__/ImageSelector.test.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 
-import { Image } from '../../../../generated/graphql';
+import { testIds } from '../../../../constants';
+import { Image, ImageFieldsFragment } from '../../../../generated/graphql';
 import getValue from '../../../../utils/getValue';
+import { fakeImage } from '../../../../utils/mockDataUtils';
 import {
   configure,
   render,
@@ -16,91 +18,119 @@ import {
   mockedLoadMoreImagesResponse,
   publisher,
 } from '../__mocks__/imageSelector';
-import ImageSelector, { ImageSelectorProps } from '../ImageSelector';
+import ImageSelector, {
+  ImageItem,
+  ImageItemProps,
+  ImageSelectorProps,
+} from '../ImageSelector';
 
 configure({ defaultHidden: true });
 
-const defaultProps: ImageSelectorProps = {
+const defaultImageSelectorProps: ImageSelectorProps = {
   onChange: jest.fn(),
   publisher,
   value: [],
 };
 
+const defaultImageItemProps: ImageItemProps = {
+  checked: false,
+  disabled: false,
+  image: images.data[0] as ImageFieldsFragment,
+  onClick: jest.fn(),
+  onDoubleClick: jest.fn(),
+};
+
 const mocks = [mockedImagesReponse, mockedLoadMoreImagesResponse];
 
-const renderComponent = (props?: Partial<ImageSelectorProps>) =>
-  render(<ImageSelector {...defaultProps} {...props} />, { mocks });
+const renderImageSelector = (props?: Partial<ImageSelectorProps>) =>
+  render(<ImageSelector {...defaultImageSelectorProps} {...props} />, {
+    mocks,
+  });
 
-test('should render image selector', async () => {
-  renderComponent();
+const renderImageItem = (props?: Partial<ImageItemProps>) =>
+  render(<ImageItem {...defaultImageItemProps} {...props} />);
 
-  const loadMoreButton = screen.getByRole('button', { name: /näytä lisää/i });
-  await waitFor(() => expect(loadMoreButton).toBeEnabled());
+describe('ImageSelector', () => {
+  test('should render image selector', async () => {
+    renderImageSelector();
 
-  images.data.forEach((image) => {
-    screen.getByLabelText(getValue(image?.name, ''));
+    const loadMoreButton = screen.getByRole('button', { name: /näytä lisää/i });
+    await waitFor(() => expect(loadMoreButton).toBeEnabled());
+
+    images.data.forEach((image) => {
+      screen.getByLabelText(getValue(image?.name, ''));
+    });
+  });
+
+  test('should load more images', async () => {
+    const user = userEvent.setup();
+    renderImageSelector();
+
+    const loadMoreButton = screen.getByRole('button', { name: /näytä lisää/i });
+
+    await waitFor(() => expect(loadMoreButton).toBeEnabled());
+    await user.click(loadMoreButton);
+
+    await waitFor(() => expect(loadMoreButton).toBeEnabled());
+
+    for (const image of loadMoreImages.data) {
+      await screen.findByLabelText(getValue(image?.name, ''), undefined, {
+        timeout: 5000,
+      });
+    }
+  });
+
+  test('should call onChange', async () => {
+    const onChange = jest.fn();
+    const user = userEvent.setup();
+    renderImageSelector({ onChange });
+
+    const loadMoreButton = screen.getByRole('button', { name: /näytä lisää/i });
+
+    await waitFor(() => expect(loadMoreButton).toBeEnabled());
+
+    const { name, atId } = images.data[0] as Image;
+
+    await user.click(screen.getByLabelText(getValue(name, '')));
+    expect(onChange).toBeCalledWith([atId]);
+  });
+
+  test('should clear value when clicking selected image', async () => {
+    const onChange = jest.fn();
+    const { name, atId } = images.data[0] as Image;
+    const user = userEvent.setup();
+    renderImageSelector({ onChange, value: [atId] });
+
+    const loadMoreButton = screen.getByRole('button', { name: /näytä lisää/i });
+
+    await waitFor(() => expect(loadMoreButton).toBeEnabled());
+
+    await user.click(screen.getByLabelText(getValue(name, '')));
+    expect(onChange).toBeCalledWith([]);
+  });
+
+  test('should call onChange with multiple image ids', async () => {
+    const onChange = jest.fn();
+    const { atId } = images.data[0] as Image;
+    const user = userEvent.setup();
+    renderImageSelector({ multiple: true, onChange, value: [atId] });
+
+    const loadMoreButton = screen.getByRole('button', { name: /näytä lisää/i });
+
+    await waitFor(() => expect(loadMoreButton).toBeEnabled());
+
+    const { name, atId: atId2 } = images.data[1] as Image;
+    await user.click(screen.getByLabelText(getValue(name, '')));
+
+    expect(onChange).toBeCalledWith([atId, atId2]);
   });
 });
 
-test('should load more images', async () => {
-  const user = userEvent.setup();
-  renderComponent();
+describe('ImageItem', () => {
+  test('should show placeholder image if url is empty', () => {
+    const image = fakeImage({ url: '' });
+    renderImageItem({ image });
 
-  const loadMoreButton = screen.getByRole('button', { name: /näytä lisää/i });
-
-  await waitFor(() => expect(loadMoreButton).toBeEnabled());
-  await user.click(loadMoreButton);
-
-  await waitFor(() => expect(loadMoreButton).toBeEnabled());
-
-  for (const image of loadMoreImages.data) {
-    await screen.findByLabelText(getValue(image?.name, ''), undefined, {
-      timeout: 5000,
-    });
-  }
-});
-
-test('should call onChange', async () => {
-  const onChange = jest.fn();
-  const user = userEvent.setup();
-  renderComponent({ onChange });
-
-  const loadMoreButton = screen.getByRole('button', { name: /näytä lisää/i });
-
-  await waitFor(() => expect(loadMoreButton).toBeEnabled());
-
-  const { name, atId } = images.data[0] as Image;
-
-  await user.click(screen.getByLabelText(getValue(name, '')));
-  expect(onChange).toBeCalledWith([atId]);
-});
-
-test('should clear value when clicking selected image', async () => {
-  const onChange = jest.fn();
-  const { name, atId } = images.data[0] as Image;
-  const user = userEvent.setup();
-  renderComponent({ onChange, value: [atId] });
-
-  const loadMoreButton = screen.getByRole('button', { name: /näytä lisää/i });
-
-  await waitFor(() => expect(loadMoreButton).toBeEnabled());
-
-  await user.click(screen.getByLabelText(getValue(name, '')));
-  expect(onChange).toBeCalledWith([]);
-});
-
-test('should call onChange with multiple image ids', async () => {
-  const onChange = jest.fn();
-  const { atId } = images.data[0] as Image;
-  const user = userEvent.setup();
-  renderComponent({ multiple: true, onChange, value: [atId] });
-
-  const loadMoreButton = screen.getByRole('button', { name: /näytä lisää/i });
-
-  await waitFor(() => expect(loadMoreButton).toBeEnabled());
-
-  const { name, atId: atId2 } = images.data[1] as Image;
-  await user.click(screen.getByLabelText(getValue(name, '')));
-
-  expect(onChange).toBeCalledWith([atId, atId2]);
+    screen.getByTestId(`${testIds.imageSelector.imageItem}-${image.id}`);
+  });
 });

--- a/src/common/components/imageSelector/imageSelector.module.scss
+++ b/src/common/components/imageSelector/imageSelector.module.scss
@@ -7,7 +7,15 @@
   grid-gap: var(--spacing-m);
 
   @include medium-up {
-    grid-template-columns: 1fr auto;
+    grid-template-columns: 1fr;
+  }
+
+  .searchInputRow {
+    @include medium-up {
+      display: grid;
+      grid-gap: var(--spacing-m);
+      grid-template-columns: repeat(2, 1fr);
+    }
   }
 
   .imagesGrid {
@@ -48,6 +56,10 @@
     position: relative;
     justify-content: center;
     outline: none;
+
+    &.showPlaceholder {
+      background-color: var(--color-black-10);
+    }
   }
 
   .image:disabled {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -215,6 +215,7 @@ export const testIds = {
   eventSearchPanel: { searchPanel: 'event-search-panel' },
   imageList: { resultList: 'image-result-list' },
   imagePreview: { image: 'image-preview-image' },
+  imageSelector: { imageItem: 'image-selector-item' },
   imageUploader: { input: 'image-dropzone-file-input' },
   keywordList: { resultList: 'keyword-result-list' },
   keywordSetList: { resultList: 'keyword-set-result-list' },

--- a/src/domain/app/i18n/en.json
+++ b/src/domain/app/i18n/en.json
@@ -1365,8 +1365,12 @@
     "pageDescription": "Image listing. Browse, filter and edit Linked Events images.",
     "pageTitle": "Images",
     "sortOptions": {
+      "id": "Id, ascending",
+      "idDesc": "Id, descending",
       "lastModifiedTime": "Last modified, ascending",
-      "lastModifiedTimeDesc": "Last modified, descending"
+      "lastModifiedTimeDesc": "Last modified, descending",
+      "name": "Name, ascending",
+      "nameDesc": "Name, descending"
     },
     "title": "Images",
     "warningNoRightsToCreate": "You have insufficient rights to create images.",

--- a/src/domain/app/i18n/en.json
+++ b/src/domain/app/i18n/en.json
@@ -110,6 +110,9 @@
     },
     "goToHome": "To front page",
     "home": "Front page",
+    "imageSelector": {
+      "labelSearch": "Search images"
+    },
     "imageUploader": {
       "areaLabel": {
         "cropArea": "Use the arrow keys to move the crop selection area",

--- a/src/domain/app/i18n/fi.json
+++ b/src/domain/app/i18n/fi.json
@@ -111,6 +111,9 @@
     },
     "goToHome": "Etusivulle",
     "home": "Etusivu",
+    "imageSelector": {
+      "labelSearch": "Hae kuvia"
+    },
     "imageUploader": {
       "areaLabel": {
         "cropArea": "Siirrä rajausaluetta nuolinäppäimillä",

--- a/src/domain/app/i18n/fi.json
+++ b/src/domain/app/i18n/fi.json
@@ -1365,8 +1365,12 @@
     "pageDescription": "Kuvien listaus. Selaa, suodata ja muokkaa Linked Events -kuvia.",
     "pageTitle": "Kuvat",
     "sortOptions": {
+      "id": "Id, nouseva",
+      "idDesc": "Id, laskeva",
       "lastModifiedTime": "Viimeksi muokattu, nouseva",
-      "lastModifiedTimeDesc": "Viimeksi muokattu, laskeva"
+      "lastModifiedTimeDesc": "Viimeksi muokattu, laskeva",
+      "name": "Nimi, nouseva",
+      "nameDesc": "Nimi, laskeva"
     },
     "title": "Kuvat",
     "warningNoRightsToCreate": "Sinulla ei ole oikeuksia luoda kuvia.",

--- a/src/domain/app/i18n/sv.json
+++ b/src/domain/app/i18n/sv.json
@@ -111,6 +111,9 @@
     },
     "goToHome": "Till startsidan",
     "home": "Startsidan",
+    "imageSelector": {
+      "labelSearch": "Sök bilder"
+    },
     "imageUploader": {
       "areaLabel": {
         "cropArea": "Använd piltangenterna för att flytta området för val av beskärning",

--- a/src/domain/app/i18n/sv.json
+++ b/src/domain/app/i18n/sv.json
@@ -1365,8 +1365,12 @@
     "pageDescription": "Bildlista. Bläddra, filtrera och redigera Linked Events bilder.",
     "pageTitle": "Bilder",
     "sortOptions": {
+      "id": "Id, stigande",
+      "idDesc": "Id, fallande",
       "lastModifiedTime": "Senast ändrad, stigande",
-      "lastModifiedTimeDesc": "Senast ändrad, fallande"
+      "lastModifiedTimeDesc": "Senast ändrad, fallande",
+      "name": "Name, stigande",
+      "nameDesc": "Name, fallande"
     },
     "title": "Bilder",
     "warningNoRightsToCreate": "Du har otillräckliga rättigheter att skapa bilder.",

--- a/src/domain/event/formSections/imageSection/__mocks__/imageSection.ts
+++ b/src/domain/event/formSections/imageSection/__mocks__/imageSection.ts
@@ -22,6 +22,7 @@ const imagesVariables = {
   mergePages: true,
   pageSize: PAGE_SIZE,
   publisher,
+  text: '',
 };
 const imagesResponse = {
   data: {

--- a/src/domain/images/constants.ts
+++ b/src/domain/images/constants.ts
@@ -1,6 +1,10 @@
 export enum IMAGE_SORT_OPTIONS {
+  ID = 'id',
+  ID_DESC = '-id',
   LAST_MODIFIED_TIME = 'last_modified_time',
   LAST_MODIFIED_TIME_DESC = '-last_modified_time',
+  NAME = 'name',
+  NAME_DESC = '-name',
 }
 
 export const DEFAULT_IMAGE_SORT = IMAGE_SORT_OPTIONS.LAST_MODIFIED_TIME_DESC;

--- a/src/domain/images/imagesTable/ImagesTable.tsx
+++ b/src/domain/images/imagesTable/ImagesTable.tsx
@@ -8,6 +8,7 @@ import Table from '../../../common/components/table/Table';
 import { ImageFieldsFragment, ImagesQuery } from '../../../generated/graphql';
 import useLocale from '../../../hooks/useLocale';
 import useQueryStringWithReturnPath from '../../../hooks/useQueryStringWithReturnPath';
+import useShowPlaceholderImage from '../../../hooks/useShowPlaceholderImage';
 import formatDate from '../../../utils/formatDate';
 import getSortByOrderAndColKey from '../../../utils/getSortByOrderAndColKey';
 import getSortOrderAndKey from '../../../utils/getSortOrderAndKey';
@@ -27,19 +28,20 @@ export interface ImagesTableProps {
 const ImageColumn = (image: ImageFieldsFragment) => {
   const locale = useLocale();
   const { url } = getImageFields(image, locale);
+  const showPlaceholder = useShowPlaceholderImage(url);
 
   return (
     <div className={styles.imagePreview}>
-      {url ? (
-        <div
-          className={styles.image}
-          style={{ backgroundImage: `url(${url})` }}
-        />
-      ) : (
+      {showPlaceholder ? (
         /* istanbul ignore next */
         <div className={styles.placeholderImage}>
           <IconPhoto size="xl" />
         </div>
+      ) : (
+        <div
+          className={styles.image}
+          style={{ backgroundImage: `url(${url})` }}
+        />
       )}
     </div>
   );

--- a/src/domain/images/imagesTable/ImagesTable.tsx
+++ b/src/domain/images/imagesTable/ImagesTable.tsx
@@ -124,14 +124,18 @@ const ImagesTable: React.FC<ImagesTableProps> = ({
         },
         {
           className: styles.idColumn,
-          key: 'id',
+          isSortable: true,
+          key: IMAGE_SORT_OPTIONS.ID,
           headerName: t('imagesPage.imagesTableColumns.id'),
+          sortIconType: 'string',
           transform: IdColumn,
         },
         {
           className: styles.nameColumn,
-          key: 'name',
+          isSortable: true,
+          key: IMAGE_SORT_OPTIONS.NAME,
           headerName: t('imagesPage.imagesTableColumns.name'),
+          sortIconType: 'string',
           transform: NameColumn,
         },
         {

--- a/src/hooks/__tests__/useShowPlaceholderImage.test.ts
+++ b/src/hooks/__tests__/useShowPlaceholderImage.test.ts
@@ -1,0 +1,53 @@
+import { renderHook, waitFor } from '@testing-library/react';
+
+import useShowPlaceholderImage from '../useShowPlaceholderImage';
+
+const render = (url: string) => renderHook(() => useShowPlaceholderImage(url));
+
+describe('useShowPlaceholderImage', () => {
+  test('should return false if image is loaded', async () => {
+    let cbCalled = false;
+    global.Image = class {
+      onload: () => void;
+
+      constructor() {
+        this.onload = jest.fn();
+        setTimeout(() => {
+          this.onload();
+          cbCalled = true;
+        });
+      }
+    } as unknown as new () => HTMLImageElement;
+
+    const { result } = render('http://test-url.com');
+
+    await waitFor(() => expect(cbCalled).toBe(true));
+    expect(result.current).toEqual(false);
+  });
+
+  test('should return true if loading image fails', async () => {
+    let cbCalled = false;
+    global.Image = class {
+      onerror: () => void;
+
+      constructor() {
+        this.onerror = jest.fn();
+        setTimeout(() => {
+          this.onerror();
+          cbCalled = true;
+        });
+      }
+    } as unknown as new () => HTMLImageElement;
+
+    const { result } = render('http://test-url.com');
+
+    await waitFor(() => expect(cbCalled).toBe(true));
+    expect(result.current).toEqual(true);
+  });
+
+  test('should return true if url is empty', async () => {
+    const { result } = render('');
+
+    expect(result.current).toEqual(true);
+  });
+});

--- a/src/hooks/useShowPlaceholderImage.ts
+++ b/src/hooks/useShowPlaceholderImage.ts
@@ -1,0 +1,30 @@
+import { useEffect } from 'react';
+import { Maybe } from 'yup';
+
+import useMountedState from './useMountedState';
+
+const testShouldShowPlaceholder = (
+  url: string,
+  cb: (success: boolean) => void
+) => {
+  const img = new Image();
+  img.src = url;
+
+  img.onload = () => cb(false);
+  img.onerror = () => cb(true);
+};
+
+const useShowPlaceholderImage = (url: Maybe<string>) => {
+  const [showPlaceholderImage, setShowPlaceholderImage] =
+    useMountedState(false);
+
+  useEffect(() => {
+    if (url) {
+      testShouldShowPlaceholder(url, setShowPlaceholderImage);
+    }
+  }, [setShowPlaceholderImage, url]);
+
+  return !url || showPlaceholderImage;
+};
+
+export default useShowPlaceholderImage;


### PR DESCRIPTION
## Description :sparkles:
- Support filtering image table by id and name columns
- Support filtering images by name and alt text in image selector component
- Show placeholder image is image in the url is not available

## Issues :bug:

### Closes :no_good_woman:
[LINK-130](https://helsinkisolutionoffice.atlassian.net/browse/LINK-130)
[LINK-348](https://helsinkisolutionoffice.atlassian.net/browse/LINK-348)

### Related :handshake:

## Testing :alembic:
Testing image filtering when adding image to an event:
1. Open http://localhost:3000/fi/events/create
2. Click "Lisää tapahtuman kuva"

Sorting image table can be tested at http://localhost:3000/fi/administration/images

## Screenshots :camera_flash:
<img width="1261" alt="Screenshot 2023-03-24 at 11 17 57" src="https://user-images.githubusercontent.com/24706814/227503264-596ca743-f455-4385-b743-da88e096e3a7.png">

<img width="1275" alt="Screenshot 2023-03-24 at 12 55 59" src="https://user-images.githubusercontent.com/24706814/227503295-33ab5062-3f8f-44a5-8172-bc343423f97c.png">



[LINK-130]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LINK-348]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ