### PR TITLE
LINK-1773 Footer data protection item localised links

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,6 @@
 import reduce from 'lodash/reduce';
 
-import { MultiLanguageObject } from './types';
+import { Language, MultiLanguageObject } from './types';
 
 export const BREAKPOINTS = {
   XS: 576,
@@ -226,6 +226,11 @@ export const testIds = {
   registrationList: { resultList: 'registration-result-list' },
 };
 
-export const DATA_PROTECTION_URL =
+export const DATA_PROTECTION_URL: { [key in Language]: string } = {
   // eslint-disable-next-line max-len
-  'https://www.hel.fi/fi/paatoksenteko-ja-hallinto/tietoa-helsingista/tietosuoja-ja-tiedonhallinta/tietosuoja/tietosuojaselosteet';
+  fi: 'https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Keha/Kayttajatunnusten%20hallinta.pdf',
+  // eslint-disable-next-line max-len
+  sv: 'https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Keha/Hantering%20av%20anvandar-id.pdf',
+  // eslint-disable-next-line max-len
+  en: 'https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Keha/Kayttajatunnusten%20hallinta.pdf',
+};

--- a/src/domain/app/footer/Footer.tsx
+++ b/src/domain/app/footer/Footer.tsx
@@ -44,7 +44,7 @@ const Footer: React.FC = () => {
     { labelKey: 'navigation.tabs.help', url: ROUTES.HELP },
     {
       labelKey: 'navigation.tabs.dataProtection',
-      url: DATA_PROTECTION_URL,
+      url: DATA_PROTECTION_URL[locale],
       externalUrl: true,
     },
   ].filter(skipFalsyType);

--- a/src/domain/app/footer/__tests__/Footer.test.tsx
+++ b/src/domain/app/footer/__tests__/Footer.test.tsx
@@ -57,7 +57,9 @@ test('should show navigation links and should route to correct page after clicki
 
   const dataProtectionLink = screen.getByRole('link', { name: /tietosuoja/i });
 
-  expect(dataProtectionLink.getAttribute('href')).toEqual(DATA_PROTECTION_URL);
+  expect(dataProtectionLink.getAttribute('href')).toEqual(
+    DATA_PROTECTION_URL['fi']
+  );
 
   const spyWindowOpen = jest
     .spyOn(window, 'open')


### PR DESCRIPTION
## Description :sparkles:
Change footer data protection item to localised links (english version doesn't exist, so uses finnish)
## Issues :bug:

### Closes :no_good_woman:

**[LINK-1173](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1173):**

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[LINK-1173]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ