### PR TITLE
LINK-1029, LINK-1032 | Unify signup endpoint addresses with API

### DIFF
--- a/schema.js
+++ b/schema.js
@@ -20,7 +20,7 @@ module.exports = buildSchema(/* GraphQL */ `
     createSeatsReservation(
       input: CreateSeatsReservationMutationInput!
     ): SeatsReservation!
-    deleteEnrolment(cancellationCode: String!): NoContent
+    deleteEnrolment(registration: String!, signup: String!): NoContent
     deleteEvent(id: ID!): NoContent
     deleteImage(id: ID!): NoContent
     deleteKeyword(id: ID!): NoContent
@@ -34,7 +34,11 @@ module.exports = buildSchema(/* GraphQL */ `
       input: SendMessageMutationInput!
       registration: String
     ): SendMessageResponse
-    updateEnrolment(input: UpdateEnrolmentMutationInput!): Enrolment!
+    updateEnrolment(
+      input: UpdateEnrolmentMutationInput!
+      registration: String!
+      signup: String!
+    ): Enrolment!
     updateEvent(input: UpdateEventMutationInput!): Event!
     updateEvents(input: [UpdateEventMutationInput!]!): [Event!]!
     updateImage(input: UpdateImageMutationInput!): Image!
@@ -56,11 +60,10 @@ module.exports = buildSchema(/* GraphQL */ `
   type Query {
     dataSource(id: ID!): DataSource!
     dataSources(page: Int, pageSize: Int): DataSourcesResponse!
-    enrolment(id: ID): Enrolment!
+    enrolment(id: ID!, registration: ID!): Enrolment!
     enrolments(
       attendeeStatus: AttendeeStatus
-      events: [ID]
-      registrations: [ID]
+      registration: ID!
       text: String
     ): [Enrolment]!
     event(id: ID, include: [String]): Event!
@@ -155,7 +158,6 @@ module.exports = buildSchema(/* GraphQL */ `
       pageSize: Int
       text: String
     ): RegistrationsResponse!
-
     user(id: ID!): User!
     users(page: Int, pageSize: Int): UsersResponse!
   }

--- a/schema.js
+++ b/schema.js
@@ -8,7 +8,6 @@ module.exports = buildSchema(/* GraphQL */ `
   type Mutation {
     createEnrolment(
       input: CreateEnrolmentMutationInput!
-      registration: String
     ): CreateEnrolmentResponse!
     createEvent(input: CreateEventMutationInput!): Event!
     createEvents(input: [CreateEventMutationInput!]!): [Event!]!
@@ -20,7 +19,7 @@ module.exports = buildSchema(/* GraphQL */ `
     createSeatsReservation(
       input: CreateSeatsReservationMutationInput!
     ): SeatsReservation!
-    deleteEnrolment(registration: String!, signup: String!): NoContent
+    deleteEnrolment(signup: String!): NoContent
     deleteEvent(id: ID!): NoContent
     deleteImage(id: ID!): NoContent
     deleteKeyword(id: ID!): NoContent
@@ -36,7 +35,6 @@ module.exports = buildSchema(/* GraphQL */ `
     ): SendMessageResponse
     updateEnrolment(
       input: UpdateEnrolmentMutationInput!
-      registration: String!
       signup: String!
     ): Enrolment!
     updateEvent(input: UpdateEventMutationInput!): Event!
@@ -60,12 +58,12 @@ module.exports = buildSchema(/* GraphQL */ `
   type Query {
     dataSource(id: ID!): DataSource!
     dataSources(page: Int, pageSize: Int): DataSourcesResponse!
-    enrolment(id: ID!, registration: ID!): Enrolment!
+    enrolment(id: ID!): Enrolment!
     enrolments(
       attendeeStatus: AttendeeStatus
-      registration: ID!
+      registration: [ID]
       text: String
-    ): [Enrolment]!
+    ): EnrolmentsResponse!
     event(id: ID, include: [String]): Event!
     events(
       adminUser: Boolean
@@ -245,6 +243,7 @@ module.exports = buildSchema(/* GraphQL */ `
   }
 
   input CreateEnrolmentMutationInput {
+    registration: String
     reservationCode: String
     signups: [SignupInput!]
   }
@@ -925,6 +924,11 @@ module.exports = buildSchema(/* GraphQL */ `
     serviceLanguage: String
     streetAddress: String
     zipcode: String
+  }
+
+  type EnrolmentsResponse {
+    meta: Meta!
+    data: [Enrolment!]!
   }
 
   type SendMessageResponse {

--- a/src/common/components/table/Table.tsx
+++ b/src/common/components/table/Table.tsx
@@ -5,6 +5,7 @@ import 'hds-core';
 import { TableProps as HdsTableProps } from 'hds-react';
 import React, { useMemo, useState } from 'react';
 
+import LoadingSpinner from '../loadingSpinner/LoadingSpinner';
 import BodyRow from './bodyRow/BodyRow';
 import HeaderRow from './headerRow/HeaderRow';
 import NoResultsRow from './noResultsRow/NoResultsRow';
@@ -22,6 +23,7 @@ export type GetRowPropsFunc = (
 type TableProps = {
   cols: Header[];
   getRowProps?: GetRowPropsFunc;
+  loading?: boolean;
   noResultsText?: string;
   onRowClick?: (item: object) => void;
   showNoResultsRow?: boolean;
@@ -56,6 +58,7 @@ const Table = ({
   indexKey,
   initialSortingColumnKey,
   initialSortingOrder,
+  loading,
   noResultsText,
   onRowClick,
   onSort,
@@ -134,21 +137,31 @@ const Table = ({
           </HeaderRow>
         </thead>
         <TableBody textAlignContentRight={textAlignContentRight}>
-          {processedRows.map((row, index) => (
-            <BodyRow
-              cols={visibleColumns}
-              getRowProps={getRowProps}
-              index={index}
-              key={row[indexKey as keyof typeof row]}
-              onRowClick={onRowClick}
-              row={row}
-            />
-          ))}
-          {showNoResultsRow && !processedRows.length && (
-            <NoResultsRow
-              colSpan={visibleColumns.length}
-              noResultsText={noResultsText}
-            />
+          {loading ? (
+            <tr>
+              <td colSpan={visibleColumns.length}>
+                <LoadingSpinner isLoading={true} />
+              </td>
+            </tr>
+          ) : (
+            <>
+              {processedRows.map((row, index) => (
+                <BodyRow
+                  cols={visibleColumns}
+                  getRowProps={getRowProps}
+                  index={index}
+                  key={row[indexKey as keyof typeof row]}
+                  onRowClick={onRowClick}
+                  row={row}
+                />
+              ))}
+              {showNoResultsRow && !processedRows.length && (
+                <NoResultsRow
+                  colSpan={visibleColumns.length}
+                  noResultsText={noResultsText}
+                />
+              )}
+            </>
           )}
         </TableBody>
       </TableContainer>

--- a/src/domain/app/apollo/apolloClient.ts
+++ b/src/domain/app/apollo/apolloClient.ts
@@ -19,6 +19,7 @@ import {
   DataSource,
   DataSourcesResponse,
   Enrolment,
+  EnrolmentsResponse,
   Event,
   EventsResponse,
   Image,
@@ -301,6 +302,14 @@ const linkedEventsLink = new RestLink({
     },
     Enrolment: (enrolment: Enrolment): Enrolment | null =>
       addTypenameEnrolment(enrolment),
+    EnrolmentsResponse: (data: EnrolmentsResponse): EnrolmentsResponse => {
+      return {
+        meta: addTypenameMeta(data.meta),
+        data: data.data.map(
+          (enrolment) => addTypenameEnrolment(enrolment) as Enrolment
+        ),
+      };
+    },
     Event: (event: Event): Event | null => addTypenameEvent(event),
     EventsResponse: (data: EventsResponse): EventsResponse => {
       data.meta = addTypenameMeta(data.meta);

--- a/src/domain/app/apollo/apolloClient.ts
+++ b/src/domain/app/apollo/apolloClient.ts
@@ -258,13 +258,6 @@ const linkedEventsLink = new RestLink({
 
       if (config.method === 'GET') {
         return fetch(addNocacheToUrl(request), config);
-      } else if (config.method === 'DELETE' && requestParts[0] === 'signup') {
-        // Apollo cleans body from delete request so parse cancellation code
-        // from the request to make this to work with LE API
-        return fetch(request.replace(requestParts[1], ''), {
-          ...config,
-          body: JSON.stringify({ cancellation_code: requestParts[1] }),
-        });
       } else if (config.method === 'PUT' && requestParts[0] === 'image') {
         // TODO: Remove LOCALIZED_IMAGE feature flag when localized image alt text
         // is deployed to production of API

--- a/src/domain/app/apollo/clearCacheUtils.ts
+++ b/src/domain/app/apollo/clearCacheUtils.ts
@@ -8,6 +8,7 @@ import {
   KeywordSetQueryVariables,
   OrganizationQueryVariables,
   PlaceQueryVariables,
+  RegistrationQueryVariables,
 } from '../../../generated/graphql';
 
 export const clearEnrolmentQueries = (
@@ -116,6 +117,16 @@ export const clearPlacesQueries = (
   apolloClient.cache.evict({
     id: 'ROOT_QUERY',
     fieldName: 'places',
+  });
+
+export const clearRegistrationQueries = (
+  apolloClient: ApolloClient<NormalizedCacheObject>,
+  args?: RegistrationQueryVariables
+): boolean =>
+  apolloClient.cache.evict({
+    id: 'ROOT_QUERY',
+    fieldName: 'registration',
+    args,
   });
 
 export const clearRegistrationsQueries = (

--- a/src/domain/app/i18n/en.json
+++ b/src/domain/app/i18n/en.json
@@ -345,6 +345,7 @@
       "labelNativeLanguage": "Native language",
       "labelParticipantAmount": "Number of registrants",
       "labelPhoneNumber": "Telephone number",
+      "labelRegistration": "Registration",
       "labelServiceLanguage": "Language of communication",
       "labelStreetAddress": "Street address",
       "labelZipcode": "Postcode",

--- a/src/domain/app/i18n/fi.json
+++ b/src/domain/app/i18n/fi.json
@@ -346,6 +346,7 @@
       "labelNativeLanguage": "Äidinkieli",
       "labelParticipantAmount": "Ilmoittautujien määrä",
       "labelPhoneNumber": "Puhelinnumero",
+      "labelRegistration": "Ilmoittautuminen",
       "labelServiceLanguage": "Asiointikieli",
       "labelStreetAddress": "Katuosoite",
       "labelZipcode": "Postinumero",

--- a/src/domain/app/i18n/sv.json
+++ b/src/domain/app/i18n/sv.json
@@ -346,6 +346,7 @@
       "labelNativeLanguage": "Modersmål",
       "labelParticipantAmount": "Antal registrerade",
       "labelPhoneNumber": "Telefonnummer",
+      "labelRegistration": "Registrering",
       "labelServiceLanguage": "Transaktionsspråk",
       "labelStreetAddress": "Gatuadress",
       "labelZipcode": "Postnummer",

--- a/src/domain/app/routes/localeRoutes/__tests__/LocaleRoutes.test.tsx
+++ b/src/domain/app/routes/localeRoutes/__tests__/LocaleRoutes.test.tsx
@@ -10,6 +10,7 @@ import {
   mockedPlacesResponse as mockedPlaceSelectorPlacesReponse,
 } from '../../../../../common/components/placeSelector/__mocks__/placeSelector';
 import { DEPRECATED_ROUTES, ROUTES } from '../../../../../constants';
+import { AttendeeStatus } from '../../../../../generated/graphql';
 import { setFeatureFlags } from '../../../../../test/featureFlags/featureFlags';
 import { Language } from '../../../../../types';
 import getValue from '../../../../../utils/getValue';
@@ -32,6 +33,7 @@ import {
   enrolmentId,
   mockedEnrolmentResponse,
 } from '../../../../enrolment/__mocks__/editEnrolmentPage';
+import { getMockedAttendeesResponse } from '../../../../enrolments/__mocks__/enrolmentsPage';
 import {
   eventName,
   mockedEventResponse,
@@ -142,6 +144,8 @@ const mocks = [
   mockedEventResponse,
   mockedUserResponse,
   mockedUsersResponse,
+  getMockedAttendeesResponse([]),
+  getMockedAttendeesResponse([], { attendeeStatus: AttendeeStatus.Waitlisted }),
 ];
 
 const renderRoute = async (route: string, locale: Language = 'fi') => {

--- a/src/domain/enrolment/EditEnrolmentPage.tsx
+++ b/src/domain/enrolment/EditEnrolmentPage.tsx
@@ -96,9 +96,8 @@ const EditEnrolmentPage: React.FC<Props> = ({
 
 const EditEnrolmentPageWrapper: React.FC = () => {
   const location = useLocation();
-  const { enrolmentId, registrationId } = useParams<{
+  const { enrolmentId } = useParams<{
     enrolmentId: string;
-    registrationId: string;
   }>();
   const { user } = useUser();
 
@@ -116,7 +115,6 @@ const EditEnrolmentPageWrapper: React.FC = () => {
     skip: !enrolmentId || !user,
     variables: {
       id: getValue(enrolmentId, ''),
-      registration: getValue(registrationId, ''),
       createPath: getPathBuilder(enrolmentPathBuilder),
     },
   });

--- a/src/domain/enrolment/EditEnrolmentPage.tsx
+++ b/src/domain/enrolment/EditEnrolmentPage.tsx
@@ -96,7 +96,10 @@ const EditEnrolmentPage: React.FC<Props> = ({
 
 const EditEnrolmentPageWrapper: React.FC = () => {
   const location = useLocation();
-  const { enrolmentId } = useParams<{ enrolmentId: string }>();
+  const { enrolmentId, registrationId } = useParams<{
+    enrolmentId: string;
+    registrationId: string;
+  }>();
   const { user } = useUser();
 
   const {
@@ -113,6 +116,7 @@ const EditEnrolmentPageWrapper: React.FC = () => {
     skip: !enrolmentId || !user,
     variables: {
       id: getValue(enrolmentId, ''),
+      registration: getValue(registrationId, ''),
       createPath: getPathBuilder(enrolmentPathBuilder),
     },
   });

--- a/src/domain/enrolment/__mocks__/createEnrolmentPage.ts
+++ b/src/domain/enrolment/__mocks__/createEnrolmentPage.ts
@@ -28,6 +28,7 @@ const enrolmentValues = {
 };
 
 const payload: CreateEnrolmentMutationInput = {
+  registration: registrationId,
   reservationCode: TEST_SEATS_RESERVATION_CODE,
   signups: [
     {
@@ -49,7 +50,6 @@ const payload: CreateEnrolmentMutationInput = {
 
 const createEnrolmentVariables = {
   input: payload,
-  registration: registrationId,
 };
 
 const createEnrolmentResponse = {

--- a/src/domain/enrolment/__mocks__/editEnrolmentPage.ts
+++ b/src/domain/enrolment/__mocks__/editEnrolmentPage.ts
@@ -41,7 +41,11 @@ const enrolment = fakeEnrolment({
   id: enrolmentId,
 });
 
-const enrolmentVariables = { createPath: undefined, id: enrolmentId };
+const enrolmentVariables = {
+  createPath: undefined,
+  id: enrolmentId,
+  registration: registrationId,
+};
 const enrolmentResponse = { data: { enrolment } };
 const mockedEnrolmentResponse: MockedResponse = {
   request: { query: EnrolmentDocument, variables: enrolmentVariables },
@@ -49,7 +53,8 @@ const mockedEnrolmentResponse: MockedResponse = {
 };
 
 const cancelEnrolmentVariables = {
-  cancellationCode: enrolment.cancellationCode,
+  registration: registrationId,
+  signup: enrolmentId,
 };
 const cancelEnrolmentResponse = { data: { deleteEnrolment: null } };
 const mockedCancelEnrolmentResponse: MockedResponse = {
@@ -77,7 +82,11 @@ const payload = {
   zipcode: enrolmentValues.zipcode,
 };
 
-const updateEnrolmentVariables = { input: payload };
+const updateEnrolmentVariables = {
+  input: payload,
+  registration: registrationId,
+  signup: enrolmentId,
+};
 
 const updateEnrolmentResponse = { data: { updateEnrolment: enrolment } };
 

--- a/src/domain/enrolment/__mocks__/editEnrolmentPage.ts
+++ b/src/domain/enrolment/__mocks__/editEnrolmentPage.ts
@@ -44,7 +44,6 @@ const enrolment = fakeEnrolment({
 const enrolmentVariables = {
   createPath: undefined,
   id: enrolmentId,
-  registration: registrationId,
 };
 const enrolmentResponse = { data: { enrolment } };
 const mockedEnrolmentResponse: MockedResponse = {
@@ -53,7 +52,6 @@ const mockedEnrolmentResponse: MockedResponse = {
 };
 
 const cancelEnrolmentVariables = {
-  registration: registrationId,
   signup: enrolmentId,
 };
 const cancelEnrolmentResponse = { data: { deleteEnrolment: null } };
@@ -84,7 +82,6 @@ const payload = {
 
 const updateEnrolmentVariables = {
   input: payload,
-  registration: registrationId,
   signup: enrolmentId,
 };
 

--- a/src/domain/enrolment/__mocks__/enrolment.ts
+++ b/src/domain/enrolment/__mocks__/enrolment.ts
@@ -1,4 +1,4 @@
 import { attendees } from '../../enrolments/__mocks__/enrolmentsPage';
-const enrolment = attendees[0];
+const enrolment = attendees.data[0];
 
 export { enrolment };

--- a/src/domain/enrolment/__tests__/CreateEnrolmentPage.test.tsx
+++ b/src/domain/enrolment/__tests__/CreateEnrolmentPage.test.tsx
@@ -126,7 +126,7 @@ const getCreateSeatsReservationMock = (seats: number): MockedResponse => {
     input: createSeatsReservationPayload,
   };
 
-  const createEnrolmentResponse = {
+  const createSeatsReservationResponse = {
     data: {
       createSeatsReservation: {
         ...seatsReservation,
@@ -141,7 +141,7 @@ const getCreateSeatsReservationMock = (seats: number): MockedResponse => {
       query: CreateSeatsReservationDocument,
       variables: createSeatsReservationVariables,
     },
-    result: createEnrolmentResponse,
+    result: createSeatsReservationResponse,
   };
 };
 
@@ -157,7 +157,7 @@ const getUpdateSeatsReservationMock = (seats: number): MockedResponse => {
     input: updateSeatsReservationPayload,
   };
 
-  const updateEnrolmentResponse = {
+  const updateSeatsReservationResponse = {
     data: {
       updateSeatsReservation: {
         ...seatsReservation,
@@ -172,7 +172,7 @@ const getUpdateSeatsReservationMock = (seats: number): MockedResponse => {
       query: UpdateSeatsReservationDocument,
       variables: updateSeatsReservationVariables,
     },
-    result: updateEnrolmentResponse,
+    result: updateSeatsReservationResponse,
   };
 };
 

--- a/src/domain/enrolment/__tests__/utils.test.ts
+++ b/src/domain/enrolment/__tests__/utils.test.ts
@@ -231,9 +231,11 @@ describe('getEnrolmentPayload function', () => {
           ...ENROLMENT_INITIAL_VALUES,
           attendees: [ATTENDEE_INITIAL_VALUES],
         },
+        registration,
         reservationCode: TEST_SEATS_RESERVATION_CODE,
       })
     ).toEqual({
+      registration: registrationId,
       reservationCode: TEST_SEATS_RESERVATION_CODE,
       signups: [
         {
@@ -287,10 +289,12 @@ describe('getEnrolmentPayload function', () => {
         phoneNumber,
         serviceLanguage,
       },
+      registration,
       reservationCode: TEST_SEATS_RESERVATION_CODE,
     });
 
     expect(payload).toEqual({
+      registration: registrationId,
       reservationCode: TEST_SEATS_RESERVATION_CODE,
       signups: [
         {
@@ -397,10 +401,7 @@ describe('getUpdateEnrolmentPayload function', () => {
 
 describe('enrolmentPathBuilder function', () => {
   const cases: [EnrolmentQueryVariables, string][] = [
-    [
-      { id: 'hel:123', registration: registrationId },
-      `/registration/${registrationId}/signup/hel:123/`,
-    ],
+    [{ id: 'hel:123' }, `/signup/hel:123/`],
   ];
 
   it.each(cases)('should build correct path', (variables, expectedPath) =>

--- a/src/domain/enrolment/__tests__/utils.test.ts
+++ b/src/domain/enrolment/__tests__/utils.test.ts
@@ -10,7 +10,10 @@ import {
   fakeSeatsReservation,
 } from '../../../utils/mockDataUtils';
 import { enrolment } from '../../enrolment/__mocks__/enrolment';
-import { registration } from '../../registration/__mocks__/registration';
+import {
+  registration,
+  registrationId,
+} from '../../registration/__mocks__/registration';
 import { TEST_REGISTRATION_ID } from '../../registration/constants';
 import { TEST_SEATS_RESERVATION_CODE } from '../../reserveSeats/constants';
 import { setSeatsReservationData } from '../../reserveSeats/utils';
@@ -394,7 +397,10 @@ describe('getUpdateEnrolmentPayload function', () => {
 
 describe('enrolmentPathBuilder function', () => {
   const cases: [EnrolmentQueryVariables, string][] = [
-    [{ id: 'hel:123' }, '/signup_edit/hel:123/'],
+    [
+      { id: 'hel:123', registration: registrationId },
+      `/registration/${registrationId}/signup/hel:123/`,
+    ],
   ];
 
   it.each(cases)('should build correct path', (variables, expectedPath) =>

--- a/src/domain/enrolment/enrolmentPageContext/EnrolmentPageContext.tsx
+++ b/src/domain/enrolment/enrolmentPageContext/EnrolmentPageContext.tsx
@@ -45,6 +45,7 @@ export const EnrolmentPageProvider: FC<PropsWithChildren> = ({ children }) => {
       setOpenModal,
       setOpenModalId,
       setOpenParticipant,
+      setOpenModalId,
       toggleOpenParticipant: (newIndex: number) => {
         setOpenParticipant(openParticipant === newIndex ? null : newIndex);
       },

--- a/src/domain/enrolment/enrolmentServerErrorsContext/__tests__/utils.test.ts
+++ b/src/domain/enrolment/enrolmentServerErrorsContext/__tests__/utils.test.ts
@@ -9,18 +9,24 @@ import {
 describe('parseEnrolmentServerErrors', () => {
   it('should set server error items', async () => {
     const result = {
-      city: ['Tämän kentän arvo ei voi olla "null".'],
-      detail: 'The participant is too old.',
-      name: ['The name must be specified.'],
-      non_field_errors: [
-        'Kenttien email, registration tulee muodostaa uniikki joukko.',
-        'Kenttien phone_number, registration tulee muodostaa uniikki joukko.',
+      registration: ['The name must be specified.'],
+      signups: [
+        {
+          city: ['Tämän kentän arvo ei voi olla "null".'],
+          detail: 'The participant is too old.',
+          name: ['The name must be specified.'],
+          non_field_errors: [
+            'Kenttien email, registration tulee muodostaa uniikki joukko.',
+            'Kenttien phone_number, registration tulee muodostaa uniikki joukko.',
+          ],
+        },
       ],
     };
 
     expect(
       parseEnrolmentServerErrors({ result, t: i18n.t.bind(i18n) })
     ).toEqual([
+      { label: 'Ilmoittautuminen', message: 'Nimi on pakollinen.' },
       { label: 'Kaupunki', message: 'Tämän kentän arvo ei voi olla "null".' },
       { label: '', message: 'Osallistuja on liian vanha.' },
       { label: 'Nimi', message: 'Nimi on pakollinen.' },

--- a/src/domain/enrolment/enrolmentServerErrorsContext/utils.ts
+++ b/src/domain/enrolment/enrolmentServerErrorsContext/utils.ts
@@ -27,6 +27,10 @@ export const parseEnrolmentServerErrors = ({
     error: LEServerError;
     key: string;
   }) {
+    if (key === 'signups') {
+      return parseSignupServerError(error);
+    }
+
     return [
       {
         label: parseEnrolmentServerErrorLabel({ key }),
@@ -35,6 +39,24 @@ export const parseEnrolmentServerErrors = ({
     ];
   }
 
+  // Get error items for video fields
+  function parseSignupServerError(error: LEServerError): ServerErrorItem[] {
+    /* istanbul ignore else */
+    if (Array.isArray(error)) {
+      return Object.entries(error[0]).reduce(
+        (previous: ServerErrorItem[], [key, e]) => [
+          ...previous,
+          {
+            label: parseEnrolmentServerErrorLabel({ key }),
+            message: parseServerErrorMessage({ error: e as string[], t }),
+          },
+        ],
+        []
+      );
+    } else {
+      return [];
+    }
+  }
   // Get correct field name for an error item
   function parseEnrolmentServerErrorLabel({ key }: { key: string }): string {
     if (isGenericServerError(key)) {

--- a/src/domain/enrolment/hooks/useEnrolmentActions.ts
+++ b/src/domain/enrolment/hooks/useEnrolmentActions.ts
@@ -126,7 +126,6 @@ const useEnrolmentActions = ({
 
       await deleteEnrolmentMutation({
         variables: {
-          registration: getValue(registration.id, ''),
           signup: getValue(enrolment?.id, ''),
         },
       });
@@ -150,8 +149,9 @@ const useEnrolmentActions = ({
     const reservationData = getSeatsReservationData(
       getValue(registration.id, '')
     );
-    const payload = getEnrolmentPayload({
+    const payload: CreateEnrolmentMutationInput = getEnrolmentPayload({
       formValues: values,
+      registration,
       reservationCode: getValue(reservationData?.code, ''),
     });
 
@@ -159,7 +159,6 @@ const useEnrolmentActions = ({
       const { data } = await createEnrolmentMutation({
         variables: {
           input: payload,
-          registration: getValue(registration.id, ''),
         },
       });
 
@@ -194,7 +193,6 @@ const useEnrolmentActions = ({
       await updateEnrolmentMutation({
         variables: {
           input: payload,
-          registration: getValue(registration.id, ''),
           signup: getValue(enrolment?.id, ''),
         },
       });

--- a/src/domain/enrolment/hooks/useEnrolmentActions.ts
+++ b/src/domain/enrolment/hooks/useEnrolmentActions.ts
@@ -23,7 +23,6 @@ import isTestEnv from '../../../utils/isTestEnv';
 import {
   clearEnrolmentQueries,
   clearEnrolmentsQueries,
-  clearRegistrationQueries,
 } from '../../app/apollo/clearCacheUtils';
 import { reportError } from '../../app/sentry/utils';
 import { getSeatsReservationData } from '../../reserveSeats/utils';
@@ -77,8 +76,6 @@ const useEnrolmentActions = ({
   };
 
   const cleanAfterUpdate = async (callbacks?: MutationCallbacks) => {
-    /* istanbul ignore next */
-    !isTestEnv && clearRegistrationQueries(apolloClient);
     /* istanbul ignore next */
     !isTestEnv && clearEnrolmentQueries(apolloClient);
     /* istanbul ignore next */

--- a/src/domain/enrolment/hooks/useEnrolmentActions.ts
+++ b/src/domain/enrolment/hooks/useEnrolmentActions.ts
@@ -23,6 +23,7 @@ import isTestEnv from '../../../utils/isTestEnv';
 import {
   clearEnrolmentQueries,
   clearEnrolmentsQueries,
+  clearRegistrationQueries,
 } from '../../app/apollo/clearCacheUtils';
 import { reportError } from '../../app/sentry/utils';
 import { getSeatsReservationData } from '../../reserveSeats/utils';
@@ -77,6 +78,8 @@ const useEnrolmentActions = ({
 
   const cleanAfterUpdate = async (callbacks?: MutationCallbacks) => {
     /* istanbul ignore next */
+    !isTestEnv && clearRegistrationQueries(apolloClient);
+    /* istanbul ignore next */
     !isTestEnv && clearEnrolmentQueries(apolloClient);
     /* istanbul ignore next */
     !isTestEnv && clearEnrolmentsQueries(apolloClient);
@@ -126,7 +129,8 @@ const useEnrolmentActions = ({
 
       await deleteEnrolmentMutation({
         variables: {
-          cancellationCode: getValue(enrolment?.cancellationCode, ''),
+          registration: getValue(registration.id, ''),
+          signup: getValue(enrolment?.id, ''),
         },
       });
 
@@ -190,7 +194,13 @@ const useEnrolmentActions = ({
     try {
       setSaving(ENROLMENT_ACTIONS.UPDATE);
 
-      await updateEnrolmentMutation({ variables: { input: payload } });
+      await updateEnrolmentMutation({
+        variables: {
+          input: payload,
+          registration: getValue(registration.id, ''),
+          signup: getValue(enrolment?.id, ''),
+        },
+      });
 
       await cleanAfterUpdate(callbacks);
     } catch (error) /* istanbul ignore next */ {

--- a/src/domain/enrolment/mutation.ts
+++ b/src/domain/enrolment/mutation.ts
@@ -17,22 +17,30 @@ export const MUTATION_ENROLMENT = gql`
     }
   }
 
-  mutation DeleteEnrolment($cancellationCode: String!) {
-    deleteEnrolment(cancellationCode: $cancellationCode)
+  mutation DeleteEnrolment($registration: String!, $signup: String!) {
+    deleteEnrolment(registration: $registration, signup: $signup)
       @rest(
         type: "NoContent"
-        path: "/signup/{args.cancellationCode}"
+        path: "/registration/{args.registration}/signup/{args.signup}/"
         method: "DELETE"
       ) {
       noContent
     }
   }
 
-  mutation UpdateEnrolment($input: UpdateEnrolmentMutationInput!) {
-    updateEnrolment(input: $input)
+  mutation UpdateEnrolment(
+    $input: UpdateEnrolmentMutationInput!
+    $registration: String!
+    $signup: String!
+  ) {
+    updateEnrolment(
+      input: $input
+      registration: $registration
+      signup: $signup
+    )
       @rest(
         type: "Enrolment"
-        path: "/signup_edit/{args.input.id}/"
+        path: "/registration/{args.registration}/signup/{args.signup}/"
         method: "PUT"
         bodyKey: "input"
       ) {

--- a/src/domain/enrolment/mutation.ts
+++ b/src/domain/enrolment/mutation.ts
@@ -2,14 +2,11 @@
 import gql from 'graphql-tag';
 
 export const MUTATION_ENROLMENT = gql`
-  mutation CreateEnrolment(
-    $input: CreateEnrolmentMutationInput!
-    $registration: String!
-  ) {
-    createEnrolment(input: $input, registration: $registration)
+  mutation CreateEnrolment($input: CreateEnrolmentMutationInput!) {
+    createEnrolment(input: $input)
       @rest(
         type: "CreateEnrolmentResponse"
-        path: "/registration/{args.registration}/signup/"
+        path: "/signup/"
         method: "POST"
         bodyKey: "input"
       ) {
@@ -17,11 +14,11 @@ export const MUTATION_ENROLMENT = gql`
     }
   }
 
-  mutation DeleteEnrolment($registration: String!, $signup: String!) {
-    deleteEnrolment(registration: $registration, signup: $signup)
+  mutation DeleteEnrolment($signup: String!) {
+    deleteEnrolment(signup: $signup)
       @rest(
         type: "NoContent"
-        path: "/registration/{args.registration}/signup/{args.signup}/"
+        path: "/signup/{args.signup}/"
         method: "DELETE"
       ) {
       noContent
@@ -30,17 +27,12 @@ export const MUTATION_ENROLMENT = gql`
 
   mutation UpdateEnrolment(
     $input: UpdateEnrolmentMutationInput!
-    $registration: String!
     $signup: String!
   ) {
-    updateEnrolment(
-      input: $input
-      registration: $registration
-      signup: $signup
-    )
+    updateEnrolment(input: $input, signup: $signup)
       @rest(
         type: "Enrolment"
-        path: "/registration/{args.registration}/signup/{args.signup}/"
+        path: "/signup/{args.signup}/"
         method: "PUT"
         bodyKey: "input"
       ) {

--- a/src/domain/enrolment/query.ts
+++ b/src/domain/enrolment/query.ts
@@ -41,9 +41,8 @@ export const QUERY_ENROLMENT = gql`
     zipcode
   }
 
-  query Enrolment($id: ID!, $registration: ID!, $createPath: Any) {
-    enrolment(id: $id, registration: $registration)
-      @rest(type: "Enrolment", pathBuilder: $createPath) {
+  query Enrolment($id: ID!, $createPath: Any) {
+    enrolment(id: $id) @rest(type: "Enrolment", pathBuilder: $createPath) {
       ...enrolmentFields
     }
   }

--- a/src/domain/enrolment/query.ts
+++ b/src/domain/enrolment/query.ts
@@ -41,8 +41,9 @@ export const QUERY_ENROLMENT = gql`
     zipcode
   }
 
-  query Enrolment($id: ID!, $createPath: Any) {
-    enrolment(id: $id) @rest(type: "Enrolment", pathBuilder: $createPath) {
+  query Enrolment($id: ID!, $registration: ID!, $createPath: Any) {
+    enrolment(id: $id, registration: $registration)
+      @rest(type: "Enrolment", pathBuilder: $createPath) {
       ...enrolmentFields
     }
   }

--- a/src/domain/enrolment/utils.ts
+++ b/src/domain/enrolment/utils.ts
@@ -201,9 +201,9 @@ export const getUpdateEnrolmentPayload = ({
 export const enrolmentPathBuilder = ({
   args,
 }: PathBuilderProps<EnrolmentQueryVariables>): string => {
-  const { id } = args;
+  const { id, registration } = args;
 
-  return `/signup_edit/${id}/`;
+  return `/registration/${registration}/signup/${id}/`;
 };
 
 export const getTotalAttendeeCapacity = (

--- a/src/domain/enrolment/utils.ts
+++ b/src/domain/enrolment/utils.ts
@@ -116,9 +116,11 @@ export const getEnrolmentNotificationsCode = (
 
 export const getEnrolmentPayload = ({
   formValues,
+  registration,
   reservationCode,
 }: {
   formValues: EnrolmentFormFields;
+  registration: RegistrationFieldsFragment;
   reservationCode: string;
 }): CreateEnrolmentMutationInput => {
   const {
@@ -153,6 +155,7 @@ export const getEnrolmentPayload = ({
   });
 
   return {
+    registration: registration.id,
     reservationCode,
     signups,
   };
@@ -201,9 +204,9 @@ export const getUpdateEnrolmentPayload = ({
 export const enrolmentPathBuilder = ({
   args,
 }: PathBuilderProps<EnrolmentQueryVariables>): string => {
-  const { id, registration } = args;
+  const { id } = args;
 
-  return `/registration/${registration}/signup/${id}/`;
+  return `/signup/${id}/`;
 };
 
 export const getTotalAttendeeCapacity = (

--- a/src/domain/enrolments/__mocks__/enrolmentsPage.ts
+++ b/src/domain/enrolments/__mocks__/enrolmentsPage.ts
@@ -3,7 +3,9 @@ import range from 'lodash/range';
 
 import {
   AttendeeStatus,
+  EnrolmentFieldsFragment,
   EnrolmentsDocument,
+  EnrolmentsQueryVariables,
   SendMessageDocument,
 } from '../../../generated/graphql';
 import {
@@ -27,19 +29,29 @@ const attendees = fakeEnrolments(
   }))
 );
 
-const attendeesResponse = { data: { enrolments: attendees } };
+const getMockedAttendeesResponse = (
+  enrolments: EnrolmentFieldsFragment[],
+  overrideVariables?: Partial<EnrolmentsQueryVariables>
+): MockedResponse => {
+  const defaultVariables = {
+    createPath: undefined,
+    registration: registrationId,
+    text: '',
+    attendeeStatus: AttendeeStatus.Attending,
+  };
+  const attendeesResponse = { data: { enrolments: enrolments } };
+  return {
+    request: {
+      query: EnrolmentsDocument,
+      variables: { ...defaultVariables, ...overrideVariables },
+    },
+    result: attendeesResponse,
+  };
+};
 
-const attendeesVariables = {
-  createPath: undefined,
-  registrations: [registrationId],
-  text: '',
+const mockedAttendeesResponse = getMockedAttendeesResponse(attendees, {
   attendeeStatus: AttendeeStatus.Attending,
-};
-
-const mockedAttendeesResponse: MockedResponse = {
-  request: { query: EnrolmentsDocument, variables: attendeesVariables },
-  result: attendeesResponse,
-};
+});
 
 const waitingAttendeeNames = range(1, 2).map(
   (n) => `Waiting attendee name ${n}`
@@ -54,19 +66,12 @@ const waitingAttendees = fakeEnrolments(
   }))
 );
 
-const waitingAttendeesResponse = { data: { enrolments: waitingAttendees } };
-
-const waitingAttendeesVariables = {
-  createPath: undefined,
-  registrations: [registrationId],
-  text: '',
-  attendeeStatus: AttendeeStatus.Waitlisted,
-};
-
-const mockedWaitingAttendeesResponse: MockedResponse = {
-  request: { query: EnrolmentsDocument, variables: waitingAttendeesVariables },
-  result: waitingAttendeesResponse,
-};
+const mockedWaitingAttendeesResponse = getMockedAttendeesResponse(
+  waitingAttendees,
+  {
+    attendeeStatus: AttendeeStatus.Waitlisted,
+  }
+);
 
 const sendMessageValues = {
   body: '<p>Message</p>',
@@ -97,12 +102,11 @@ const mockedSendMessageResponse: MockedResponse = {
 export {
   attendeeNames,
   attendees,
-  attendeesResponse,
+  getMockedAttendeesResponse,
   mockedAttendeesResponse,
   mockedSendMessageResponse,
   mockedWaitingAttendeesResponse,
   sendMessageValues,
   waitingAttendeeNames,
   waitingAttendees,
-  waitingAttendeesResponse,
 };

--- a/src/domain/enrolments/__mocks__/enrolmentsPage.ts
+++ b/src/domain/enrolments/__mocks__/enrolmentsPage.ts
@@ -3,9 +3,9 @@ import range from 'lodash/range';
 
 import {
   AttendeeStatus,
-  EnrolmentFieldsFragment,
   EnrolmentsDocument,
   EnrolmentsQueryVariables,
+  EnrolmentsResponse,
   SendMessageDocument,
 } from '../../../generated/graphql';
 import {
@@ -30,16 +30,16 @@ const attendees = fakeEnrolments(
 );
 
 const getMockedAttendeesResponse = (
-  enrolments: EnrolmentFieldsFragment[],
+  enrolmentsResponse: EnrolmentsResponse,
   overrideVariables?: Partial<EnrolmentsQueryVariables>
 ): MockedResponse => {
   const defaultVariables = {
     createPath: undefined,
-    registration: registrationId,
+    registration: [registrationId],
     text: '',
     attendeeStatus: AttendeeStatus.Attending,
   };
-  const attendeesResponse = { data: { enrolments: enrolments } };
+  const attendeesResponse = { data: { enrolments: enrolmentsResponse } };
   return {
     request: {
       query: EnrolmentsDocument,

--- a/src/domain/enrolments/__tests__/EnrolmentsPage.test.tsx
+++ b/src/domain/enrolments/__tests__/EnrolmentsPage.test.tsx
@@ -7,6 +7,7 @@ import { ROUTES } from '../../../constants';
 import { AttendeeStatus } from '../../../generated/graphql';
 import getValue from '../../../utils/getValue';
 import { fakeAuthenticatedAuthContextValue } from '../../../utils/mockAuthContextValue';
+import { fakeEnrolments } from '../../../utils/mockDataUtils';
 import {
   configure,
   CustomRenderOptions,
@@ -49,7 +50,9 @@ const defaultMocks = [
   mockedRegistrationResponse,
   mockedUserResponse,
   getMockedAttendeesResponse(attendees),
-  getMockedAttendeesResponse([], { attendeeStatus: AttendeeStatus.Waitlisted }),
+  getMockedAttendeesResponse(fakeEnrolments(0), {
+    attendeeStatus: AttendeeStatus.Waitlisted,
+  }),
 ];
 
 beforeEach(() => jest.clearAllMocks());
@@ -115,7 +118,7 @@ test('should render enrolments page', async () => {
 
 test('scrolls to enrolment table row and calls history.replace correctly (deletes enrolmentId from state)', async () => {
   const history = createMemoryHistory();
-  history.push(route, { enrolmentId: attendees[0].id });
+  history.push(route, { enrolmentId: attendees.data[0].id });
 
   const replaceSpy = jest.spyOn(history, 'replace');
 
@@ -132,7 +135,7 @@ test('scrolls to enrolment table row and calls history.replace correctly (delete
   );
 
   const enrolmentRowButton = screen.getAllByRole('button', {
-    name: getValue(attendees[0].name, ''),
+    name: getValue(attendees.data[0].name, ''),
   })[0];
   await waitFor(() => expect(enrolmentRowButton).toHaveFocus());
 });

--- a/src/domain/enrolments/__tests__/EnrolmentsPage.test.tsx
+++ b/src/domain/enrolments/__tests__/EnrolmentsPage.test.tsx
@@ -4,6 +4,7 @@ import { createMemoryHistory } from 'history';
 import React from 'react';
 
 import { ROUTES } from '../../../constants';
+import { AttendeeStatus } from '../../../generated/graphql';
 import getValue from '../../../utils/getValue';
 import { fakeAuthenticatedAuthContextValue } from '../../../utils/mockAuthContextValue';
 import {
@@ -27,6 +28,7 @@ import {
 import { mockedUserResponse } from '../../user/__mocks__/user';
 import {
   attendees,
+  getMockedAttendeesResponse,
   mockedSendMessageResponse,
   sendMessageValues,
 } from '../__mocks__/enrolmentsPage';
@@ -46,6 +48,8 @@ const defaultMocks = [
   mockedOrganizationAncestorsResponse,
   mockedRegistrationResponse,
   mockedUserResponse,
+  getMockedAttendeesResponse(attendees),
+  getMockedAttendeesResponse([], { attendeeStatus: AttendeeStatus.Waitlisted }),
 ];
 
 beforeEach(() => jest.clearAllMocks());

--- a/src/domain/enrolments/__tests__/utils.test.ts
+++ b/src/domain/enrolments/__tests__/utils.test.ts
@@ -4,12 +4,7 @@ import {
 } from '../../../generated/graphql';
 import { fakeEnrolment, fakeRegistration } from '../../../utils/mockDataUtils';
 import { registrationId } from '../../registration/__mocks__/registration';
-import { attendees, waitingAttendees } from '../__mocks__/enrolmentsPage';
-import {
-  enrolmentsPathBuilder,
-  filterEnrolments,
-  getEnrolmentFields,
-} from '../utils';
+import { enrolmentsPathBuilder, getEnrolmentFields } from '../utils';
 
 describe('getEnrolmentFields function', () => {
   it('should return default values if value is not set', () => {
@@ -17,7 +12,7 @@ describe('getEnrolmentFields function', () => {
       enrolment: fakeEnrolment({
         email: null,
         name: null,
-        id: null,
+        id: '',
         phoneNumber: null,
       }),
       language: 'fi',
@@ -55,64 +50,4 @@ describe('enrolmentsPathBuilder function', () => {
     (variables, expectedPath) =>
       expect(enrolmentsPathBuilder({ args: variables })).toBe(expectedPath)
   );
-});
-
-describe('filterEnrolments function', () => {
-  const enrolments = [...attendees, ...waitingAttendees];
-
-  test('should return only attendees', () => {
-    const filteredEnrolments = filterEnrolments({
-      enrolments,
-      query: {
-        attendeeStatus: AttendeeStatus.Attending,
-        registration: registrationId,
-      },
-    });
-
-    expect(filteredEnrolments).toEqual(attendees);
-    expect(filteredEnrolments).not.toContain(waitingAttendees);
-  });
-
-  test('should return only waiting list attendees', () => {
-    const filteredEnrolments = filterEnrolments({
-      enrolments,
-      query: {
-        attendeeStatus: AttendeeStatus.Waitlisted,
-        registration: registrationId,
-      },
-    });
-
-    expect(filteredEnrolments).toEqual(waitingAttendees);
-    expect(filteredEnrolments).not.toContain(attendees);
-  });
-
-  test('should filter attendees by name text', () => {
-    const filteredEnrolments = filterEnrolments({
-      enrolments,
-      query: { registration: registrationId, text: waitingAttendees[0].name },
-    });
-
-    expect(filteredEnrolments).toEqual([waitingAttendees[0]]);
-  });
-
-  test('should filter attendees by email text', () => {
-    const filteredEnrolments = filterEnrolments({
-      enrolments,
-      query: { registration: registrationId, text: waitingAttendees[0].email },
-    });
-
-    expect(filteredEnrolments).toEqual([waitingAttendees[0]]);
-  });
-
-  test('should filter attendees by phone number text', () => {
-    const filteredEnrolments = filterEnrolments({
-      enrolments,
-      query: {
-        registration: registrationId,
-        text: waitingAttendees[0].phoneNumber,
-      },
-    });
-
-    expect(filteredEnrolments).toEqual([waitingAttendees[0]]);
-  });
 });

--- a/src/domain/enrolments/__tests__/utils.test.ts
+++ b/src/domain/enrolments/__tests__/utils.test.ts
@@ -3,6 +3,7 @@ import {
   EnrolmentsQueryVariables,
 } from '../../../generated/graphql';
 import { fakeEnrolment, fakeRegistration } from '../../../utils/mockDataUtils';
+import { registrationId } from '../../registration/__mocks__/registration';
 import { attendees, waitingAttendees } from '../__mocks__/enrolmentsPage';
 import {
   enrolmentsPathBuilder,
@@ -33,15 +34,20 @@ describe('getEnrolmentFields function', () => {
 describe('enrolmentsPathBuilder function', () => {
   const cases: [EnrolmentsQueryVariables, string][] = [
     [
-      { attendeeStatus: AttendeeStatus.Attending },
-      '/signup/?attendee_status=attending',
+      {
+        attendeeStatus: AttendeeStatus.Attending,
+        registration: registrationId,
+      },
+      `/registration/${registrationId}/signup/?attendee_status=attending`,
     ],
-    [{ events: ['event:1', 'event:2'] }, '/signup/?events=event:1,event:2'],
     [
-      { registrations: ['registration:1', 'registration:2'] },
-      '/signup/?registrations=registration:1,registration:2',
+      { registration: registrationId },
+      `/registration/${registrationId}/signup/`,
     ],
-    [{ text: 'text' }, '/signup/?text=text'],
+    [
+      { registration: registrationId, text: 'text' },
+      `/registration/${registrationId}/signup/?text=text`,
+    ],
   ];
 
   it.each(cases)(
@@ -57,7 +63,10 @@ describe('filterEnrolments function', () => {
   test('should return only attendees', () => {
     const filteredEnrolments = filterEnrolments({
       enrolments,
-      query: { attendeeStatus: AttendeeStatus.Attending },
+      query: {
+        attendeeStatus: AttendeeStatus.Attending,
+        registration: registrationId,
+      },
     });
 
     expect(filteredEnrolments).toEqual(attendees);
@@ -67,7 +76,10 @@ describe('filterEnrolments function', () => {
   test('should return only waiting list attendees', () => {
     const filteredEnrolments = filterEnrolments({
       enrolments,
-      query: { attendeeStatus: AttendeeStatus.Waitlisted },
+      query: {
+        attendeeStatus: AttendeeStatus.Waitlisted,
+        registration: registrationId,
+      },
     });
 
     expect(filteredEnrolments).toEqual(waitingAttendees);
@@ -77,7 +89,7 @@ describe('filterEnrolments function', () => {
   test('should filter attendees by name text', () => {
     const filteredEnrolments = filterEnrolments({
       enrolments,
-      query: { text: waitingAttendees[0].name },
+      query: { registration: registrationId, text: waitingAttendees[0].name },
     });
 
     expect(filteredEnrolments).toEqual([waitingAttendees[0]]);
@@ -86,7 +98,7 @@ describe('filterEnrolments function', () => {
   test('should filter attendees by email text', () => {
     const filteredEnrolments = filterEnrolments({
       enrolments,
-      query: { text: waitingAttendees[0].email },
+      query: { registration: registrationId, text: waitingAttendees[0].email },
     });
 
     expect(filteredEnrolments).toEqual([waitingAttendees[0]]);
@@ -95,7 +107,10 @@ describe('filterEnrolments function', () => {
   test('should filter attendees by phone number text', () => {
     const filteredEnrolments = filterEnrolments({
       enrolments,
-      query: { text: waitingAttendees[0].phoneNumber },
+      query: {
+        registration: registrationId,
+        text: waitingAttendees[0].phoneNumber,
+      },
     });
 
     expect(filteredEnrolments).toEqual([waitingAttendees[0]]);

--- a/src/domain/enrolments/__tests__/utils.test.ts
+++ b/src/domain/enrolments/__tests__/utils.test.ts
@@ -29,20 +29,14 @@ describe('getEnrolmentFields function', () => {
 describe('enrolmentsPathBuilder function', () => {
   const cases: [EnrolmentsQueryVariables, string][] = [
     [
-      {
-        attendeeStatus: AttendeeStatus.Attending,
-        registration: registrationId,
-      },
-      `/registration/${registrationId}/signup/?attendee_status=attending`,
+      { attendeeStatus: AttendeeStatus.Attending },
+      `/signup/?attendee_status=attending`,
     ],
     [
-      { registration: registrationId },
-      `/registration/${registrationId}/signup/`,
+      { registration: [registrationId] },
+      `/signup/?registration=${registrationId}`,
     ],
-    [
-      { registration: registrationId, text: 'text' },
-      `/registration/${registrationId}/signup/?text=text`,
-    ],
+    [{ text: 'text' }, `/signup/?text=text`],
   ];
 
   it.each(cases)(

--- a/src/domain/enrolments/enrolmentsTable/EnrolmentsTable.tsx
+++ b/src/domain/enrolments/enrolmentsTable/EnrolmentsTable.tsx
@@ -112,14 +112,15 @@ const EnrolmentsTable: React.FC<EnrolmentsTableProps> = ({
   const { data: enrolmentsData, loading } = useEnrolmentsQuery({
     variables: {
       ...enrolmentsVariables,
-      registration: getValue(registration.id, ''),
+      registration: [getValue(registration.id, '')],
       text: enrolmentText,
       createPath: getPathBuilder(enrolmentsPathBuilder),
     },
   });
-  const enrolments = getValue(enrolmentsData?.enrolments, []).filter(
+
+  const enrolments = getValue(enrolmentsData?.enrolments.data, []).filter(
     skipFalsyType
-  ) as EnrolmentFieldsFragment[];
+  );
 
   const enrolmentCount = enrolments.length;
   const pageCount = getPageCount(enrolmentCount, ENROLMENTS_PAGE_SIZE);

--- a/src/domain/enrolments/enrolmentsTable/EnrolmentsTable.tsx
+++ b/src/domain/enrolments/enrolmentsTable/EnrolmentsTable.tsx
@@ -80,7 +80,7 @@ const AttendeeStatusColumn: FC<ColumnProps> = ({ enrolment, registration }) => {
 
 export interface EnrolmentsTableProps {
   caption: string;
-  enrolmentsVariables: EnrolmentsQueryVariables;
+  enrolmentsVariables: Partial<EnrolmentsQueryVariables>;
   heading: string;
   pagePath: 'attendeePage' | 'waitingPage';
   registration: RegistrationFieldsFragment;
@@ -110,6 +110,7 @@ const EnrolmentsTable: React.FC<EnrolmentsTableProps> = ({
   const enrolments = filterEnrolments({
     enrolments: getValue(registration?.signups?.filter(skipFalsyType), []),
     query: {
+      registration: getValue(registration.id, ''),
       text: enrolmentText,
       ...enrolmentsVariables,
     },

--- a/src/domain/enrolments/enrolmentsTable/__tests__/EnrolmentsTable.test.tsx
+++ b/src/domain/enrolments/enrolmentsTable/__tests__/EnrolmentsTable.test.tsx
@@ -2,6 +2,7 @@ import { MockedResponse } from '@apollo/client/testing';
 import React from 'react';
 
 import { AttendeeStatus } from '../../../../generated/graphql';
+import { fakeEnrolments } from '../../../../utils/mockDataUtils';
 import {
   configure,
   loadingSpinnerIsNotInDocument,
@@ -39,7 +40,7 @@ const defaultProps: EnrolmentsTableProps = {
 };
 
 const enrolmentName = attendeeNames[0];
-const enrolmentId = attendees[0].id;
+const enrolmentId = attendees.data[0].id;
 
 const renderComponent = (mocks: MockedResponse[] = defaultMocks) => {
   return render(
@@ -60,7 +61,10 @@ const getElement = (key: 'page1' | 'page2') => {
 };
 
 test('should render enrolments table', async () => {
-  renderComponent([...defaultMocks, getMockedAttendeesResponse([])]);
+  renderComponent([
+    ...defaultMocks,
+    getMockedAttendeesResponse(fakeEnrolments(0)),
+  ]);
 
   screen.getByRole('heading', { name: 'Enrolments table' });
 

--- a/src/domain/enrolments/query.ts
+++ b/src/domain/enrolments/query.ts
@@ -4,7 +4,7 @@ import gql from 'graphql-tag';
 export const QUERY_ENROLMENTS = gql`
   query Enrolments(
     $attendeeStatus: AttendeeStatus
-    $registration: ID!
+    $registration: [ID]
     $text: String
     $createPath: Any
   ) {
@@ -12,8 +12,13 @@ export const QUERY_ENROLMENTS = gql`
       attendeeStatus: $attendeeStatus
       registration: $registration
       text: $text
-    ) @rest(type: "Enrolment", pathBuilder: $createPath) {
-      ...enrolmentFields
+    ) @rest(type: "EnrolmentsResponse", pathBuilder: $createPath) {
+      meta {
+        ...metaFields
+      }
+      data {
+        ...enrolmentFields
+      }
     }
   }
 `;

--- a/src/domain/enrolments/query.ts
+++ b/src/domain/enrolments/query.ts
@@ -4,15 +4,13 @@ import gql from 'graphql-tag';
 export const QUERY_ENROLMENTS = gql`
   query Enrolments(
     $attendeeStatus: AttendeeStatus
-    $events: [ID]
-    $registrations: [ID]
+    $registration: ID!
     $text: String
     $createPath: Any
   ) {
     enrolments(
       attendeeStatus: $attendeeStatus
-      events: $events
-      registrations: $registrations
+      registration: $registration
       text: $text
     ) @rest(type: "Enrolment", pathBuilder: $createPath) {
       ...enrolmentFields

--- a/src/domain/enrolments/utils.ts
+++ b/src/domain/enrolments/utils.ts
@@ -71,29 +71,3 @@ export const enrolmentsPathBuilder = ({
 
   return `/registration/${registration}/signup/${query}`;
 };
-
-export const filterEnrolments = ({
-  enrolments,
-  query,
-}: {
-  enrolments: EnrolmentFieldsFragment[];
-  query: EnrolmentsQueryVariables;
-}): EnrolmentFieldsFragment[] => {
-  const { attendeeStatus, text } = query;
-  let filteredEnrolments = [...enrolments];
-
-  if (attendeeStatus) {
-    filteredEnrolments = filteredEnrolments.filter(
-      (enrolment) => enrolment.attendeeStatus === attendeeStatus
-    );
-  }
-  if (text) {
-    filteredEnrolments = filteredEnrolments.filter(
-      (enrolment) =>
-        enrolment.name?.toLowerCase().includes(text.toLowerCase()) ||
-        enrolment.email?.toLowerCase().includes(text.toLowerCase()) ||
-        enrolment.phoneNumber?.toLowerCase().includes(text.toLowerCase())
-    );
-  }
-  return filteredEnrolments;
-};

--- a/src/domain/enrolments/utils.ts
+++ b/src/domain/enrolments/utils.ts
@@ -60,18 +60,16 @@ export const getEnrolmentItemId = (id: string): string =>
 export const enrolmentsPathBuilder = ({
   args,
 }: PathBuilderProps<EnrolmentsQueryVariables>): string => {
-  const { attendeeStatus, events, registrations, text } = args;
+  const { attendeeStatus, registration, text } = args;
 
   const variableToKeyItems = [
     { key: 'attendee_status', value: attendeeStatus },
-    { key: 'events', value: events },
-    { key: 'registrations', value: registrations },
     { key: 'text', value: text },
   ];
 
   const query = queryBuilder(variableToKeyItems);
 
-  return `/signup/${query}`;
+  return `/registration/${registration}/signup/${query}`;
 };
 
 export const filterEnrolments = ({

--- a/src/domain/enrolments/utils.ts
+++ b/src/domain/enrolments/utils.ts
@@ -64,10 +64,11 @@ export const enrolmentsPathBuilder = ({
 
   const variableToKeyItems = [
     { key: 'attendee_status', value: attendeeStatus },
+    { key: 'registration', value: registration },
     { key: 'text', value: text },
   ];
 
   const query = queryBuilder(variableToKeyItems);
 
-  return `/registration/${registration}/signup/${query}`;
+  return `/signup/${query}`;
 };

--- a/src/domain/registration/__mocks__/registration.ts
+++ b/src/domain/registration/__mocks__/registration.ts
@@ -7,10 +7,6 @@ import {
   fakeRegistration,
   fakeRegistrations,
 } from '../../../utils/mockDataUtils';
-import {
-  attendees,
-  waitingAttendees,
-} from '../../enrolments/__mocks__/enrolmentsPage';
 import { event } from '../../event/__mocks__/event';
 import {
   REGISTRATION_INCLUDES,
@@ -37,7 +33,7 @@ const registrationOverrides = {
   maximumAttendeeCapacity: 100,
   minimumAttendeeCapacity: 10,
   publisher: event.publisher,
-  signups: [...attendees, ...waitingAttendees],
+  signups: [],
   waitingListCapacity: 5,
 };
 

--- a/src/domain/registration/constants.ts
+++ b/src/domain/registration/constants.ts
@@ -42,12 +42,7 @@ export const REGISTRATION_INITIAL_VALUES: RegistrationFormFields = {
 
 export const REGISTRATION_SELECT_FIELDS = [REGISTRATION_FIELDS.EVENT];
 
-export const REGISTRATION_INCLUDES = [
-  'event',
-  'signups',
-  'keywords',
-  'location',
-];
+export const REGISTRATION_INCLUDES = ['event', 'keywords', 'location'];
 
 export const TEST_REGISTRATION_ID = 'registration:0';
 

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -509,7 +509,8 @@ export type MutationCreateSeatsReservationArgs = {
 
 
 export type MutationDeleteEnrolmentArgs = {
-  cancellationCode: Scalars['String'];
+  registration: Scalars['String'];
+  signup: Scalars['String'];
 };
 
 
@@ -566,6 +567,8 @@ export type MutationSendMessageArgs = {
 
 export type MutationUpdateEnrolmentArgs = {
   input: UpdateEnrolmentMutationInput;
+  registration: Scalars['String'];
+  signup: Scalars['String'];
 };
 
 
@@ -784,14 +787,14 @@ export type QueryDataSourcesArgs = {
 
 
 export type QueryEnrolmentArgs = {
-  id?: InputMaybe<Scalars['ID']>;
+  id: Scalars['ID'];
+  registration: Scalars['ID'];
 };
 
 
 export type QueryEnrolmentsArgs = {
   attendeeStatus?: InputMaybe<AttendeeStatus>;
-  events?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
-  registrations?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
+  registration: Scalars['ID'];
   text?: InputMaybe<Scalars['String']>;
 };
 
@@ -1237,7 +1240,8 @@ export type CreateEnrolmentMutationVariables = Exact<{
 export type CreateEnrolmentMutation = { __typename?: 'Mutation', createEnrolment: { __typename?: 'CreateEnrolmentResponse', attending?: { __typename?: 'EnrolmentPeopleResponse', count?: number | null, people?: Array<{ __typename?: 'EnrolmentPerson', id?: number | null, name?: string | null }> | null } | null, waitlisted?: { __typename?: 'EnrolmentPeopleResponse', count?: number | null, people?: Array<{ __typename?: 'EnrolmentPerson', id?: number | null, name?: string | null }> | null } | null } };
 
 export type DeleteEnrolmentMutationVariables = Exact<{
-  cancellationCode: Scalars['String'];
+  registration: Scalars['String'];
+  signup: Scalars['String'];
 }>;
 
 
@@ -1245,6 +1249,8 @@ export type DeleteEnrolmentMutation = { __typename?: 'Mutation', deleteEnrolment
 
 export type UpdateEnrolmentMutationVariables = Exact<{
   input: UpdateEnrolmentMutationInput;
+  registration: Scalars['String'];
+  signup: Scalars['String'];
 }>;
 
 
@@ -1268,6 +1274,7 @@ export type EnrolmentFieldsFragment = { __typename?: 'Enrolment', id: string, at
 
 export type EnrolmentQueryVariables = Exact<{
   id: Scalars['ID'];
+  registration: Scalars['ID'];
   createPath?: InputMaybe<Scalars['Any']>;
 }>;
 
@@ -1276,8 +1283,7 @@ export type EnrolmentQuery = { __typename?: 'Query', enrolment: { __typename?: '
 
 export type EnrolmentsQueryVariables = Exact<{
   attendeeStatus?: InputMaybe<AttendeeStatus>;
-  events?: InputMaybe<Array<InputMaybe<Scalars['ID']>> | InputMaybe<Scalars['ID']>>;
-  registrations?: InputMaybe<Array<InputMaybe<Scalars['ID']>> | InputMaybe<Scalars['ID']>>;
+  registration: Scalars['ID'];
   text?: InputMaybe<Scalars['String']>;
   createPath?: InputMaybe<Scalars['Any']>;
 }>;
@@ -2247,8 +2253,8 @@ export type CreateEnrolmentMutationHookResult = ReturnType<typeof useCreateEnrol
 export type CreateEnrolmentMutationResult = Apollo.MutationResult<CreateEnrolmentMutation>;
 export type CreateEnrolmentMutationOptions = Apollo.BaseMutationOptions<CreateEnrolmentMutation, CreateEnrolmentMutationVariables>;
 export const DeleteEnrolmentDocument = gql`
-    mutation DeleteEnrolment($cancellationCode: String!) {
-  deleteEnrolment(cancellationCode: $cancellationCode) @rest(type: "NoContent", path: "/signup/{args.cancellationCode}", method: "DELETE") {
+    mutation DeleteEnrolment($registration: String!, $signup: String!) {
+  deleteEnrolment(registration: $registration, signup: $signup) @rest(type: "NoContent", path: "/registration/{args.registration}/signup/{args.signup}/", method: "DELETE") {
     noContent
   }
 }
@@ -2268,7 +2274,8 @@ export type DeleteEnrolmentMutationFn = Apollo.MutationFunction<DeleteEnrolmentM
  * @example
  * const [deleteEnrolmentMutation, { data, loading, error }] = useDeleteEnrolmentMutation({
  *   variables: {
- *      cancellationCode: // value for 'cancellationCode'
+ *      registration: // value for 'registration'
+ *      signup: // value for 'signup'
  *   },
  * });
  */
@@ -2280,8 +2287,8 @@ export type DeleteEnrolmentMutationHookResult = ReturnType<typeof useDeleteEnrol
 export type DeleteEnrolmentMutationResult = Apollo.MutationResult<DeleteEnrolmentMutation>;
 export type DeleteEnrolmentMutationOptions = Apollo.BaseMutationOptions<DeleteEnrolmentMutation, DeleteEnrolmentMutationVariables>;
 export const UpdateEnrolmentDocument = gql`
-    mutation UpdateEnrolment($input: UpdateEnrolmentMutationInput!) {
-  updateEnrolment(input: $input) @rest(type: "Enrolment", path: "/signup_edit/{args.input.id}/", method: "PUT", bodyKey: "input") {
+    mutation UpdateEnrolment($input: UpdateEnrolmentMutationInput!, $registration: String!, $signup: String!) {
+  updateEnrolment(input: $input, registration: $registration, signup: $signup) @rest(type: "Enrolment", path: "/registration/{args.registration}/signup/{args.signup}/", method: "PUT", bodyKey: "input") {
     ...enrolmentFields
   }
 }
@@ -2302,6 +2309,8 @@ export type UpdateEnrolmentMutationFn = Apollo.MutationFunction<UpdateEnrolmentM
  * const [updateEnrolmentMutation, { data, loading, error }] = useUpdateEnrolmentMutation({
  *   variables: {
  *      input: // value for 'input'
+ *      registration: // value for 'registration'
+ *      signup: // value for 'signup'
  *   },
  * });
  */
@@ -2350,8 +2359,8 @@ export type SendMessageMutationHookResult = ReturnType<typeof useSendMessageMuta
 export type SendMessageMutationResult = Apollo.MutationResult<SendMessageMutation>;
 export type SendMessageMutationOptions = Apollo.BaseMutationOptions<SendMessageMutation, SendMessageMutationVariables>;
 export const EnrolmentDocument = gql`
-    query Enrolment($id: ID!, $createPath: Any) {
-  enrolment(id: $id) @rest(type: "Enrolment", pathBuilder: $createPath) {
+    query Enrolment($id: ID!, $registration: ID!, $createPath: Any) {
+  enrolment(id: $id, registration: $registration) @rest(type: "Enrolment", pathBuilder: $createPath) {
     ...enrolmentFields
   }
 }
@@ -2370,6 +2379,7 @@ export const EnrolmentDocument = gql`
  * const { data, loading, error } = useEnrolmentQuery({
  *   variables: {
  *      id: // value for 'id'
+ *      registration: // value for 'registration'
  *      createPath: // value for 'createPath'
  *   },
  * });
@@ -2386,11 +2396,10 @@ export type EnrolmentQueryHookResult = ReturnType<typeof useEnrolmentQuery>;
 export type EnrolmentLazyQueryHookResult = ReturnType<typeof useEnrolmentLazyQuery>;
 export type EnrolmentQueryResult = Apollo.QueryResult<EnrolmentQuery, EnrolmentQueryVariables>;
 export const EnrolmentsDocument = gql`
-    query Enrolments($attendeeStatus: AttendeeStatus, $events: [ID], $registrations: [ID], $text: String, $createPath: Any) {
+    query Enrolments($attendeeStatus: AttendeeStatus, $registration: ID!, $text: String, $createPath: Any) {
   enrolments(
     attendeeStatus: $attendeeStatus
-    events: $events
-    registrations: $registrations
+    registration: $registration
     text: $text
   ) @rest(type: "Enrolment", pathBuilder: $createPath) {
     ...enrolmentFields
@@ -2411,14 +2420,13 @@ export const EnrolmentsDocument = gql`
  * const { data, loading, error } = useEnrolmentsQuery({
  *   variables: {
  *      attendeeStatus: // value for 'attendeeStatus'
- *      events: // value for 'events'
- *      registrations: // value for 'registrations'
+ *      registration: // value for 'registration'
  *      text: // value for 'text'
  *      createPath: // value for 'createPath'
  *   },
  * });
  */
-export function useEnrolmentsQuery(baseOptions?: Apollo.QueryHookOptions<EnrolmentsQuery, EnrolmentsQueryVariables>) {
+export function useEnrolmentsQuery(baseOptions: Apollo.QueryHookOptions<EnrolmentsQuery, EnrolmentsQueryVariables>) {
         const options = {...defaultOptions, ...baseOptions}
         return Apollo.useQuery<EnrolmentsQuery, EnrolmentsQueryVariables>(EnrolmentsDocument, options);
       }

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -22,6 +22,7 @@ export enum AttendeeStatus {
 }
 
 export type CreateEnrolmentMutationInput = {
+  registration?: InputMaybe<Scalars['String']>;
   reservationCode?: InputMaybe<Scalars['String']>;
   signups?: InputMaybe<Array<SignupInput>>;
 };
@@ -197,6 +198,12 @@ export type EnrolmentPerson = {
   __typename?: 'EnrolmentPerson';
   id?: Maybe<Scalars['Int']>;
   name?: Maybe<Scalars['String']>;
+};
+
+export type EnrolmentsResponse = {
+  __typename?: 'EnrolmentsResponse';
+  data: Array<Enrolment>;
+  meta: Meta;
 };
 
 export type Event = {
@@ -464,7 +471,6 @@ export type Mutation = {
 
 export type MutationCreateEnrolmentArgs = {
   input: CreateEnrolmentMutationInput;
-  registration?: InputMaybe<Scalars['String']>;
 };
 
 
@@ -509,7 +515,6 @@ export type MutationCreateSeatsReservationArgs = {
 
 
 export type MutationDeleteEnrolmentArgs = {
-  registration: Scalars['String'];
   signup: Scalars['String'];
 };
 
@@ -567,7 +572,6 @@ export type MutationSendMessageArgs = {
 
 export type MutationUpdateEnrolmentArgs = {
   input: UpdateEnrolmentMutationInput;
-  registration: Scalars['String'];
   signup: Scalars['String'];
 };
 
@@ -752,7 +756,7 @@ export type Query = {
   dataSource: DataSource;
   dataSources: DataSourcesResponse;
   enrolment: Enrolment;
-  enrolments: Array<Maybe<Enrolment>>;
+  enrolments: EnrolmentsResponse;
   event: Event;
   events: EventsResponse;
   image: Image;
@@ -788,13 +792,12 @@ export type QueryDataSourcesArgs = {
 
 export type QueryEnrolmentArgs = {
   id: Scalars['ID'];
-  registration: Scalars['ID'];
 };
 
 
 export type QueryEnrolmentsArgs = {
   attendeeStatus?: InputMaybe<AttendeeStatus>;
-  registration: Scalars['ID'];
+  registration?: InputMaybe<Array<InputMaybe<Scalars['ID']>>>;
   text?: InputMaybe<Scalars['String']>;
 };
 
@@ -1233,14 +1236,12 @@ export type DataSourcesQuery = { __typename?: 'Query', dataSources: { __typename
 
 export type CreateEnrolmentMutationVariables = Exact<{
   input: CreateEnrolmentMutationInput;
-  registration: Scalars['String'];
 }>;
 
 
 export type CreateEnrolmentMutation = { __typename?: 'Mutation', createEnrolment: { __typename?: 'CreateEnrolmentResponse', attending?: { __typename?: 'EnrolmentPeopleResponse', count?: number | null, people?: Array<{ __typename?: 'EnrolmentPerson', id?: number | null, name?: string | null }> | null } | null, waitlisted?: { __typename?: 'EnrolmentPeopleResponse', count?: number | null, people?: Array<{ __typename?: 'EnrolmentPerson', id?: number | null, name?: string | null }> | null } | null } };
 
 export type DeleteEnrolmentMutationVariables = Exact<{
-  registration: Scalars['String'];
   signup: Scalars['String'];
 }>;
 
@@ -1249,7 +1250,6 @@ export type DeleteEnrolmentMutation = { __typename?: 'Mutation', deleteEnrolment
 
 export type UpdateEnrolmentMutationVariables = Exact<{
   input: UpdateEnrolmentMutationInput;
-  registration: Scalars['String'];
   signup: Scalars['String'];
 }>;
 
@@ -1274,7 +1274,6 @@ export type EnrolmentFieldsFragment = { __typename?: 'Enrolment', id: string, at
 
 export type EnrolmentQueryVariables = Exact<{
   id: Scalars['ID'];
-  registration: Scalars['ID'];
   createPath?: InputMaybe<Scalars['Any']>;
 }>;
 
@@ -1283,13 +1282,13 @@ export type EnrolmentQuery = { __typename?: 'Query', enrolment: { __typename?: '
 
 export type EnrolmentsQueryVariables = Exact<{
   attendeeStatus?: InputMaybe<AttendeeStatus>;
-  registration: Scalars['ID'];
+  registration?: InputMaybe<Array<InputMaybe<Scalars['ID']>> | InputMaybe<Scalars['ID']>>;
   text?: InputMaybe<Scalars['String']>;
   createPath?: InputMaybe<Scalars['Any']>;
 }>;
 
 
-export type EnrolmentsQuery = { __typename?: 'Query', enrolments: Array<{ __typename?: 'Enrolment', id: string, attendeeStatus?: AttendeeStatus | null, cancellationCode?: string | null, city?: string | null, dateOfBirth?: string | null, email?: string | null, extraInfo?: string | null, membershipNumber?: string | null, name?: string | null, nativeLanguage?: string | null, notifications?: string | null, phoneNumber?: string | null, serviceLanguage?: string | null, streetAddress?: string | null, zipcode?: string | null } | null> };
+export type EnrolmentsQuery = { __typename?: 'Query', enrolments: { __typename?: 'EnrolmentsResponse', meta: { __typename?: 'Meta', count: number, next?: string | null, previous?: string | null }, data: Array<{ __typename?: 'Enrolment', id: string, attendeeStatus?: AttendeeStatus | null, cancellationCode?: string | null, city?: string | null, dateOfBirth?: string | null, email?: string | null, extraInfo?: string | null, membershipNumber?: string | null, name?: string | null, nativeLanguage?: string | null, notifications?: string | null, phoneNumber?: string | null, serviceLanguage?: string | null, streetAddress?: string | null, zipcode?: string | null }> } };
 
 export type CreateEventMutationVariables = Exact<{
   input: CreateEventMutationInput;
@@ -2219,8 +2218,8 @@ export type DataSourcesQueryHookResult = ReturnType<typeof useDataSourcesQuery>;
 export type DataSourcesLazyQueryHookResult = ReturnType<typeof useDataSourcesLazyQuery>;
 export type DataSourcesQueryResult = Apollo.QueryResult<DataSourcesQuery, DataSourcesQueryVariables>;
 export const CreateEnrolmentDocument = gql`
-    mutation CreateEnrolment($input: CreateEnrolmentMutationInput!, $registration: String!) {
-  createEnrolment(input: $input, registration: $registration) @rest(type: "CreateEnrolmentResponse", path: "/registration/{args.registration}/signup/", method: "POST", bodyKey: "input") {
+    mutation CreateEnrolment($input: CreateEnrolmentMutationInput!) {
+  createEnrolment(input: $input) @rest(type: "CreateEnrolmentResponse", path: "/signup/", method: "POST", bodyKey: "input") {
     ...createEnrolmentFields
   }
 }
@@ -2241,7 +2240,6 @@ export type CreateEnrolmentMutationFn = Apollo.MutationFunction<CreateEnrolmentM
  * const [createEnrolmentMutation, { data, loading, error }] = useCreateEnrolmentMutation({
  *   variables: {
  *      input: // value for 'input'
- *      registration: // value for 'registration'
  *   },
  * });
  */
@@ -2253,8 +2251,8 @@ export type CreateEnrolmentMutationHookResult = ReturnType<typeof useCreateEnrol
 export type CreateEnrolmentMutationResult = Apollo.MutationResult<CreateEnrolmentMutation>;
 export type CreateEnrolmentMutationOptions = Apollo.BaseMutationOptions<CreateEnrolmentMutation, CreateEnrolmentMutationVariables>;
 export const DeleteEnrolmentDocument = gql`
-    mutation DeleteEnrolment($registration: String!, $signup: String!) {
-  deleteEnrolment(registration: $registration, signup: $signup) @rest(type: "NoContent", path: "/registration/{args.registration}/signup/{args.signup}/", method: "DELETE") {
+    mutation DeleteEnrolment($signup: String!) {
+  deleteEnrolment(signup: $signup) @rest(type: "NoContent", path: "/signup/{args.signup}/", method: "DELETE") {
     noContent
   }
 }
@@ -2274,7 +2272,6 @@ export type DeleteEnrolmentMutationFn = Apollo.MutationFunction<DeleteEnrolmentM
  * @example
  * const [deleteEnrolmentMutation, { data, loading, error }] = useDeleteEnrolmentMutation({
  *   variables: {
- *      registration: // value for 'registration'
  *      signup: // value for 'signup'
  *   },
  * });
@@ -2287,8 +2284,8 @@ export type DeleteEnrolmentMutationHookResult = ReturnType<typeof useDeleteEnrol
 export type DeleteEnrolmentMutationResult = Apollo.MutationResult<DeleteEnrolmentMutation>;
 export type DeleteEnrolmentMutationOptions = Apollo.BaseMutationOptions<DeleteEnrolmentMutation, DeleteEnrolmentMutationVariables>;
 export const UpdateEnrolmentDocument = gql`
-    mutation UpdateEnrolment($input: UpdateEnrolmentMutationInput!, $registration: String!, $signup: String!) {
-  updateEnrolment(input: $input, registration: $registration, signup: $signup) @rest(type: "Enrolment", path: "/registration/{args.registration}/signup/{args.signup}/", method: "PUT", bodyKey: "input") {
+    mutation UpdateEnrolment($input: UpdateEnrolmentMutationInput!, $signup: String!) {
+  updateEnrolment(input: $input, signup: $signup) @rest(type: "Enrolment", path: "/signup/{args.signup}/", method: "PUT", bodyKey: "input") {
     ...enrolmentFields
   }
 }
@@ -2309,7 +2306,6 @@ export type UpdateEnrolmentMutationFn = Apollo.MutationFunction<UpdateEnrolmentM
  * const [updateEnrolmentMutation, { data, loading, error }] = useUpdateEnrolmentMutation({
  *   variables: {
  *      input: // value for 'input'
- *      registration: // value for 'registration'
  *      signup: // value for 'signup'
  *   },
  * });
@@ -2359,8 +2355,8 @@ export type SendMessageMutationHookResult = ReturnType<typeof useSendMessageMuta
 export type SendMessageMutationResult = Apollo.MutationResult<SendMessageMutation>;
 export type SendMessageMutationOptions = Apollo.BaseMutationOptions<SendMessageMutation, SendMessageMutationVariables>;
 export const EnrolmentDocument = gql`
-    query Enrolment($id: ID!, $registration: ID!, $createPath: Any) {
-  enrolment(id: $id, registration: $registration) @rest(type: "Enrolment", pathBuilder: $createPath) {
+    query Enrolment($id: ID!, $createPath: Any) {
+  enrolment(id: $id) @rest(type: "Enrolment", pathBuilder: $createPath) {
     ...enrolmentFields
   }
 }
@@ -2379,7 +2375,6 @@ export const EnrolmentDocument = gql`
  * const { data, loading, error } = useEnrolmentQuery({
  *   variables: {
  *      id: // value for 'id'
- *      registration: // value for 'registration'
  *      createPath: // value for 'createPath'
  *   },
  * });
@@ -2396,16 +2391,22 @@ export type EnrolmentQueryHookResult = ReturnType<typeof useEnrolmentQuery>;
 export type EnrolmentLazyQueryHookResult = ReturnType<typeof useEnrolmentLazyQuery>;
 export type EnrolmentQueryResult = Apollo.QueryResult<EnrolmentQuery, EnrolmentQueryVariables>;
 export const EnrolmentsDocument = gql`
-    query Enrolments($attendeeStatus: AttendeeStatus, $registration: ID!, $text: String, $createPath: Any) {
+    query Enrolments($attendeeStatus: AttendeeStatus, $registration: [ID], $text: String, $createPath: Any) {
   enrolments(
     attendeeStatus: $attendeeStatus
     registration: $registration
     text: $text
-  ) @rest(type: "Enrolment", pathBuilder: $createPath) {
-    ...enrolmentFields
+  ) @rest(type: "EnrolmentsResponse", pathBuilder: $createPath) {
+    meta {
+      ...metaFields
+    }
+    data {
+      ...enrolmentFields
+    }
   }
 }
-    ${EnrolmentFieldsFragmentDoc}`;
+    ${MetaFieldsFragmentDoc}
+${EnrolmentFieldsFragmentDoc}`;
 
 /**
  * __useEnrolmentsQuery__
@@ -2426,7 +2427,7 @@ export const EnrolmentsDocument = gql`
  *   },
  * });
  */
-export function useEnrolmentsQuery(baseOptions: Apollo.QueryHookOptions<EnrolmentsQuery, EnrolmentsQueryVariables>) {
+export function useEnrolmentsQuery(baseOptions?: Apollo.QueryHookOptions<EnrolmentsQuery, EnrolmentsQueryVariables>) {
         const options = {...defaultOptions, ...baseOptions}
         return Apollo.useQuery<EnrolmentsQuery, EnrolmentsQueryVariables>(EnrolmentsDocument, options);
       }

--- a/src/utils/mockDataUtils.ts
+++ b/src/utils/mockDataUtils.ts
@@ -18,6 +18,7 @@ import {
   Enrolment,
   EnrolmentPeopleResponse,
   EnrolmentPerson,
+  EnrolmentsResponse,
   Event,
   EventsResponse,
   EventStatus,
@@ -83,9 +84,12 @@ export const fakeDataSource = (overrides?: Partial<DataSource>): DataSource => {
 
 export const fakeEnrolments = (
   count = 1,
-  enrolments: Partial<Enrolment>[]
-): Enrolment[] =>
-  generateNodeArray((i) => fakeEnrolment(enrolments?.[i]), count);
+  enrolments?: Partial<Enrolment>[]
+): EnrolmentsResponse => ({
+  data: generateNodeArray((i) => fakeEnrolment(enrolments?.[i]), count),
+  meta: fakeMeta(count),
+  __typename: 'EnrolmentsResponse',
+});
 
 export const fakeEnrolment = (overrides?: Partial<Enrolment>): Enrolment => {
   const id = overrides?.id || faker.datatype.uuid();


### PR DESCRIPTION
## Description :sparkles:
Unify signup endpoint addresses with API
Get enrolment from the dedicated endpoint instead of using include signups parameter

## Closes
[LINK-1029](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1029)
[LINK-1032](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1032)

## Additional notes
BE PR: https://github.com/City-of-Helsinki/linkedevents/pull/583


[LINK-1029]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1029?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LINK-1032]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1032?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ