### PR TITLE
LINK-1272 | Don't allow to delete combobox value when component is disabled

### DIFF
--- a/src/common/components/formFields/hooks/__tests__/useMultiSelectFieldProps.test.tsx
+++ b/src/common/components/formFields/hooks/__tests__/useMultiSelectFieldProps.test.tsx
@@ -1,0 +1,60 @@
+import { renderHook } from '@testing-library/react';
+import { Formik } from 'formik';
+import React from 'react';
+
+import useMultiSelectFieldProps, {
+  UseMultiSelectFieldPropsProps,
+} from '../useMultiSelectFieldProps';
+
+const defaultProps: UseMultiSelectFieldPropsProps = {
+  disabled: false,
+  name: 'name',
+  onBlur: jest.fn(),
+  onChange: jest.fn(),
+  value: [],
+};
+
+const renderMultiSelectFieldPropsHook = (
+  props?: Partial<UseMultiSelectFieldPropsProps>
+) => {
+  const wrapper = ({ children }) => (
+    <Formik initialValues={{ name: '' }} onSubmit={jest.fn()}>
+      {children}
+    </Formik>
+  );
+
+  return renderHook(
+    () =>
+      useMultiSelectFieldProps({
+        ...defaultProps,
+        ...props,
+      }),
+    { wrapper }
+  );
+};
+
+describe('useMultiSelectFieldProps', () => {
+  it('should call onChange if hook is not disabled', async () => {
+    const onChange = jest.fn();
+    const { result } = renderMultiSelectFieldPropsHook({
+      disabled: false,
+      onChange,
+    });
+
+    result.current.handleChange([]);
+
+    expect(onChange).toBeCalledWith({ target: { id: 'name', value: [] } });
+  });
+
+  it('should not call onChange if hook is disabled', async () => {
+    const onChange = jest.fn();
+    const { result } = renderMultiSelectFieldPropsHook({
+      disabled: true,
+      onChange,
+    });
+
+    result.current.handleChange([]);
+
+    expect(onChange).not.toBeCalledWith({ target: { id: 'name', value: [] } });
+  });
+});

--- a/src/common/components/formFields/hooks/__tests__/useSingleSelectFieldProps.test.tsx
+++ b/src/common/components/formFields/hooks/__tests__/useSingleSelectFieldProps.test.tsx
@@ -1,0 +1,62 @@
+import { renderHook } from '@testing-library/react';
+import { Formik } from 'formik';
+import React from 'react';
+
+import useSingleSelectFieldProps, {
+  UseSingleSelectFieldPropsProps,
+} from '../useSingleSelectFieldProps';
+
+const defaultProps: UseSingleSelectFieldPropsProps = {
+  disabled: false,
+  name: 'name',
+  onBlur: jest.fn(),
+  onChange: jest.fn(),
+  value: '',
+};
+
+const renderSingleSelectFieldPropsHook = (
+  props?: Partial<UseSingleSelectFieldPropsProps>
+) => {
+  const wrapper = ({ children }) => (
+    <Formik initialValues={{ name: '' }} onSubmit={jest.fn()}>
+      {children}
+    </Formik>
+  );
+
+  return renderHook(
+    () =>
+      useSingleSelectFieldProps({
+        ...defaultProps,
+        ...props,
+      }),
+    { wrapper }
+  );
+};
+
+describe('useSingleSelectFieldProps', () => {
+  it('should call onChange if hook is not disabled', async () => {
+    const onChange = jest.fn();
+    const { result } = renderSingleSelectFieldPropsHook({
+      disabled: false,
+      onChange,
+    });
+
+    result.current.handleChange(null);
+
+    expect(onChange).toBeCalledWith({ target: { id: 'name', value: null } });
+  });
+
+  it('should not call onChange if hook is disabled', async () => {
+    const onChange = jest.fn();
+    const { result } = renderSingleSelectFieldPropsHook({
+      disabled: true,
+      onChange,
+    });
+
+    result.current.handleChange(null);
+
+    expect(onChange).not.toBeCalledWith({
+      target: { id: 'name', value: null },
+    });
+  });
+});

--- a/src/common/components/formFields/hooks/useMultiSelectFieldProps.ts
+++ b/src/common/components/formFields/hooks/useMultiSelectFieldProps.ts
@@ -2,27 +2,28 @@ import { FormikHandlers, useField } from 'formik';
 import { useTranslation } from 'react-i18next';
 
 import { OptionType } from '../../../../types';
-import getValue from '../../../../utils/getValue';
 import { getErrorText } from '../../../../utils/validationUtils';
 
-type UseComboboxFieldPropsState = {
+type UseMultiSelectFieldPropsState = {
   errorText: string;
   handleBlur: () => void;
-  handleChange: (selected: OptionType | null) => void;
+  handleChange: (selected: OptionType[]) => void;
 };
 
-type Props = {
+export type UseMultiSelectFieldPropsProps = {
+  disabled?: boolean;
   name: string;
   onBlur: FormikHandlers['handleBlur'];
   onChange: FormikHandlers['handleChange'];
-  value: string;
+  value: string[];
 };
-const useComboboxFieldProps = ({
+const useMultiSelectFieldProps = ({
+  disabled,
   name,
   onBlur,
   onChange,
   value,
-}: Props): UseComboboxFieldPropsState => {
+}: UseMultiSelectFieldPropsProps): UseMultiSelectFieldPropsState => {
   const { t } = useTranslation();
   const [, { touched, error }] = useField(name);
 
@@ -32,11 +33,17 @@ const useComboboxFieldProps = ({
     onBlur({ target: { id: name, value } });
   };
 
-  const handleChange = (selected: OptionType | null) => {
-    onChange({ target: { id: name, value: getValue(selected?.value, null) } });
+  const handleChange = (selected: OptionType[]) => {
+    // TODO: HDS Combobox component allowes to remove value even if component
+    // is disabled. Remove if statement when that behaviour is fixed to HDS
+    if (!disabled) {
+      onChange({
+        target: { id: name, value: selected.map((item) => item.value) },
+      });
+    }
   };
 
   return { errorText, handleBlur, handleChange };
 };
 
-export default useComboboxFieldProps;
+export default useMultiSelectFieldProps;

--- a/src/common/components/formFields/hooks/useSingleSelectFieldProps.ts
+++ b/src/common/components/formFields/hooks/useSingleSelectFieldProps.ts
@@ -1,0 +1,50 @@
+import { FormikHandlers, useField } from 'formik';
+import { useTranslation } from 'react-i18next';
+
+import { OptionType } from '../../../../types';
+import getValue from '../../../../utils/getValue';
+import { getErrorText } from '../../../../utils/validationUtils';
+
+type UseSingleSelectFieldPropsState = {
+  errorText: string;
+  handleBlur: () => void;
+  handleChange: (selected: OptionType | null) => void;
+};
+
+export type UseSingleSelectFieldPropsProps = {
+  disabled?: boolean;
+  name: string;
+  onBlur: FormikHandlers['handleBlur'];
+  onChange: FormikHandlers['handleChange'];
+  value: string;
+};
+const useSingleSelectFieldProps = ({
+  disabled,
+  name,
+  onBlur,
+  onChange,
+  value,
+}: UseSingleSelectFieldPropsProps): UseSingleSelectFieldPropsState => {
+  const { t } = useTranslation();
+  const [, { touched, error }] = useField(name);
+
+  const errorText = getErrorText(error, touched, t);
+
+  const handleBlur = () => {
+    onBlur({ target: { id: name, value } });
+  };
+
+  const handleChange = (selected: OptionType | null) => {
+    // TODO: HDS Combobox component allowes to remove value even if component
+    // is disabled. Remove if statement when that behaviour is fixed to HDS
+    if (!disabled) {
+      onChange({
+        target: { id: name, value: getValue(selected?.value, null) },
+      });
+    }
+  };
+
+  return { errorText, handleBlur, handleChange };
+};
+
+export default useSingleSelectFieldProps;

--- a/src/common/components/formFields/keywordSelectorField/KeywordSelectorField.tsx
+++ b/src/common/components/formFields/keywordSelectorField/KeywordSelectorField.tsx
@@ -1,12 +1,10 @@
-import { FieldProps, useField } from 'formik';
+import { FieldProps } from 'formik';
 import React from 'react';
-import { useTranslation } from 'react-i18next';
 
-import { OptionType } from '../../../../types';
-import { getErrorText } from '../../../../utils/validationUtils';
 import KeywordSelector, {
   KeywordSelectorProps,
 } from '../../keywordSelector/KeywordSelector';
+import useMultiSelectFieldProps from '../hooks/useMultiSelectFieldProps';
 
 type Props = KeywordSelectorProps & FieldProps;
 
@@ -14,27 +12,22 @@ const KeywordSelectorField: React.FC<Props> = ({
   field: { name, onBlur, onChange, value, ...field },
   form,
   helper,
+  disabled,
   ...rest
 }) => {
-  const { t } = useTranslation();
-  const [, { touched, error }] = useField(name);
-
-  const errorText = getErrorText(error, touched, t);
-
-  const handleBlur = () => {
-    onBlur({ target: { id: name, value } });
-  };
-
-  const handleChange = (selected: OptionType[]) => {
-    onChange({
-      target: { id: name, value: selected.map((item) => item.value) },
-    });
-  };
+  const { errorText, handleBlur, handleChange } = useMultiSelectFieldProps({
+    disabled,
+    name,
+    onBlur,
+    onChange,
+    value,
+  });
 
   return (
     <KeywordSelector
       {...rest}
       {...field}
+      disabled={disabled}
       name={name}
       onBlur={handleBlur}
       onChange={handleChange}

--- a/src/common/components/formFields/placeSelectorField/PlaceSelectorField.tsx
+++ b/src/common/components/formFields/placeSelectorField/PlaceSelectorField.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import PlaceSelector, {
   PlaceSelectorProps,
 } from '../../placeSelector/PlaceSelector';
-import useComboboxFieldProps from '../hooks/useComboboxFieldProps';
+import useSingleSelectFieldProps from '../hooks/useSingleSelectFieldProps';
 
 type Props = PlaceSelectorProps & FieldProps<string>;
 
@@ -12,9 +12,11 @@ const PlaceSelectorField: React.FC<Props> = ({
   field: { name, onBlur, onChange, value, ...field },
   form,
   helper,
+  disabled,
   ...rest
 }) => {
-  const { errorText, handleBlur, handleChange } = useComboboxFieldProps({
+  const { errorText, handleBlur, handleChange } = useSingleSelectFieldProps({
+    disabled,
     name,
     onBlur,
     onChange,
@@ -25,6 +27,7 @@ const PlaceSelectorField: React.FC<Props> = ({
     <PlaceSelector
       {...rest}
       {...field}
+      disabled={disabled}
       name={name}
       onBlur={handleBlur}
       onChange={handleChange}

--- a/src/common/components/formFields/publisherSelectorField/PublisherSelectorField.tsx
+++ b/src/common/components/formFields/publisherSelectorField/PublisherSelectorField.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import PublisherSelector, {
   PublisherSelectorProps,
 } from '../../publisherSelector/PublisherSelector';
-import useComboboxFieldProps from '../hooks/useComboboxFieldProps';
+import useSingleSelectFieldProps from '../hooks/useSingleSelectFieldProps';
 
 type Props = PublisherSelectorProps & FieldProps<string>;
 
@@ -12,9 +12,11 @@ const PublisherSelectorField: React.FC<Props> = ({
   field: { name, onBlur, onChange, value, ...field },
   form,
   helper,
+  disabled,
   ...rest
 }) => {
-  const { errorText, handleBlur, handleChange } = useComboboxFieldProps({
+  const { errorText, handleBlur, handleChange } = useSingleSelectFieldProps({
+    disabled,
     name,
     onBlur,
     onChange,
@@ -25,6 +27,7 @@ const PublisherSelectorField: React.FC<Props> = ({
     <PublisherSelector
       {...rest}
       {...field}
+      disabled={disabled}
       name={name}
       onBlur={handleBlur}
       onChange={handleChange}

--- a/src/common/components/formFields/registrationEventSelectorField/RegistrationEventSelectorField.tsx
+++ b/src/common/components/formFields/registrationEventSelectorField/RegistrationEventSelectorField.tsx
@@ -12,7 +12,7 @@ import { Language, OptionType } from '../../../../types';
 import EventSelector, {
   EventSelectorProps,
 } from '../../eventSelector/EventSelector';
-import useComboboxFieldProps from '../hooks/useComboboxFieldProps';
+import useSingleSelectFieldProps from '../hooks/useSingleSelectFieldProps';
 
 type Props = EventSelectorProps & FieldProps<string>;
 
@@ -31,9 +31,11 @@ const RegistrationEventSelectorField: React.FC<Props> = ({
   field: { name, onBlur, onChange, value, ...field },
   form,
   helper,
+  disabled,
   ...rest
 }) => {
-  const { errorText, handleBlur, handleChange } = useComboboxFieldProps({
+  const { errorText, handleBlur, handleChange } = useSingleSelectFieldProps({
+    disabled,
     name,
     onBlur,
     onChange,
@@ -44,6 +46,7 @@ const RegistrationEventSelectorField: React.FC<Props> = ({
     <EventSelector
       {...rest}
       {...field}
+      disabled={disabled}
       name={name}
       variables={{
         adminUser: true,

--- a/src/common/components/formFields/singleKeywordSelectorField/SingleKeywordSelectorField.tsx
+++ b/src/common/components/formFields/singleKeywordSelectorField/SingleKeywordSelectorField.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import SingleKeywordSelector, {
   SingleKeywordSelectorProps,
 } from '../../singleKeywordSelector/SingleKeywordSelector';
-import useComboboxFieldProps from '../hooks/useComboboxFieldProps';
+import useSingleSelectFieldProps from '../hooks/useSingleSelectFieldProps';
 
 type Props = SingleKeywordSelectorProps & FieldProps<string>;
 
@@ -12,9 +12,11 @@ const SingleKeywordSelectorField: React.FC<Props> = ({
   field: { name, onBlur, onChange, value, ...field },
   form,
   helper,
+  disabled,
   ...rest
 }) => {
-  const { errorText, handleBlur, handleChange } = useComboboxFieldProps({
+  const { errorText, handleBlur, handleChange } = useSingleSelectFieldProps({
+    disabled,
     name,
     onBlur,
     onChange,
@@ -25,6 +27,7 @@ const SingleKeywordSelectorField: React.FC<Props> = ({
     <SingleKeywordSelector
       {...rest}
       {...field}
+      disabled={disabled}
       name={name}
       onBlur={handleBlur}
       onChange={handleChange}

--- a/src/common/components/formFields/singleOrganizationClassSelectorField/SingleOrganizationClassSelectorField.tsx
+++ b/src/common/components/formFields/singleOrganizationClassSelectorField/SingleOrganizationClassSelectorField.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import SingleOrganizationClassSelector, {
   SingleOrganizationClassSelectorProps,
 } from '../../singleOrganizationClassSelector/SingleOrganizationClassSelector';
-import useComboboxFieldProps from '../hooks/useComboboxFieldProps';
+import useSingleSelectFieldProps from '../hooks/useSingleSelectFieldProps';
 
 type Props = SingleOrganizationClassSelectorProps & FieldProps<string>;
 
@@ -12,9 +12,11 @@ const SingleOrganizationClassSelectorField: React.FC<Props> = ({
   field: { name, onBlur, onChange, value, ...field },
   form,
   helper,
+  disabled,
   ...rest
 }) => {
-  const { errorText, handleBlur, handleChange } = useComboboxFieldProps({
+  const { errorText, handleBlur, handleChange } = useSingleSelectFieldProps({
+    disabled,
     name,
     onBlur,
     onChange,
@@ -25,6 +27,7 @@ const SingleOrganizationClassSelectorField: React.FC<Props> = ({
     <SingleOrganizationClassSelector
       {...rest}
       {...field}
+      disabled={disabled}
       name={name}
       onBlur={handleBlur}
       onChange={handleChange}

--- a/src/common/components/formFields/singleOrganizationSelectorField/SingleOrganizationSelectorField.tsx
+++ b/src/common/components/formFields/singleOrganizationSelectorField/SingleOrganizationSelectorField.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import SingleOrganizationSelector, {
   SingleOrganizationSelectorProps,
 } from '../../singleOrganizationSelector/SingleOrganizationSelector';
-import useComboboxFieldProps from '../hooks/useComboboxFieldProps';
+import useSingleSelectFieldProps from '../hooks/useSingleSelectFieldProps';
 
 type Props = SingleOrganizationSelectorProps & FieldProps;
 
@@ -12,9 +12,11 @@ const SingleOrganizationSelectorField: React.FC<Props> = ({
   field: { name, onBlur, onChange, value, ...field },
   form,
   helper,
+  disabled,
   ...rest
 }) => {
-  const { errorText, handleBlur, handleChange } = useComboboxFieldProps({
+  const { errorText, handleBlur, handleChange } = useSingleSelectFieldProps({
+    disabled,
     name,
     onBlur,
     onChange,
@@ -28,6 +30,7 @@ const SingleOrganizationSelectorField: React.FC<Props> = ({
       name={name}
       onBlur={handleBlur}
       onChange={handleChange}
+      disabled={disabled}
       value={value}
       helper={helper}
       error={errorText}

--- a/src/common/components/formFields/singleSelectField/SingleSelectField.tsx
+++ b/src/common/components/formFields/singleSelectField/SingleSelectField.tsx
@@ -1,12 +1,10 @@
-import { FieldProps, useField } from 'formik';
+import { FieldProps } from 'formik';
 import { SingleSelectProps } from 'hds-react';
 import React from 'react';
-import { useTranslation } from 'react-i18next';
 
 import { OptionType } from '../../../../types';
-import getValue from '../../../../utils/getValue';
-import { getErrorText } from '../../../../utils/validationUtils';
 import SingleSelect from '../../singleSelect/SingleSelect';
+import useSingleSelectFieldProps from '../hooks/useSingleSelectFieldProps';
 
 type Props = SingleSelectProps<OptionType> & FieldProps;
 
@@ -15,27 +13,22 @@ const SingleSelectField: React.FC<Props> = ({
   form,
   helper,
   options,
+  disabled,
   ...rest
 }) => {
-  const { t } = useTranslation();
-  const [, { touched, error }] = useField(name);
-
-  const errorText = getErrorText(error, touched, t);
-
-  const handleBlur = () => {
-    onBlur({ target: { id: name, value } });
-  };
-
-  const handleChange = (selected: OptionType | null) => {
-    onChange({
-      target: { id: name, value: getValue(selected?.value, null) },
-    });
-  };
+  const { errorText, handleBlur, handleChange } = useSingleSelectFieldProps({
+    disabled,
+    name,
+    onBlur,
+    onChange,
+    value,
+  });
 
   return (
     <SingleSelect
       {...rest}
       {...field}
+      disabled={disabled}
       id={name}
       onBlur={handleBlur}
       onChange={handleChange}

--- a/src/common/components/formFields/umbrellaEventSelectorField/UmbrellaEventSelectorField.tsx
+++ b/src/common/components/formFields/umbrellaEventSelectorField/UmbrellaEventSelectorField.tsx
@@ -8,7 +8,7 @@ import { Language, OptionType } from '../../../../types';
 import EventSelector, {
   EventSelectorProps,
 } from '../../eventSelector/EventSelector';
-import useComboboxFieldProps from '../hooks/useComboboxFieldProps';
+import useSingleSelectFieldProps from '../hooks/useSingleSelectFieldProps';
 
 type Props = EventSelectorProps & FieldProps<string>;
 
@@ -24,9 +24,11 @@ const UmbrellaEventSelectorField: React.FC<Props> = ({
   field: { name, onBlur, onChange, value, ...field },
   form,
   helper,
+  disabled,
   ...rest
 }) => {
-  const { errorText, handleBlur, handleChange } = useComboboxFieldProps({
+  const { errorText, handleBlur, handleChange } = useSingleSelectFieldProps({
+    disabled,
     name,
     onBlur,
     onChange,
@@ -37,6 +39,7 @@ const UmbrellaEventSelectorField: React.FC<Props> = ({
     <EventSelector
       {...rest}
       {...field}
+      disabled={disabled}
       name={name}
       variables={{
         sort: EVENT_SORT_OPTIONS.NAME,

--- a/src/common/components/formFields/userSelectorField/UserSelectorField.tsx
+++ b/src/common/components/formFields/userSelectorField/UserSelectorField.tsx
@@ -1,12 +1,10 @@
-import { FieldProps, useField } from 'formik';
+import { FieldProps } from 'formik';
 import React from 'react';
-import { useTranslation } from 'react-i18next';
 
-import { OptionType } from '../../../../types';
-import { getErrorText } from '../../../../utils/validationUtils';
 import UserSelector, {
   UserSelectorProps,
 } from '../../userSelector/UserSelector';
+import useMultiSelectFieldProps from '../hooks/useMultiSelectFieldProps';
 
 type Props = UserSelectorProps & FieldProps;
 
@@ -14,27 +12,22 @@ const UserSelectorField: React.FC<Props> = ({
   field: { name, onBlur, onChange, value, ...field },
   form,
   helper,
+  disabled,
   ...rest
 }) => {
-  const { t } = useTranslation();
-  const [, { touched, error }] = useField(name);
-
-  const errorText = getErrorText(error, touched, t);
-
-  const handleBlur = () => {
-    onBlur({ target: { id: name, value } });
-  };
-
-  const handleChange = (selected: OptionType[]) => {
-    onChange({
-      target: { id: name, value: selected.map((item) => item.value) },
-    });
-  };
+  const { errorText, handleBlur, handleChange } = useMultiSelectFieldProps({
+    disabled,
+    name,
+    onBlur,
+    onChange,
+    value,
+  });
 
   return (
     <UserSelector
       {...rest}
       {...field}
+      disabled={disabled}
       name={name}
       onBlur={handleBlur}
       onChange={handleChange}


### PR DESCRIPTION
## Description :sparkles:
At the moment user can remove combobox value event if component is disabled. You can reproduce this in publisher field at https://linkedcomponents-ui-dev.agw.arodevtest.hel.fi/fi/administration/keyword-sets/edit/ahjo:testq?returnPath=%2Fadministration%2Fkeyword-sets

Purpose of this PR is to prevent onChange when component is disabled

## Issues :bug:

### Closes :no_good_woman:
[LINK-1272](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1272)

## Screenshots :camera_flash:
<img width="1520" alt="Screenshot 2023-04-12 at 10 58 44" src="https://user-images.githubusercontent.com/24706814/231392937-4d12ec61-f21f-4d17-bc67-9d94ff8292a7.png">



[LINK-1272]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ