### PR TITLE
LINK-1773 | Footer add data protection item

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -225,3 +225,7 @@ export const testIds = {
   placeList: { resultList: 'place-result-list' },
   registrationList: { resultList: 'registration-result-list' },
 };
+
+export const DATA_PROTECTION_URL =
+  // eslint-disable-next-line max-len
+  'https://www.hel.fi/fi/paatoksenteko-ja-hallinto/tietoa-helsingista/tietosuoja-ja-tiedonhallinta/tietosuoja/tietosuojaselosteet';

--- a/src/domain/app/footer/Footer.tsx
+++ b/src/domain/app/footer/Footer.tsx
@@ -7,15 +7,9 @@ import { matchPath, PathPattern, useLocation, useNavigate } from 'react-router';
 import { DATA_PROTECTION_URL, ROUTES } from '../../../constants';
 import useLocale from '../../../hooks/useLocale';
 import { featureFlagUtils } from '../../../utils/featureFlags';
+import skipFalsyType from '../../../utils/skipFalsyType';
 import { useTheme } from '../theme/Theme';
 import styles from './footer.module.scss';
-
-interface NavigationItem {
-  labelKey: string;
-  url: ROUTES;
-  target: string;
-  externalUrl?: boolean;
-}
 
 const NO_FOOTER_PATHS: PathPattern[] = [
   { path: ROUTES.EDIT_EVENT },
@@ -53,10 +47,10 @@ const Footer: React.FC = () => {
       url: DATA_PROTECTION_URL,
       externalUrl: true,
     },
-  ].filter((i) => i) as NavigationItem[];
+  ].filter(skipFalsyType);
 
   const navigationItems = FOOTER_NAVIGATION_ITEMS.map(
-    ({ labelKey, url, externalUrl, target }) => ({
+    ({ labelKey, url, externalUrl }) => ({
       label: t(labelKey),
       url: !externalUrl ? `/${locale}${url}` : url,
       externalUrl: externalUrl || false,
@@ -67,9 +61,12 @@ const Footer: React.FC = () => {
   const goToPage =
     (pathname: string, external?: boolean) =>
     (event?: React.MouseEvent<HTMLAnchorElement>) => {
+      event?.preventDefault();
+
       if (!external) {
-        event?.preventDefault();
         navigate({ pathname });
+      } else {
+        window.open(pathname, '_blank');
       }
     };
 

--- a/src/domain/app/footer/Footer.tsx
+++ b/src/domain/app/footer/Footer.tsx
@@ -53,7 +53,7 @@ const Footer: React.FC = () => {
     ({ labelKey, url, externalUrl }) => ({
       label: t(labelKey),
       url: !externalUrl ? `/${locale}${url}` : url,
-      externalUrl: externalUrl || false,
+      externalUrl: externalUrl,
       target: externalUrl ? '_blank' : '_self',
     })
   );

--- a/src/domain/app/footer/Footer.tsx
+++ b/src/domain/app/footer/Footer.tsx
@@ -28,7 +28,7 @@ const Footer: React.FC = () => {
   const logoLanguage = locale === 'sv' ? 'sv' : 'fi';
 
   const FOOTER_NAVIGATION_ITEMS = [
-    { labelKey: 'navigation.tabs.events', url: ROUTES.EVENTS, target: '_self' },
+    { labelKey: 'navigation.tabs.events', url: ROUTES.EVENTS },
     {
       labelKey: 'navigation.searchEvents',
       url: ROUTES.SEARCH,
@@ -41,7 +41,7 @@ const Footer: React.FC = () => {
       labelKey: 'navigation.tabs.admin',
       url: ROUTES.ADMIN,
     },
-    { labelKey: 'navigation.tabs.help', url: ROUTES.HELP, target: '_self' },
+    { labelKey: 'navigation.tabs.help', url: ROUTES.HELP },
     {
       labelKey: 'navigation.tabs.dataProtection',
       url: DATA_PROTECTION_URL,

--- a/src/domain/app/footer/Footer.tsx
+++ b/src/domain/app/footer/Footer.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { matchPath, PathPattern, useLocation, useNavigate } from 'react-router';
 
-import { ROUTES } from '../../../constants';
+import { DATA_PROTECTION_URL, ROUTES } from '../../../constants';
 import useLocale from '../../../hooks/useLocale';
 import { featureFlagUtils } from '../../../utils/featureFlags';
 import { useTheme } from '../theme/Theme';
@@ -13,6 +13,8 @@ import styles from './footer.module.scss';
 interface NavigationItem {
   labelKey: string;
   url: ROUTES;
+  target: string;
+  externalUrl?: boolean;
 }
 
 const NO_FOOTER_PATHS: PathPattern[] = [
@@ -46,17 +48,29 @@ const Footer: React.FC = () => {
       url: ROUTES.ADMIN,
     },
     { labelKey: 'navigation.tabs.help', url: ROUTES.HELP, target: '_self' },
+    {
+      labelKey: 'navigation.tabs.dataProtection',
+      url: DATA_PROTECTION_URL,
+      externalUrl: true,
+    },
   ].filter((i) => i) as NavigationItem[];
 
-  const navigationItems = FOOTER_NAVIGATION_ITEMS.map(({ labelKey, url }) => ({
-    label: t(labelKey),
-    url: `/${locale}${url}`,
-  }));
+  const navigationItems = FOOTER_NAVIGATION_ITEMS.map(
+    ({ labelKey, url, externalUrl, target }) => ({
+      label: t(labelKey),
+      url: !externalUrl ? `/${locale}${url}` : url,
+      externalUrl: externalUrl || false,
+      target: externalUrl ? '_blank' : '_self',
+    })
+  );
 
   const goToPage =
-    (pathname: string) => (event?: React.MouseEvent<HTMLAnchorElement>) => {
-      event?.preventDefault();
-      navigate({ pathname });
+    (pathname: string, external?: boolean) =>
+    (event?: React.MouseEvent<HTMLAnchorElement>) => {
+      if (!external) {
+        event?.preventDefault();
+        navigate({ pathname });
+      }
     };
 
   const getFooterThemeClassName = () => {
@@ -99,7 +113,8 @@ const Footer: React.FC = () => {
                 key={item.url}
                 href={item.url}
                 label={item.label}
-                onClick={goToPage(item.url)}
+                target={item.target}
+                onClick={goToPage(item.url, item.externalUrl)}
               />
             ))}
           </HdsFooter.Navigation>

--- a/src/domain/app/footer/Footer.tsx
+++ b/src/domain/app/footer/Footer.tsx
@@ -53,7 +53,7 @@ const Footer: React.FC = () => {
     ({ labelKey, url, externalUrl }) => ({
       label: t(labelKey),
       url: !externalUrl ? `/${locale}${url}` : url,
-      externalUrl: externalUrl,
+      externalUrl,
       target: externalUrl ? '_blank' : '_self',
     })
   );

--- a/src/domain/app/footer/__tests__/Footer.test.tsx
+++ b/src/domain/app/footer/__tests__/Footer.test.tsx
@@ -66,6 +66,8 @@ test('should show navigation links and should route to correct page after clicki
   await user.click(dataProtectionLink);
 
   expect(spyWindowOpen).toHaveBeenCalled();
+
+  spyWindowOpen.mockRestore();
 });
 
 test('should not show keywords and registrations link when those features are disabled', async () => {

--- a/src/domain/app/footer/__tests__/Footer.test.tsx
+++ b/src/domain/app/footer/__tests__/Footer.test.tsx
@@ -2,7 +2,7 @@
 import i18n from 'i18next';
 import React from 'react';
 
-import { ROUTES } from '../../../../constants';
+import { DATA_PROTECTION_URL, ROUTES } from '../../../../constants';
 import { setFeatureFlags } from '../../../../test/featureFlags/featureFlags';
 import {
   configure,
@@ -46,6 +46,7 @@ test('should show navigation links and should route to correct page after clicki
     { name: /hallinta/i, url: `/fi${ROUTES.ADMIN}` },
     { name: /tuki/i, url: `/fi${ROUTES.HELP}` },
   ];
+
   for (const { name, url } of links) {
     const link = screen.getByRole('link', { name });
 
@@ -53,6 +54,18 @@ test('should show navigation links and should route to correct page after clicki
 
     await waitFor(() => expect(history.location.pathname).toBe(url));
   }
+
+  const dataProtectionLink = screen.getByRole('link', { name: /tietosuoja/i });
+
+  expect(dataProtectionLink.getAttribute('href')).toEqual(DATA_PROTECTION_URL);
+
+  const spyWindowOpen = jest
+    .spyOn(window, 'open')
+    .mockImplementation(jest.fn());
+
+  await user.click(dataProtectionLink);
+
+  expect(spyWindowOpen).toHaveBeenCalled();
 });
 
 test('should not show keywords and registrations link when those features are disabled', async () => {

--- a/src/domain/app/i18n/en.json
+++ b/src/domain/app/i18n/en.json
@@ -1562,7 +1562,8 @@
       "admin": "Admin",
       "events": "Events",
       "help": "Support",
-      "registrations": "Registration"
+      "registrations": "Registration",
+      "dataProtection": "Data Protection"
     }
   },
   "notFound": {

--- a/src/domain/app/i18n/fi.json
+++ b/src/domain/app/i18n/fi.json
@@ -1562,7 +1562,8 @@
       "admin": "Hallinta",
       "events": "Tapahtumat",
       "help": "Tuki",
-      "registrations": "Ilmoittautuminen"
+      "registrations": "Ilmoittautuminen",
+      "dataProtection": "Tietosuoja"
     }
   },
   "notFound": {

--- a/src/domain/app/i18n/sv.json
+++ b/src/domain/app/i18n/sv.json
@@ -1562,7 +1562,8 @@
       "admin": "Admin",
       "events": "Evenemang",
       "help": "Stöd",
-      "registrations": "Registrering"
+      "registrations": "Registrering",
+      "dataProtection": "Dataskydd"
     }
   },
   "notFound": {


### PR DESCRIPTION
## Description :sparkles:
Add data protection link to footer items.
## Issues :bug:

### Closes :no_good_woman:

**[LINK-1173](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1173):**

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

<img width="1237" alt="Screenshot 2023-04-13 at 14 51 43" src="https://user-images.githubusercontent.com/66477579/231750208-6a81d644-0ebc-4641-b681-efe679880349.png">

<img width="1246" alt="Screenshot 2023-04-13 at 14 52 42" src="https://user-images.githubusercontent.com/66477579/231750401-d4ef4557-ba55-401f-9324-9dacade94588.png">

## Additional notes :spiral_notepad:

[LINK-1173]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ