### PR TITLE
LINK-1197 | Prevent deleting registration with signups

### DIFF
--- a/src/domain/app/i18n/en.json
+++ b/src/domain/app/i18n/en.json
@@ -1709,6 +1709,7 @@
         "warningNotAuthenticated": "To create a registration, log in first."
       },
       "editButtonPanel": {
+        "warningHasEnrolments": "Registrations with participants cannot be deleted.",
         "warningNoRightsToCreate": "You have insufficient rights to create registrations.",
         "warningNoRightsToEdit": "You have insufficient rights to edit this registration."
       },

--- a/src/domain/app/i18n/fi.json
+++ b/src/domain/app/i18n/fi.json
@@ -1709,6 +1709,7 @@
         "warningNotAuthenticated": "Jos haluat luoda ilmoittautumisen, kirjaudu ensin sisään."
       },
       "editButtonPanel": {
+        "warningHasEnrolments": "Ilmoittautumisia joilla on osallistujia ei voi poistaa.",
         "warningNoRightsToCreate": "Sinulla ei ole oikeuksia lisätä ilmoittautumisia.",
         "warningNoRightsToEdit": "Sinulla ei ole oikeuksia muokata tätä ilmoittautumista."
       },

--- a/src/domain/app/i18n/sv.json
+++ b/src/domain/app/i18n/sv.json
@@ -1709,6 +1709,7 @@
         "warningNotAuthenticated": "För att skapa en registrering, logga in först."
       },
       "editButtonPanel": {
+        "warningHasEnrolments": "Registreringar med deltagare kan inte raderas.",
         "warningNoRightsToCreate": "Du har otillräckliga rättigheter att skapa registreringar.",
         "warningNoRightsToEdit": "Du har inte tillräckliga rättigheter för att redigera detta registrering."
       },

--- a/src/domain/registration/__tests__/utils.test.ts
+++ b/src/domain/registration/__tests__/utils.test.ts
@@ -78,6 +78,18 @@ describe('getEditRegistrationWarning function', () => {
       })
     ).toBe('Sinulla ei ole oikeuksia muokata tätä ilmoittautumista.');
   });
+
+  it('should return warning if registration has enrolments', () => {
+    expect(
+      getEditRegistrationWarning({
+        authenticated: true,
+        registration: fakeRegistration({ currentAttendeeCount: 1 }),
+        t: i18n.t.bind(i18n),
+        userCanDoAction: true,
+        action: REGISTRATION_ACTIONS.DELETE,
+      })
+    ).toBe('Ilmoittautumisia joilla on osallistujia ei voi poistaa.');
+  });
 });
 
 describe('getRegistrationFields function', () => {

--- a/src/domain/registration/createButtonPanel/CreateButtonPanel.tsx
+++ b/src/domain/registration/createButtonPanel/CreateButtonPanel.tsx
@@ -24,7 +24,6 @@ const CreateButtonPanel: React.FC<Props> = ({ onSave, saving }) => {
     authenticated,
     onClick: onSave,
     organizationAncestors: [],
-    publisher: '',
     t,
     user,
   });

--- a/src/domain/registration/editButtonPanel/EditButtonPanel.tsx
+++ b/src/domain/registration/editButtonPanel/EditButtonPanel.tsx
@@ -84,7 +84,7 @@ const EditButtonPanel: React.FC<EditButtonPanelProps> = ({
       authenticated,
       onClick,
       organizationAncestors,
-      publisher,
+      registration,
       t,
       user,
     });

--- a/src/domain/registration/utils.ts
+++ b/src/domain/registration/utils.ts
@@ -73,11 +73,13 @@ export const checkCanUserDoAction = ({
 export const getEditRegistrationWarning = ({
   action,
   authenticated,
+  registration,
   t,
   userCanDoAction,
 }: {
   action: REGISTRATION_ACTIONS;
   authenticated: boolean;
+  registration?: RegistrationFieldsFragment;
   t: TFunction;
   userCanDoAction: boolean;
 }): string => {
@@ -96,6 +98,13 @@ export const getEditRegistrationWarning = ({
     return t('registration.form.editButtonPanel.warningNoRightsToEdit');
   }
 
+  if (
+    registration &&
+    hasEnrolments(registration) &&
+    action === REGISTRATION_ACTIONS.DELETE
+  )
+    return t('registration.form.editButtonPanel.warningHasEnrolments');
+
   return '';
 };
 
@@ -103,6 +112,7 @@ export const checkIsEditActionAllowed = ({
   action,
   authenticated,
   organizationAncestors,
+  registration,
   publisher,
   t,
   user,
@@ -111,6 +121,7 @@ export const checkIsEditActionAllowed = ({
   authenticated: boolean;
   organizationAncestors: OrganizationFieldsFragment[];
   publisher: string;
+  registration?: RegistrationFieldsFragment;
   t: TFunction;
   user?: UserFieldsFragment;
 }): Editability => {
@@ -124,6 +135,7 @@ export const checkIsEditActionAllowed = ({
   const warning = getEditRegistrationWarning({
     action,
     authenticated,
+    registration,
     t,
     userCanDoAction,
   });
@@ -136,7 +148,7 @@ export const getEditButtonProps = ({
   authenticated,
   onClick,
   organizationAncestors,
-  publisher,
+  registration,
   t,
   user,
 }: {
@@ -144,15 +156,17 @@ export const getEditButtonProps = ({
   authenticated: boolean;
   onClick: () => void;
   organizationAncestors: OrganizationFieldsFragment[];
-  publisher: string;
+  registration?: RegistrationFieldsFragment;
   t: TFunction;
   user?: UserFieldsFragment;
 }): MenuItemOptionProps => {
+  const publisher = getValue(registration?.publisher, '');
   const { editable, warning } = checkIsEditActionAllowed({
     action,
     authenticated,
     organizationAncestors,
     publisher,
+    registration,
     t,
     user,
   });
@@ -372,6 +386,14 @@ export const isWaitingCapacityUsed = (
   } else {
     return true;
   }
+};
+
+export const hasEnrolments = (
+  registration: RegistrationFieldsFragment
+): boolean => {
+  return Boolean(
+    registration.currentAttendeeCount || registration.currentWaitingListCount
+  );
 };
 
 export const isRegistrationPossible = (

--- a/src/domain/registrations/RegistrationsPage.tsx
+++ b/src/domain/registrations/RegistrationsPage.tsx
@@ -48,7 +48,6 @@ const RegistrationsPage: React.FC<Props> = ({ user }) => {
     authenticated,
     onClick: goToCreateRegistrationPage,
     organizationAncestors: [],
-    publisher: '',
     t,
     user,
   });

--- a/src/domain/registrations/registrationActionsDropdown/RegistrationActionsDropdown.tsx
+++ b/src/domain/registrations/registrationActionsDropdown/RegistrationActionsDropdown.tsx
@@ -79,7 +79,7 @@ const RegistrationActionsDropdown: React.FC<
       authenticated,
       onClick,
       organizationAncestors,
-      publisher,
+      registration,
       t,
       user,
     });

--- a/src/utils/mockDataUtils.ts
+++ b/src/utils/mockDataUtils.ts
@@ -489,6 +489,7 @@ export const fakeRegistration = (
       createdBy: faker.name.firstName(),
       currentAttendeeCount: 0,
       currentWaitingListCount: 0,
+      dataSource: TEST_DATA_SOURCE_ID,
       enrolmentEndTime: '2020-09-30T16:00:00.000000Z',
       enrolmentStartTime: '2020-09-27T15:00:00.000000Z',
       event: null,


### PR DESCRIPTION
## Description :sparkles:
Prevent to delete a registration which already has signups

## Issues :bug:
[LINK-1197](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1197)
