### PR TITLE
Added Email button for the event list page

### DIFF
--- a/src/domain/app/i18n/en.json
+++ b/src/domain/app/i18n/en.json
@@ -517,6 +517,7 @@
         "warningNotAuthenticated": "If you want to publish this event, you must first login."
       },
       "buttonPostpone": "Postpone event",
+      "buttonSendEmail": "Send email",
       "buttonPublish": {
         "course": "Publish course",
         "general": "Publish event",
@@ -538,7 +539,8 @@
         "warningCannotPublishSubEvent": "A sub event of a series cannot be published.",
         "warningDeletedEvent": "Deleted events can't be edited.",
         "warningEventInPast": "Past events can't be edited.",
-        "warningNoRightsToEdit": "You have insufficient rights to edit this event."
+        "warningNoRightsToEdit": "You have insufficient rights to edit this event.",
+        "warningNoEmailFound": "Could not find email address linked to this event"
       },
       "helperUmbrellaEvent": "Note. An umbrella event must be created before you can add subevents to it.",
       "infoTextAttendeeCapacity": {

--- a/src/domain/app/i18n/fi.json
+++ b/src/domain/app/i18n/fi.json
@@ -540,7 +540,7 @@
         "warningDeletedEvent": "Poistettuja tapahtumia ei voi muokata.",
         "warningEventInPast": "Menneisyydessä olevia tapahtumia ei voi muokata.",
         "warningNoRightsToEdit": "Sinulla ei ole oikeuksia muokata tätä tapahtumaa.",
-        "warningNoEmailFound": "Could not find email address linked to this event"
+        "warningNoEmailFound": "Tähän tapahtumaan ei liity sähköpostiosoitetta."
       },
       "helperUmbrellaEvent": "Huom. Kattotapahtuma täytyy luoda ennen kuin voit lisätä sille alatapahtumia.",
       "infoTextAttendeeCapacity": {

--- a/src/domain/app/i18n/fi.json
+++ b/src/domain/app/i18n/fi.json
@@ -517,6 +517,7 @@
         "warningNotAuthenticated": "Jos haluat julkaista tapahtuman, kirjaudu ensin sisään."
       },
       "buttonPostpone": "Lykkää tapahtumaa",
+      "buttonSendEmail": "Lähetä sähköposti",
       "buttonPublish": {
         "course": "Julkaise kurssi",
         "general": "Julkaise tapahtuma",
@@ -538,7 +539,8 @@
         "warningCannotPublishSubEvent": "Sarjan alatapahtumia ei voi julkaista.",
         "warningDeletedEvent": "Poistettuja tapahtumia ei voi muokata.",
         "warningEventInPast": "Menneisyydessä olevia tapahtumia ei voi muokata.",
-        "warningNoRightsToEdit": "Sinulla ei ole oikeuksia muokata tätä tapahtumaa."
+        "warningNoRightsToEdit": "Sinulla ei ole oikeuksia muokata tätä tapahtumaa.",
+        "warningNoEmailFound": "Could not find email address linked to this event"
       },
       "helperUmbrellaEvent": "Huom. Kattotapahtuma täytyy luoda ennen kuin voit lisätä sille alatapahtumia.",
       "infoTextAttendeeCapacity": {

--- a/src/domain/app/i18n/sv.json
+++ b/src/domain/app/i18n/sv.json
@@ -540,7 +540,7 @@
         "warningDeletedEvent": "Raderade evenemang kan inte redigeras.",
         "warningEventInPast": "Tidigare evenemnag kan inte redigeras.",
         "warningNoRightsToEdit": "Du har inte tillräckliga rättigheter för att redigera detta evenemang.",
-        "warningNoEmailFound": "Could not find email address linked to this event"
+        "warningNoEmailFound": "E-postadressen som är kopplad till denna evenemang kunde inte hittas"
       },
       "helperUmbrellaEvent": "Notera. Ett huvudevenemang måste skapas innan du kan lägga till underevenemangen till det.",
       "infoTextAttendeeCapacity": {

--- a/src/domain/app/i18n/sv.json
+++ b/src/domain/app/i18n/sv.json
@@ -517,6 +517,7 @@
         "warningNotAuthenticated": "Om du vill publicera evenemanget måste du först logga in."
       },
       "buttonPostpone": "Skjut upp",
+      "buttonSendEmail": "Skicka epost",
       "buttonPublish": {
         "course": "Publicera kursen",
         "general": "Publicera evenemanget",
@@ -538,7 +539,8 @@
         "warningCannotPublishSubEvent": "Ett underevenemang i en serie kan inte publiceras.",
         "warningDeletedEvent": "Raderade evenemang kan inte redigeras.",
         "warningEventInPast": "Tidigare evenemnag kan inte redigeras.",
-        "warningNoRightsToEdit": "Du har inte tillräckliga rättigheter för att redigera detta evenemang."
+        "warningNoRightsToEdit": "Du har inte tillräckliga rättigheter för att redigera detta evenemang.",
+        "warningNoEmailFound": "Could not find email address linked to this event"
       },
       "helperUmbrellaEvent": "Notera. Ett huvudevenemang måste skapas innan du kan lägga till underevenemangen till det.",
       "infoTextAttendeeCapacity": {

--- a/src/domain/event/constants.tsx
+++ b/src/domain/event/constants.tsx
@@ -5,6 +5,7 @@ import {
   IconCheck,
   IconCogwheel,
   IconCross,
+  IconEnvelope,
   IconPen,
 } from 'hds-react';
 import React from 'react';
@@ -234,6 +235,7 @@ export enum EVENT_ACTIONS {
   PUBLISH = 'publish',
   UPDATE_DRAFT = 'updateDraft',
   UPDATE_PUBLIC = 'updatePublic',
+  SEND_EMAIL = 'sendEmail',
 }
 
 export const SUB_EVENTS_VARIABLES: EventsQueryVariables = {
@@ -282,6 +284,7 @@ export const EVENT_ICONS = {
   [EVENT_ACTIONS.PUBLISH]: <IconCheck aria-hidden={true} />,
   [EVENT_ACTIONS.UPDATE_DRAFT]: <IconPen aria-hidden={true} />,
   [EVENT_ACTIONS.UPDATE_PUBLIC]: <IconPen aria-hidden={true} />,
+  [EVENT_ACTIONS.SEND_EMAIL]: <IconEnvelope aria-hidden={true} />,
 };
 
 export const EVENT_LABEL_KEYS = {
@@ -295,6 +298,7 @@ export const EVENT_LABEL_KEYS = {
   [EVENT_ACTIONS.PUBLISH]: 'event.form.buttonPublish',
   [EVENT_ACTIONS.UPDATE_DRAFT]: 'event.form.buttonUpdateDraft',
   [EVENT_ACTIONS.UPDATE_PUBLIC]: 'event.form.buttonUpdatePublic',
+  [EVENT_ACTIONS.SEND_EMAIL]: 'event.form.buttonSendEmail',
 };
 
 export const ADD_EVENT_TIME_FORM_NAME = 'add-event-time';

--- a/src/domain/event/utils.ts
+++ b/src/domain/event/utils.ts
@@ -1071,9 +1071,9 @@ export const checkCanUserDoAction = ({
   organizationAncestors: OrganizationFieldsFragment[];
   user?: UserFieldsFragment;
 }): boolean => {
-  const { isDraft, publisher } = event
+  const { isDraft, publisher, createdBy } = event
     ? getEventFields(event, 'fi')
-    : { isDraft: true, publisher: selectedPublisher };
+    : { isDraft: true, publisher: selectedPublisher, createdBy: undefined };
 
   const isRegularUser = isReqularUserInOrganization({
     id: publisher,
@@ -1101,10 +1101,13 @@ export const checkCanUserDoAction = ({
     case EVENT_ACTIONS.ACCEPT_AND_PUBLISH:
     case EVENT_ACTIONS.PUBLISH:
     case EVENT_ACTIONS.UPDATE_PUBLIC:
+    case EVENT_ACTIONS.SEND_EMAIL:
       return isAdminUser;
     case EVENT_ACTIONS.UPDATE_DRAFT:
       return isRegularUser || isAdminUser;
   }
+
+  return false;
 };
 
 export const getIsButtonVisible = ({
@@ -1127,6 +1130,7 @@ export const getIsButtonVisible = ({
     case EVENT_ACTIONS.ACCEPT_AND_PUBLISH:
       return isDraft && userCanDoAction;
     case EVENT_ACTIONS.CREATE_DRAFT:
+    case EVENT_ACTIONS.SEND_EMAIL:
       return userCanDoAction;
     case EVENT_ACTIONS.PUBLISH:
       return !authenticated || userCanDoAction;
@@ -1135,6 +1139,10 @@ export const getIsButtonVisible = ({
     case EVENT_ACTIONS.UPDATE_PUBLIC:
       return isPublic;
   }
+};
+
+const validateCreatedBy = (createdBy: string | null | undefined): boolean => {
+  return createdBy !== (null || undefined || '' || ' - ');
 };
 
 const getCreateEventActionWarning = ({
@@ -1206,8 +1214,13 @@ const getUpdateEventActionWarning = (
   }
 ) => {
   const { action, authenticated, event, t, userCanDoAction } = props;
-  const { deleted, eventStatus, isDraft } = getEventFields(event, 'fi');
+  const { deleted, eventStatus, isDraft, createdBy } = getEventFields(
+    event,
+    'fi'
+  );
   const isCancelled = eventStatus === EventStatus.EventCancelled;
+
+  const noEmailFound = !validateCreatedBy(createdBy);
 
   const isInThePast = isEventInThePast(event);
 
@@ -1233,6 +1246,10 @@ const getUpdateEventActionWarning = (
 
   if (isInThePast && NOT_ALLOWED_WHEN_IN_PAST.includes(action)) {
     return t('event.form.editButtonPanel.warningEventInPast');
+  }
+
+  if (noEmailFound && action == EVENT_ACTIONS.SEND_EMAIL) {
+    return t('event.form.editButtonPanel.warningNoEmailFound');
   }
 
   if (isDraft) {

--- a/src/domain/event/utils.ts
+++ b/src/domain/event/utils.ts
@@ -1071,9 +1071,9 @@ export const checkCanUserDoAction = ({
   organizationAncestors: OrganizationFieldsFragment[];
   user?: UserFieldsFragment;
 }): boolean => {
-  const { isDraft, publisher, createdBy } = event
+  const { isDraft, publisher } = event
     ? getEventFields(event, 'fi')
-    : { isDraft: true, publisher: selectedPublisher, createdBy: undefined };
+    : { isDraft: true, publisher: selectedPublisher };
 
   const isRegularUser = isReqularUserInOrganization({
     id: publisher,
@@ -1105,9 +1105,9 @@ export const checkCanUserDoAction = ({
       return isAdminUser;
     case EVENT_ACTIONS.UPDATE_DRAFT:
       return isRegularUser || isAdminUser;
+    default:
+      return false;
   }
-
-  return false;
 };
 
 export const getIsButtonVisible = ({
@@ -1142,7 +1142,7 @@ export const getIsButtonVisible = ({
 };
 
 const validateCreatedBy = (createdBy: string | null | undefined): boolean => {
-  return createdBy !== (null || undefined || '' || ' - ');
+  return !!createdBy && createdBy !== ' - ';
 };
 
 const getCreateEventActionWarning = ({
@@ -1248,7 +1248,7 @@ const getUpdateEventActionWarning = (
     return t('event.form.editButtonPanel.warningEventInPast');
   }
 
-  if (noEmailFound && action == EVENT_ACTIONS.SEND_EMAIL) {
+  if (noEmailFound && action === EVENT_ACTIONS.SEND_EMAIL) {
     return t('event.form.editButtonPanel.warningNoEmailFound');
   }
 

--- a/src/domain/events/eventActionsDropdown/EventActionsDropdown.tsx
+++ b/src/domain/events/eventActionsDropdown/EventActionsDropdown.tsx
@@ -8,6 +8,7 @@ import { ROUTES } from '../../../constants';
 import { EventFieldsFragment } from '../../../generated/graphql';
 import useLocale from '../../../hooks/useLocale';
 import useQueryStringWithReturnPath from '../../../hooks/useQueryStringWithReturnPath';
+import getLocalisedString from '../../../utils/getLocalisedString';
 import getValue from '../../../utils/getValue';
 import skipFalsyType from '../../../utils/skipFalsyType';
 import { useAuth } from '../../auth/hooks/useAuth';
@@ -64,6 +65,18 @@ const EventActionsDropdown: React.FC<EventActionsDropdownProps> = ({
     navigate(`/${locale}${ROUTES.CREATE_EVENT}`);
   };
 
+  const sendEmail = () => {
+    let targetEmail = '';
+    if (event.createdBy != null && event.createdBy != undefined) {
+      targetEmail = event.createdBy.split('-')[1].trim();
+    }
+    window.location.href =
+      'mailto:' +
+      targetEmail +
+      '?subject=' +
+      getLocalisedString(event.name, locale);
+  };
+
   const getActionItemProps = ({
     action,
     onClick,
@@ -90,6 +103,10 @@ const EventActionsDropdown: React.FC<EventActionsDropdownProps> = ({
     getActionItemProps({
       action: EVENT_ACTIONS.COPY,
       onClick: copyEvent,
+    }),
+    getActionItemProps({
+      action: EVENT_ACTIONS.SEND_EMAIL,
+      onClick: sendEmail,
     }),
     getActionItemProps({
       action: EVENT_ACTIONS.POSTPONE,

--- a/src/domain/events/eventActionsDropdown/EventActionsDropdown.tsx
+++ b/src/domain/events/eventActionsDropdown/EventActionsDropdown.tsx
@@ -67,7 +67,7 @@ const EventActionsDropdown: React.FC<EventActionsDropdownProps> = ({
 
   const sendEmail = () => {
     let targetEmail = '';
-    if (event.createdBy != null && event.createdBy != undefined) {
+    if (event.createdBy) {
       targetEmail = event.createdBy.split('-')[1].trim();
     }
     window.location.href =

--- a/src/domain/events/eventActionsDropdown/__tests__/EventActionsDropdown.test.tsx
+++ b/src/domain/events/eventActionsDropdown/__tests__/EventActionsDropdown.test.tsx
@@ -60,7 +60,7 @@ const renderComponent = ({
   });
 
 const getElement = (
-  key: 'cancel' | 'copy' | 'delete' | 'edit' | 'menu' | 'postpone' | 'toggle'
+  key: 'cancel' | 'copy' | 'delete' | 'edit' | 'menu' | 'postpone' | 'toggle' | 'email'
 ) => {
   switch (key) {
     case 'cancel':
@@ -77,6 +77,8 @@ const getElement = (
       return screen.getByRole('button', { name: 'Lykkää tapahtumaa' });
     case 'toggle':
       return screen.getByRole('button', { name: /valinnat/i });
+    case 'email':
+      return screen.getByRole('button', { name: 'Lähetä sähköposti'});
   }
 };
 
@@ -284,4 +286,32 @@ test('should postpone event', async () => {
   await waitFor(() =>
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
   );
+});
+
+test('should call the mailto function when clicking Send Email button', async () => {
+  const mocks: MockedResponse[] = [
+    ...defaultMocks
+  ];
+
+  const originalLocation = window.location;
+
+  delete window.location;
+
+  window.location = {href: ''}
+  let specialEvent = {... event};
+  specialEvent.createdBy = 'Jaska Jokunen - testisähköposti@testidomaini.fi';
+  
+  const user = userEvent.setup();
+  renderComponent({authContextValue, props: { event: specialEvent }, mocks });
+
+  await openMenu();
+
+  const sendMailButton = getElement('email');
+  await user.click(sendMailButton);
+
+  await waitFor(() =>
+    expect(window.location.href).toBe("mailto:testisähköposti@testidomaini.fi?subject=Name fi")
+  );
+
+  window.location = originalLocation;
 });

--- a/src/domain/events/eventActionsDropdown/__tests__/EventActionsDropdown.test.tsx
+++ b/src/domain/events/eventActionsDropdown/__tests__/EventActionsDropdown.test.tsx
@@ -60,7 +60,15 @@ const renderComponent = ({
   });
 
 const getElement = (
-  key: 'cancel' | 'copy' | 'delete' | 'edit' | 'menu' | 'postpone' | 'toggle' | 'email'
+  key:
+    | 'cancel'
+    | 'copy'
+    | 'delete'
+    | 'edit'
+    | 'menu'
+    | 'postpone'
+    | 'toggle'
+    | 'email'
 ) => {
   switch (key) {
     case 'cancel':
@@ -78,7 +86,7 @@ const getElement = (
     case 'toggle':
       return screen.getByRole('button', { name: /valinnat/i });
     case 'email':
-      return screen.getByRole('button', { name: 'Lähetä sähköposti'});
+      return screen.getByRole('button', { name: 'Lähetä sähköposti' });
   }
 };
 
@@ -289,20 +297,18 @@ test('should postpone event', async () => {
 });
 
 test('should call the mailto function when clicking Send Email button', async () => {
-  const mocks: MockedResponse[] = [
-    ...defaultMocks
-  ];
+  const mocks: MockedResponse[] = [...defaultMocks];
 
   const originalLocation = window.location;
 
   delete window.location;
 
-  window.location = {href: ''}
-  let specialEvent = {... event};
+  window.location = { href: '' };
+  const specialEvent = { ...event };
   specialEvent.createdBy = 'Jaska Jokunen - testisähköposti@testidomaini.fi';
-  
+
   const user = userEvent.setup();
-  renderComponent({authContextValue, props: { event: specialEvent }, mocks });
+  renderComponent({ authContextValue, props: { event: specialEvent }, mocks });
 
   await openMenu();
 
@@ -310,7 +316,9 @@ test('should call the mailto function when clicking Send Email button', async ()
   await user.click(sendMailButton);
 
   await waitFor(() =>
-    expect(window.location.href).toBe("mailto:testisähköposti@testidomaini.fi?subject=Name fi")
+    expect(window.location.href).toBe(
+      'mailto:testisähköposti@testidomaini.fi?subject=Name fi'
+    )
   );
 
   window.location = originalLocation;


### PR DESCRIPTION
## Description :sparkles:
Send Email button to send notification information to event creator in the event listing page.

## Issues :bug:
The email information has to be parsed from the createdBy string which usually contains email address. There is potential that if the createdBy field is malformed that this feature does not work.

### Closes :no_good_woman:

**[LINK-1266](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1266):**



[LINK-1266]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1266?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ