### PR TITLE
LINK-1342 event form info texts update

### DIFF
--- a/src/domain/app/authenticationNotification/AuthenticationNotification.tsx
+++ b/src/domain/app/authenticationNotification/AuthenticationNotification.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-undef */
 import classNames from 'classnames';
 import { NotificationType } from 'hds-react';
 import React, { useState } from 'react';
@@ -29,6 +30,7 @@ type OnlyNotAuthenticatedErrorProps = {
   noRequiredOrganizationLabel?: null;
   noRequiredOrganizationText?: null;
   showOnlyNotAuthenticatedError: true;
+  notAuthenticatedMessage?: JSX.Element;
 } & CommonProps;
 
 type AllErrorsProps = {
@@ -37,6 +39,7 @@ type AllErrorsProps = {
   noRequiredOrganizationLabel: string;
   noRequiredOrganizationText: string;
   showOnlyNotAuthenticatedError?: false;
+  notAuthenticatedMessage?: JSX.Element;
 } & CommonProps;
 
 export type AuthenticationNotificationProps =
@@ -51,6 +54,7 @@ const AuthenticationNotification: React.FC<AuthenticationNotificationProps> = ({
   noRequiredOrganizationText,
   requiredOrganizationType = 'admin',
   showOnlyNotAuthenticatedError,
+  notAuthenticatedMessage,
 }) => {
   const location = useLocation();
   const { t } = useTranslation();
@@ -115,19 +119,21 @@ const AuthenticationNotification: React.FC<AuthenticationNotificationProps> = ({
   };
 
   if (!authenticated) {
+    const message = notAuthenticatedMessage ? (
+      notAuthenticatedMessage
+    ) : (
+      <p>
+        {t('authenticationNotification.part1')}{' '}
+        <button className={styles.button} onClick={handleSignIn} type="button">
+          {t('authenticationNotification.button')}
+        </button>
+        {t('authenticationNotification.part2')}
+      </p>
+    );
+
     return (
       <Notification {...notificationProps} label={t('common.signIn')}>
-        <p>
-          {t('authenticationNotification.part1')}{' '}
-          <button
-            className={styles.button}
-            onClick={handleSignIn}
-            type="button"
-          >
-            {t('authenticationNotification.button')}
-          </button>
-          {t('authenticationNotification.part2')}
-        </p>
+        {message}
       </Notification>
     );
   }

--- a/src/domain/app/authenticationNotification/AuthenticationNotification.tsx
+++ b/src/domain/app/authenticationNotification/AuthenticationNotification.tsx
@@ -29,7 +29,7 @@ type OnlyNotAuthenticatedErrorProps = {
   noRequiredOrganizationLabel?: null;
   noRequiredOrganizationText?: null;
   showOnlyNotAuthenticatedError: true;
-  notAuthenticatedMessage?: ReactNode;
+  notAuthenticatedCustomMessage?: ReactNode;
 } & CommonProps;
 
 type AllErrorsProps = {
@@ -38,7 +38,7 @@ type AllErrorsProps = {
   noRequiredOrganizationLabel: string;
   noRequiredOrganizationText: string;
   showOnlyNotAuthenticatedError?: false;
-  notAuthenticatedMessage?: ReactNode;
+  notAuthenticatedCustomMessage?: ReactNode;
 } & CommonProps;
 
 export type AuthenticationNotificationProps =
@@ -53,7 +53,7 @@ const AuthenticationNotification: React.FC<AuthenticationNotificationProps> = ({
   noRequiredOrganizationText,
   requiredOrganizationType = 'admin',
   showOnlyNotAuthenticatedError,
-  notAuthenticatedMessage,
+  notAuthenticatedCustomMessage,
 }) => {
   const location = useLocation();
   const { t } = useTranslation();
@@ -118,8 +118,8 @@ const AuthenticationNotification: React.FC<AuthenticationNotificationProps> = ({
   };
 
   if (!authenticated) {
-    const message = notAuthenticatedMessage ? (
-      notAuthenticatedMessage
+    const message = notAuthenticatedCustomMessage ? (
+      notAuthenticatedCustomMessage
     ) : (
       <p>
         {t('authenticationNotification.part1')}{' '}

--- a/src/domain/app/authenticationNotification/AuthenticationNotification.tsx
+++ b/src/domain/app/authenticationNotification/AuthenticationNotification.tsx
@@ -1,7 +1,6 @@
-/* eslint-disable no-undef */
 import classNames from 'classnames';
 import { NotificationType } from 'hds-react';
-import React, { useState } from 'react';
+import React, { ReactNode, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
 
@@ -30,7 +29,7 @@ type OnlyNotAuthenticatedErrorProps = {
   noRequiredOrganizationLabel?: null;
   noRequiredOrganizationText?: null;
   showOnlyNotAuthenticatedError: true;
-  notAuthenticatedMessage?: JSX.Element;
+  notAuthenticatedMessage?: ReactNode;
 } & CommonProps;
 
 type AllErrorsProps = {
@@ -39,7 +38,7 @@ type AllErrorsProps = {
   noRequiredOrganizationLabel: string;
   noRequiredOrganizationText: string;
   showOnlyNotAuthenticatedError?: false;
-  notAuthenticatedMessage?: JSX.Element;
+  notAuthenticatedMessage?: ReactNode;
 } & CommonProps;
 
 export type AuthenticationNotificationProps =

--- a/src/domain/app/authenticationNotification/__tests__/AuthenticationNotification.test.tsx
+++ b/src/domain/app/authenticationNotification/__tests__/AuthenticationNotification.test.tsx
@@ -52,3 +52,14 @@ test('should hide notification when clicking close button', async () => {
   await user.click(closeButton);
   await waitFor(() => expect(notification).toHaveStyle(hiddenStyles));
 });
+
+test('should show custom message', async () => {
+  render(
+    <AuthenticationNotification
+      {...props}
+      notAuthenticatedCustomMessage={<p>Custom message</p>}
+    />
+  );
+
+  expect(await screen.findByText(/custom message/i)).toBeInTheDocument();
+});

--- a/src/domain/app/i18n/en.json
+++ b/src/domain/app/i18n/en.json
@@ -572,20 +572,34 @@
         "general": "If age restrictions apply to the event, set the age minimum and maximum age limit here.",
         "volunteering": "If age restrictions apply to the volunteering, set the age minimum and maximum age limit here."
       },
-      "infoTextDescription1": {
-        "course": "A short description is displayed in some services when there is no space for a long description. It tells the most essential things about the course concisely.",
-        "general": "A short description is displayed in some services when there is no space for a long description. It tells the most essential things about the event concisely.",
-        "volunteering": "A short description is displayed in some services when there is no space for a long description. It tells the most essential things about the volunteering concisely."
-      },
-      "infoTextDescription2": {
-        "course": "The description is a longer and more detailed description of the content of the course.",
-        "general": "The description is a longer and more detailed description of the content of the event.",
-        "volunteering": "The description is a longer and more detailed description of the content of the volunteering."
-      },
-      "infoTextDescription3": {
-        "course": "Also record the course's <a href=\"https://q.surveypal.com/thinksustainably-Tapahtumat-kriteerit-2021/0\" target=\"_blank\" rel=\"noopener noreferrer\" aria-label=\"responsibility information {{openInNewTab}}\">responsibility information</a>. Filling out the form only takes about 2 minutes and it opens in a new window. You will not lose the information filled in this form.",
-        "general": "Also record the event's <a href=\"https://q.surveypal.com/thinksustainably-Tapahtumat-kriteerit-2021/0\" target=\"_blank\" rel=\"noopener noreferrer\" aria-label=\"responsibility information {{openInNewTab}}\">responsibility information</a>. Filling out the form only takes about 2 minutes and it opens in a new window. You will not lose the information filled in this form.",
-        "volunteering": "Also record the volunteering's <a href=\"https://q.surveypal.com/thinksustainably-Tapahtumat-kriteerit-2021/0\" target=\"_blank\" rel=\"noopener noreferrer\" aria-label=\"responsibility information {{openInNewTab}}\">responsibility information</a>. Filling out the form only takes about 2 minutes and it opens in a new window. You will not lose the information filled in this form."
+      "infoTextDescription": {
+        "course": {
+          "paragraph1": "A short description is displayed in some services when there is no space for a long description. It tells the most essential things about the course concisely.",
+          "paragraph2": "The description is a longer and more detailed description of the content of the course.",
+          "paragraph3": "Also record the course's <a href=\"https://q.surveypal.com/thinksustainably-Tapahtumat-kriteerit-2021/0\" target=\"_blank\" rel=\"noopener noreferrer\" aria-label=\"responsibility information {{openInNewTab}}\">responsibility information</a>. Filling out the form only takes about 2 minutes and it opens in a new window. You will not lose the information filled in this form."
+        },
+        "general": {
+          "paragraph1": "The description text includes language versions: Finnish and English, possibly also Swedish. <strong>Content specifically aimed at visitors must be at least in Finnish and English.</strong>",
+          "paragraph2": "A short description is shown in some services when there is no room for a long description. It explains the most important things about the event in a concise way.",
+          "paragraph3": "A description is a longer and more detailed explanation of the content of the event.",
+          "paragraph4": "The text must not contain misspellings, umlauts, superlatives and superlatives, or the 'we' form, because then it refers to the city of Helsinki, not to the event itself.",
+          "paragraph5": "In addition, the content of the event must comply with the City of Helsinki's guidelines, i.e. the City does not publish:",
+          "exclusions": [
+            "political events (demonstrations, radical events related to elections or wars, etc.)",
+            "religious events (church services, prayers, although concerts are included in the calendar)",
+            "online events not related to Helsinki or the metropolitan area",
+            "events taking place in a private dwelling",
+            "not open to all, e.g. professional or investor events",
+            "dining without a programme; simply eating is not an event in itself",
+            "fund-raising events (except for charity events, where there is a programme)",
+            "job or student recruitment advertisements"
+          ]
+        },
+        "volunteering": {
+          "paragraph1": "A short description is displayed in some services when there is no space for a long description. It tells the most essential things about the volunteering concisely.",
+          "paragraph2": "The description is a longer and more detailed description of the content of the volunteering.",
+          "paragraph3": "Also record the volunteering's <a href=\"https://q.surveypal.com/thinksustainably-Tapahtumat-kriteerit-2021/0\" target=\"_blank\" rel=\"noopener noreferrer\" aria-label=\"responsibility information {{openInNewTab}}\">responsibility information</a>. Filling out the form only takes about 2 minutes and it opens in a new window. You will not lose the information filled in this form."
+        }
       },
       "infoTextEnrolmentTime": {
         "course": "If it is possible to register for the course, specify the start and end times of the registration here.",
@@ -623,7 +637,7 @@
       "infoTextImage4": "Alt text improves accessibility because screen readers pass alt text to the user. So describe the content of the picture in an understandable way.",
       "infoTextInfoLanguages": {
         "course": "Select the languages to be used to input course information for this service.",
-        "general": "Select the languages to be used to input event information for this service.",
+        "general": "Select the languages you want to use to describe the event information in Linked Events. <strong>Content specifically aimed at visitors has to be at least in Finnish and English.</strong>",
         "volunteering": "Select the languages to be used to input volunteering information for this service."
       },
       "infoTextInLanguages": {

--- a/src/domain/app/i18n/en.json
+++ b/src/domain/app/i18n/en.json
@@ -680,10 +680,18 @@
         "volunteering": "Enter the name of the organization hosting the volunteering if the organizer is not the same as the publisher."
       },
       "infoTextPublication": {
-        "paragraph1": "Published information must be interesting to residents and/or visitors and be located in the metropolitan area.",
+        "paragraph1": {
+          "general": "Published information must be interesting to residents and/or visitors and be located in the metropolitan area.",
+          "course": "Published information must be interesting to residents and/or visitors and be located in the metropolitan area.",
+          "volunteering": "Published information must be interesting to residents and/or visitors and be located in the metropolitan area."
+        },
         "paragraph2": "The type of event you choose can be published in the following channels:",
         "paragraph3": "or via the interface on other services.",
-        "paragraph4": "Please only enter event/hobby information that has not yet been published on any of the services mentioned above.",
+        "paragraph4": {
+          "general": "Please only enter event information that has not yet been published on any of the services mentioned above.",
+          "course": "Please only enter hobby information that has not yet been published on any of the services mentioned above.",
+          "volunteering": "Please only enter event information that has not yet been published on any of the services mentioned above."
+        },
         "paragraph5": "The event to be moderated must be announced at least one week before the event."
       },
       "infoTextPublisher": {

--- a/src/domain/app/i18n/en.json
+++ b/src/domain/app/i18n/en.json
@@ -665,7 +665,13 @@
         "general": "Enter the name of the organization hosting the event if the organizer is not the same as the publisher.",
         "volunteering": "Enter the name of the organization hosting the volunteering if the organizer is not the same as the publisher."
       },
-      "infoTextPublication": "The event type you selected will be published on the following channels:",
+      "infoTextPublication": {
+        "paragraph1": "Published information must be interesting to residents and/or visitors and be located in the metropolitan area.",
+        "paragraph2": "The type of event you choose can be published in the following channels:",
+        "paragraph3": "or via the interface on other services.",
+        "paragraph4": "Please only enter event/hobby information that has not yet been published on any of the services mentioned above.",
+        "paragraph5": "The event to be moderated must be announced at least one week before the event."
+      },
       "infoTextPublisher": {
         "course": "Select the organization to be displayed as the course publisher. You do not need to make a selection if you only have rights to publish under one organization.",
         "general": "Select the organization to be displayed as the event publisher. You do not need to make a selection if you only have rights to publish under one organization.",
@@ -838,6 +844,10 @@
         "course": "Course video",
         "general": "Event video",
         "volunteering": "Volunteering video"
+      },
+      "notificationNotAuthenticated": {
+        "paragraph1": "The City of Helsinki publishes information about events in the Helsinki Metropolitan Area free of charge, for example on the services <a href=\"https://tapahtumat.hel.fi\" target=\"_blank\" rel=\"noreferrer\">tapahtumat.hel.fi</a> and <a href=\"https://harrastukset.hel.fi\" target=\"_blank\" rel=\"noreferrer\">harrastukset.hel.fi</a>. Event information will also be visible on other digital platforms that use the city's Linked Events interface.",
+        "paragraph2": "You can continue to explore the service, but you will need to log in if you want to save changes."
       },
       "placeholderAudienceMaxAge": {
         "course": "Enter the maximum age for the course",

--- a/src/domain/app/i18n/fi.json
+++ b/src/domain/app/i18n/fi.json
@@ -665,7 +665,13 @@
         "general": "Kirjoita tähän tapahtuman järjestävän organisaation nimi, jos järjestäjä ei ole sama kuin julkaisija.",
         "volunteering": "Kirjoita tähän vapaaehtoistehtävän järjestävän organisaation nimi, jos järjestäjä ei ole sama kuin julkaisija."
       },
-      "infoTextPublication": "Valitsemasi tapahtumatyyppi julkaistaan seuraavissa kanavissa:",
+      "infoTextPublication": {
+        "paragraph1": "Julkaistavien tapahtuma-/harrastustietojen tulee olla kaupunkilaisia ja/tai vierailijoita kiinnostavia ja sijaita pääkaupunkiseudulla.",
+        "paragraph2": "Valitsemasi tapahtumatyyppi voidaan julkaista seuraavissa kanavissa:",
+        "paragraph3": "tai rajapinnan kautta muissa palveluissa.",
+        "paragraph4": "Ilmoitathan vain tapahtuma-/harrastustietoja, joita ei ole vielä julkaistu joissakin edellä mainituista palveluista.",
+        "paragraph5": "Moderoitava tapahtuma pitää ilmoittaa vähintään viikkoa ennen tapahtumaa."
+      },
       "infoTextPublisher": {
         "course": "Valitse organisaatio, joka näytetään kurssin julkaisijana. Valintaa ei tarvitse tehdä, jos sinulla on vain yhden organisaation julkaisuoikeudet.",
         "general": "Valitse organisaatio, joka näytetään tapahtuman julkaisijana. Valintaa ei tarvitse tehdä, jos sinulla on vain yhden organisaation julkaisuoikeudet.",
@@ -838,6 +844,10 @@
         "course": "Kurssin video",
         "general": "Tapahtuman video",
         "volunteering": "Vapaaehtoistehtävän video"
+      },
+      "notificationNotAuthenticated": {
+        "paragraph1": "Helsingin kaupunki julkaisee maksutta pääkaupunkiseudulla toteutettavien tapahtumien tietoja muun muassa <a href=\"https://tapahtumat.hel.fi\" target=\"_blank\" rel=\"noreferrer\">tapahtumat.hel.fi</a>- ja <a href=\"https://harrastukset.hel.fi\" target=\"_blank\" rel=\"noreferrer\">harrastukset.hel.fi</a>-palveluissa. Tilaisuudet tiedot tulevat näkyviin lisäksi muihin digitaalisiin alustoihin, jotka hyödyntävät kaupungin Linked Events -rajapintaa.",
+        "paragraph2": "Voit jatkaa palveluun tutustumista, mutta sinun täytyy kirjautua sisään, jos haluat tallentaa muutoksia."
       },
       "placeholderAudienceMaxAge": {
         "course": "Syötä kurssin yläikäraja",

--- a/src/domain/app/i18n/fi.json
+++ b/src/domain/app/i18n/fi.json
@@ -572,20 +572,34 @@
         "general": "Jos vain tietyn ikäisten henkilöiden on sallittua osallistua tapahtumaan, määritä ikärajat tässä.",
         "volunteering": "Jos vain tietyn ikäisten henkilöiden on sallittua osallistua vapaaehtoistehtävään, määritä ikärajat tässä."
       },
-      "infoTextDescription1": {
-        "course": "Lyhyt kuvaus näytetään joissain palveluissa silloin kun pitkälle kuvaukselle ei ole tilaa. Se kertoo kurssista olennaisimmat asiat ytimekkäästi.",
-        "general": "Lyhyt kuvaus näytetään joissain palveluissa silloin kun pitkälle kuvaukselle ei ole tilaa. Se kertoo tapahtumasta olennaisimmat asiat ytimekkäästi.",
-        "volunteering": "Lyhyt kuvaus näytetään joissain palveluissa silloin kun pitkälle kuvaukselle ei ole tilaa. Se kertoo vapaaehtoistehtävästä olennaisimmat asiat ytimekkäästi."
-      },
-      "infoTextDescription2": {
-        "course": "Kuvaus on pidempi ja tarkempi selostus kurssin sisällöstä.",
-        "general": "Kuvaus on pidempi ja tarkempi selostus tapahtuman sisällöstä.",
-        "volunteering": "Kuvaus on pidempi ja tarkempi selostus vapaaehtoistehtävän sisällöstä."
-      },
-      "infoTextDescription3": {
-        "course": "Kirjaa myös kurssin <a href=\"https://q.surveypal.com/thinksustainably-Tapahtumat-kriteerit-2021/0\" target=\"_blank\" rel=\"noopener noreferrer\" aria-label=\"vastuullisuustiedot {{openInNewTab}}\">vastuullisuustiedot</a>. Lomakkeen täyttäminen vie vain noin 2 minuuttia ja se avataan uuteen ikkunaan. Et menetä tähän lomakkeeseen täytettyjä tietoja.",
-        "general": "Kirjaa myös tapahtuman <a href=\"https://q.surveypal.com/thinksustainably-Tapahtumat-kriteerit-2021/0\" target=\"_blank\" rel=\"noopener noreferrer\" aria-label=\"vastuullisuustiedot {{openInNewTab}}\">vastuullisuustiedot</a>. Lomakkeen täyttäminen vie vain noin 2 minuuttia ja se avataan uuteen ikkunaan. Et menetä tähän lomakkeeseen täytettyjä tietoja.",
-        "volunteering": "Kirjaa myös vapaaehtoistehtävän <a href=\"https://q.surveypal.com/thinksustainably-Tapahtumat-kriteerit-2021/0\" target=\"_blank\" rel=\"noopener noreferrer\" aria-label=\"vastuullisuustiedot {{openInNewTab}}\">vastuullisuustiedot</a>. Lomakkeen täyttäminen vie vain noin 2 minuuttia ja se avataan uuteen ikkunaan. Et menetä tähän lomakkeeseen täytettyjä tietoja."
+      "infoTextDescription": {
+        "course": {
+          "paragraph1": "Lyhyt kuvaus näytetään joissain palveluissa silloin kun pitkälle kuvaukselle ei ole tilaa. Se kertoo kurssista olennaisimmat asiat ytimekkäästi.",
+          "paragraph2": "Kuvaus on pidempi ja tarkempi selostus kurssin sisällöstä.",
+          "paragraph3": "Kirjaa myös kurssin <a href=\"https://q.surveypal.com/thinksustainably-Tapahtumat-kriteerit-2021/0\" target=\"_blank\" rel=\"noopener noreferrer\" aria-label=\"vastuullisuustiedot {{openInNewTab}}\">vastuullisuustiedot</a>. Lomakkeen täyttäminen vie vain noin 2 minuuttia ja se avataan uuteen ikkunaan. Et menetä tähän lomakkeeseen täytettyjä tietoja."
+        },
+        "general": {
+          "paragraph1": "Kuvausteksti sisältää kieliversiot: suomi ja englanti, mahdollisesti myös ruotsi. <strong>Erityisesti vierailijoille suunnattu sisältö pitää olla vähintään suomeksi ja englanniksi.</strong>",
+          "paragraph2": "Lyhyt kuvaus näytetään joissain palveluissa silloin kun pitkälle kuvaukselle ei ole tilaa. Se kertoo tapahtumasta olennaisimmat asiat ytimekkäästi.",
+          "paragraph3": "Kuvaus on pidempi ja tarkempi selostus tapahtuman sisällöstä.",
+          "paragraph4": "Teksti ei sisällä kirjoitusvirheitä, ylisanoja, korulauseita ja superlatiiveja tai me-muotoa, sillä silloin se viittaa Helsingin kaupunkiin, ei tapahtumaan itseensä. ",
+          "paragraph5": "Lisäksi tapahtuman sisällön pitää noudattaa Helsingin kaupungin linjauksia eli kaupunki ei julkaise:",
+          "exclusions": [
+            "poliittisia tapahtumia (mielenosoitukset, vaaleihin tai sotiin liittyvät tms. radikaalit tapahtumat)",
+            "uskonnollisia tapahtumia (jumalanpalvelukset, rukoushetket, tosin konsertit käyvät kalenteriin)",
+            "verkkotapahtumia, jotka eivät liity Helsinkiin tai pääkaupunkiseutuun",
+            "yksityisasunnossa tapahtuvia tilaisuuksia",
+            "ei kaikille avoimia, esim.  ammattilais- tai sijoittajatapahtumia",
+            "ruokailua ilman ohjelmaa; pelkkä syöminen ei ole tapahtuma sinänsä",
+            "rahan ym. asioiden keräystapahtumia (poikkeuksena hyväntekeväisyystapahtuma, jossa on ohjelmaa)",
+            "työ- tai opiskelijahakuilmoituksia"
+          ]
+        },
+        "volunteering": {
+          "paragraph1": "Lyhyt kuvaus näytetään joissain palveluissa silloin kun pitkälle kuvaukselle ei ole tilaa. Se kertoo vapaaehtoistehtävästä olennaisimmat asiat ytimekkäästi.",
+          "paragraph2": "Kuvaus on pidempi ja tarkempi selostus vapaaehtoistehtävän sisällöstä.",
+          "paragraph3": "Kirjaa myös vapaaehtoistehtävän <a href=\"https://q.surveypal.com/thinksustainably-Tapahtumat-kriteerit-2021/0\" target=\"_blank\" rel=\"noopener noreferrer\" aria-label=\"vastuullisuustiedot {{openInNewTab}}\">vastuullisuustiedot</a>. Lomakkeen täyttäminen vie vain noin 2 minuuttia ja se avataan uuteen ikkunaan. Et menetä tähän lomakkeeseen täytettyjä tietoja."
+        }
       },
       "infoTextEnrolmentTime": {
         "course": "Jos kurssille on mahdollista ilmoittautua, määrittele ilmoittautumisen alkamis- ja päättymisajat tässä.",
@@ -623,7 +637,7 @@
       "infoTextImage4": "Alt-teksti parantaa saavutettavuutta, sillä ruudunlukuohjelmat välittävät alt-tekstin sisällön käyttäjälle. Kuvaa tähän kohtaan siis kuvan sisältö ymmärrettävästi.",
       "infoTextInfoLanguages": {
         "course": "Valitse kielet, joilla kuvaat kurssin tiedot Linked Events -palvelussa.",
-        "general": "Valitse kielet, joilla kuvaat tapahtuman tiedot Linked Events -palvelussa.",
+        "general": "Valitse kielet, joilla kuvaat tapahtuman tiedot Linked Events -palvelussa. <strong>Erityisesti vierailijoille suunnattu sisältö pitää olla vähintään suomeksi ja englanniksi.</strong",
         "volunteering": "Valitse kielet, joilla kuvaat vapaaehtoistehtävän tiedot Linked Events -palvelussa."
       },
       "infoTextInLanguages": {

--- a/src/domain/app/i18n/fi.json
+++ b/src/domain/app/i18n/fi.json
@@ -680,10 +680,18 @@
         "volunteering": "Kirjoita tähän vapaaehtoistehtävän järjestävän organisaation nimi, jos järjestäjä ei ole sama kuin julkaisija."
       },
       "infoTextPublication": {
-        "paragraph1": "Julkaistavien tapahtuma-/harrastustietojen tulee olla kaupunkilaisia ja/tai vierailijoita kiinnostavia ja sijaita pääkaupunkiseudulla.",
+        "paragraph1": {
+          "general": "Julkaistavien tapahtumatietojen tulee olla kaupunkilaisia ja/tai vierailijoita kiinnostavia ja sijaita pääkaupunkiseudulla.",
+          "course": "Julkaistavien harrastustietojen tulee olla kaupunkilaisia ja/tai vierailijoita kiinnostavia ja sijaita pääkaupunkiseudulla.",
+          "volunteering": "Julkaistavien tapahtumatietojen tulee olla kaupunkilaisia ja/tai vierailijoita kiinnostavia ja sijaita pääkaupunkiseudulla."
+        },
         "paragraph2": "Valitsemasi tapahtumatyyppi voidaan julkaista seuraavissa kanavissa:",
         "paragraph3": "tai rajapinnan kautta muissa palveluissa.",
-        "paragraph4": "Ilmoitathan vain tapahtuma-/harrastustietoja, joita ei ole vielä julkaistu joissakin edellä mainituista palveluista.",
+        "paragraph4": {
+          "general": "Ilmoitathan vain tapahtumatietoja, joita ei ole vielä julkaistu joissakin edellä mainituista palveluista.",
+          "course": "Ilmoitathan vain harrastustietoja, joita ei ole vielä julkaistu joissakin edellä mainituista palveluista.",
+          "volunteering": "Ilmoitathan vain tapahtumatietoja, joita ei ole vielä julkaistu joissakin edellä mainituista palveluista."
+        },
         "paragraph5": "Moderoitava tapahtuma pitää ilmoittaa vähintään viikkoa ennen tapahtumaa."
       },
       "infoTextPublisher": {

--- a/src/domain/app/i18n/sv.json
+++ b/src/domain/app/i18n/sv.json
@@ -572,20 +572,34 @@
         "general": "Om åldersbegränsningar gäller för evenemanget, ställ in lägsta och högsta åldersgräns här.",
         "volunteering": "Om åldersbegränsningar gäller för volontärarbetet, ställ in lägsta och högsta åldersgräns här."
       },
-      "infoTextDescription1": {
-        "course": "Den korta beskrivningen visas i vissa tjänster när det inte finns plats för en lång beskrivning. Den berättar de viktigaste sakerna om kursen kortfattat.",
-        "general": "Den korta beskrivningen visas i vissa tjänster när det inte finns plats för en lång beskrivning. Den berättar de viktigaste sakerna om evenemanget kortfattat.",
-        "volunteering": "Den korta beskrivningen visas i vissa tjänster när det inte finns plats för en lång beskrivning. Den berättar de viktigaste sakerna om volontärarbetet kortfattat."
-      },
-      "infoTextDescription2": {
-        "course": "Beskrivningen är en längre och mer detaljerad beskrivning av innehållet i kursen.",
-        "general": "Beskrivningen är en längre och mer detaljerad beskrivning av innehållet i evenemanget.",
-        "volunteering": "Beskrivningen är en längre och mer detaljerad beskrivning av innehållet i volontärarbetet."
-      },
-      "infoTextDescription3": {
-        "course": "Anteckna även kursens <a href=\"https://q.surveypal.com/thinksustainably-Tapahtumat-kriteerit-2021/0\" target=\"_blank\" rel=\"noopener noreferrer\" aria-label=\"ansvarsinformation {{openInNewTab}}\">ansvarsinformation</a>. Att fylla i formuläret tar bara cirka 2 minuter och det öppnas i ett nytt fönster. Du kommer inte att förlora informationen i detta formulär.",
-        "general": "Anteckna även evenemangets <a href=\"https://q.surveypal.com/thinksustainably-Tapahtumat-kriteerit-2021/0\" target=\"_blank\" rel=\"noopener noreferrer\" aria-label=\"ansvarsinformation {{openInNewTab}}\">ansvarsinformation</a>. Att fylla i formuläret tar bara cirka 2 minuter och det öppnas i ett nytt fönster. Du kommer inte att förlora informationen i detta formulär.",
-        "volunteering": "Anteckna även volontärens <a href=\"https://q.surveypal.com/thinksustainably-Tapahtumat-kriteerit-2021/0\" target=\"_blank\" rel=\"noopener noreferrer\" aria-label=\"ansvarsinformation {{openInNewTab}}\">ansvarsinformation</a>. Att fylla i formuläret tar bara cirka 2 minuter och det öppnas i ett nytt fönster. Du kommer inte att förlora informationen i detta formulär."
+      "infoTextDescription": {
+        "course": {
+          "paragraph1": "Den korta beskrivningen visas i vissa tjänster när det inte finns plats för en lång beskrivning. Den berättar de viktigaste sakerna om kursen kortfattat.",
+          "paragraph2": "Beskrivningen är en längre och mer detaljerad beskrivning av innehållet i kursen.",
+          "paragraph3": "Anteckna även kursens <a href=\"https://q.surveypal.com/thinksustainably-Tapahtumat-kriteerit-2021/0\" target=\"_blank\" rel=\"noopener noreferrer\" aria-label=\"ansvarsinformation {{openInNewTab}}\">ansvarsinformation</a>. Att fylla i formuläret tar bara cirka 2 minuter och det öppnas i ett nytt fönster. Du kommer inte att förlora informationen i detta formulär."
+        },
+        "general": {
+          "paragraph1": "The description text includes language versions: Finnish and English, possibly also Swedish. <strong>Content specifically aimed at visitors must be at least in Finnish and English.</strong>",
+          "paragraph2": "A short description is shown in some services when there is no room for a long description. It explains the most important things about the event in a concise way.",
+          "paragraph3": "A description is a longer and more detailed explanation of the content of the event.",
+          "paragraph4": "The text must not contain misspellings, umlauts, superlatives and superlatives, or the 'we' form, because then it refers to the city of Helsinki, not to the event itself.",
+          "paragraph5": "In addition, the content of the event must comply with the City of Helsinki's guidelines, i.e. the City does not publish:",
+          "exclusions": [
+            "political events (demonstrations, radical events related to elections or wars, etc.)",
+            "religious events (church services, prayers, although concerts are included in the calendar)",
+            "online events not related to Helsinki or the metropolitan area",
+            "events taking place in a private dwelling",
+            "not open to all, e.g. professional or investor events",
+            "dining without a programme; simply eating is not an event in itself",
+            "fund-raising events (except for charity events, where there is a programme)",
+            "job or student recruitment advertisements"
+          ]
+        },
+        "volunteering": {
+          "paragraph1": "Den korta beskrivningen visas i vissa tjänster när det inte finns plats för en lång beskrivning. Den berättar de viktigaste sakerna om volontärarbetet kortfattat.",
+          "paragraph2": "Beskrivningen är en längre och mer detaljerad beskrivning av innehållet i volontärarbetet.",
+          "paragraph3": "Anteckna även volontärens <a href=\"https://q.surveypal.com/thinksustainably-Tapahtumat-kriteerit-2021/0\" target=\"_blank\" rel=\"noopener noreferrer\" aria-label=\"ansvarsinformation {{openInNewTab}}\">ansvarsinformation</a>. Att fylla i formuläret tar bara cirka 2 minuter och det öppnas i ett nytt fönster. Du kommer inte att förlora informationen i detta formulär."
+        }
       },
       "infoTextEnrolmentTime": {
         "course": "Om det är möjligt att registrera sig för kursen, ange start- och sluttiderna för registreringen här.",
@@ -623,7 +637,7 @@
       "infoTextImage4": "Alt-text förbättrar tillgängligheten eftersom skärmläsare skickar alt-text till användaren. Så beskriv innehållet i bilden på ett förståeligt sätt.",
       "infoTextInfoLanguages": {
         "course": "Välj de språk som kursinformationen matas in på.",
-        "general": "Välj de språk som evenemangsinformationen matas in på.",
+        "general": "Välj de språk som evenemangsinformationen matas in på. <strong>Content specifically aimed at visitors has to be at least in Finnish and English.</strong>",
         "volunteering": "Välj de språk som volontärarbetesinformation matas in på."
       },
       "infoTextInLanguages": {
@@ -665,7 +679,13 @@
         "general": "Ange namnet på organisationen som är värd för evenemanget om arrangören inte är densamma som utgivaren.",
         "volunteering": "Ange namnet på organisationen som är värd för volontärarbetet om arrangören inte är densamma som utgivaren."
       },
-      "infoTextPublication": "Evenemangtypen du valde kommer att publiceras på följande kanaler:",
+      "infoTextPublication": {
+        "paragraph1": "Published information must be interesting to residents and/or visitors and be located in the metropolitan area.",
+        "paragraph2": "Evenemangtypen du valde kommer att publiceras på följande kanaler:",
+        "paragraph3": "or via the interface on other services.",
+        "paragraph4": "Please only enter event/hobby information that has not yet been published on any of the services mentioned above.",
+        "paragraph5": "The event to be moderated must be announced at least one week before the event."
+      },
       "infoTextPublisher": {
         "course": "Välj den organisation som ska visas som kurssutgivare. Du behöver inte göra ett val om du bara har publiceringsrättigheter för en organisation.",
         "general": "Välj den organisation som ska visas som evenemangsutgivare. Du behöver inte göra ett val om du bara har publiceringsrättigheter för en organisation.",

--- a/src/domain/app/i18n/sv.json
+++ b/src/domain/app/i18n/sv.json
@@ -680,10 +680,18 @@
         "volunteering": "Ange namnet på organisationen som är värd för volontärarbetet om arrangören inte är densamma som utgivaren."
       },
       "infoTextPublication": {
-        "paragraph1": "Published information must be interesting to residents and/or visitors and be located in the metropolitan area.",
+        "paragraph1": {
+          "general": "Published information must be interesting to residents and/or visitors and be located in the metropolitan area.",
+          "course": "Published information must be interesting to residents and/or visitors and be located in the metropolitan area.",
+          "volunteering": "Published information must be interesting to residents and/or visitors and be located in the metropolitan area."
+        },
         "paragraph2": "Evenemangtypen du valde kommer att publiceras på följande kanaler:",
         "paragraph3": "or via the interface on other services.",
-        "paragraph4": "Please only enter event/hobby information that has not yet been published on any of the services mentioned above.",
+        "paragraph4": {
+          "general": "Please only enter event information that has not yet been published on any of the services mentioned above.",
+          "course": "Please only enter hobby information that has not yet been published on any of the services mentioned above.",
+          "volunteering": "Please only enter event information that has not yet been published on any of the services mentioned above."
+        },
         "paragraph5": "The event to be moderated must be announced at least one week before the event."
       },
       "infoTextPublisher": {

--- a/src/domain/app/i18n/sv.json
+++ b/src/domain/app/i18n/sv.json
@@ -839,6 +839,10 @@
         "general": "Video för evenemanget",
         "volunteering": "Video för volontärarbetet"
       },
+      "notificationNotAuthenticated": {
+        "paragraph1": "The City of Helsinki publishes information about events in the Helsinki Metropolitan Area free of charge, for example on the services <a href=\"https://tapahtumat.hel.fi\" target=\"_blank\" rel=\"noreferrer\">tapahtumat.hel.fi</a> and <a href=\"https://harrastukset.hel.fi\" target=\"_blank\" rel=\"noreferrer\">harrastukset.hel.fi</a>. Event information will also be visible on other digital platforms that use the city's Linked Events interface.",
+        "paragraph2": "You can continue to explore the service, but you will need to log in if you want to save changes."
+      },
       "placeholderAudienceMaxAge": {
         "course": "Ange högsta ålder för kursen",
         "general": "Ange högsta ålder för evenemanget",

--- a/src/domain/event/constants.tsx
+++ b/src/domain/event/constants.tsx
@@ -360,6 +360,8 @@ export const PUBLICATION_LIST_LINKS: Record<EVENT_TYPE, PublicationListLink[]> =
     [EVENT_TYPE.Course]: [],
     [EVENT_TYPE.General]: [
       { href: 'https://tapahtumat.hel.fi', text: 'tapahtumat.hel.fi' },
+      { href: 'https://harrastukset.hel.fi', text: 'harrastukset.hel.fi' },
+      { href: 'https://www.myhelsinki.fi', text: 'myhelsinki.fi' },
     ],
     [EVENT_TYPE.Volunteering]: [
       {

--- a/src/domain/event/eventAuthenticationNotification/EventAuthenticationNotification.tsx
+++ b/src/domain/event/eventAuthenticationNotification/EventAuthenticationNotification.tsx
@@ -56,6 +56,16 @@ const EventAuthenticationNotification: React.FC<
         )}
         noRequiredOrganizationText={t('authentication.noRightsUpdateEvent')}
         requiredOrganizationType="external"
+        notAuthenticatedMessage={
+          <>
+            <p
+              dangerouslySetInnerHTML={{
+                __html: t('event.form.notificationNotAuthenticated.paragraph1'),
+              }}
+            />
+            <p>{t('event.form.notificationNotAuthenticated.paragraph2')}</p>
+          </>
+        }
       />
     </LoadingSpinner>
   );

--- a/src/domain/event/eventAuthenticationNotification/EventAuthenticationNotification.tsx
+++ b/src/domain/event/eventAuthenticationNotification/EventAuthenticationNotification.tsx
@@ -56,7 +56,7 @@ const EventAuthenticationNotification: React.FC<
         )}
         noRequiredOrganizationText={t('authentication.noRightsUpdateEvent')}
         requiredOrganizationType="external"
-        notAuthenticatedMessage={
+        notAuthenticatedCustomMessage={
           <>
             <p
               dangerouslySetInnerHTML={{

--- a/src/domain/event/formSections/descriptionSection/DescriptionSection.tsx
+++ b/src/domain/event/formSections/descriptionSection/DescriptionSection.tsx
@@ -15,7 +15,7 @@ import lowerCaseFirstLetter from '../../../../utils/lowerCaseFirstLetter';
 import skipFalsyType from '../../../../utils/skipFalsyType';
 import FieldColumn from '../../../app/layout/fieldColumn/FieldColumn';
 import FieldRow from '../../../app/layout/fieldRow/FieldRow';
-import { EVENT_FIELDS } from '../../constants';
+import { EVENT_FIELDS, EVENT_TYPE } from '../../constants';
 import useSortedInfoLanguages from '../../hooks/useSortedInfoLanguages';
 import { formatSingleDescription } from '../../utils';
 
@@ -111,15 +111,52 @@ const DescriptionSection: React.FC<DescriptionSectionProps> = ({
                     label={t(`event.form.notificationTitleDescription.${type}`)}
                     type="info"
                   >
-                    <p>{t(`event.form.infoTextDescription1.${type}`)}</p>
-                    <p>{t(`event.form.infoTextDescription2.${type}`)}</p>
                     <p
                       dangerouslySetInnerHTML={{
-                        __html: t(`event.form.infoTextDescription3.${type}`, {
-                          openInNewTab: t('common.openInNewTab'),
-                        }),
+                        __html: t(
+                          `event.form.infoTextDescription.${type}.paragraph1`
+                        ),
                       }}
                     />
+                    <p>
+                      {t(`event.form.infoTextDescription.${type}.paragraph2`)}
+                    </p>
+                    <p
+                      dangerouslySetInnerHTML={{
+                        __html: t(
+                          `event.form.infoTextDescription.${type}.paragraph3`,
+                          {
+                            openInNewTab: t('common.openInNewTab'),
+                          }
+                        ),
+                      }}
+                    />
+                    {type === EVENT_TYPE.General && (
+                      <>
+                        <p>
+                          {t(
+                            `event.form.infoTextDescription.${type}.paragraph4`
+                          )}
+                        </p>
+                        <p>
+                          {t(
+                            `event.form.infoTextDescription.${type}.paragraph5`
+                          )}
+                        </p>
+                        <ul style={{ paddingInlineStart: 'var(--spacing-s)' }}>
+                          {Object.values(
+                            t(
+                              `event.form.infoTextDescription.${type}.exclusions`,
+                              {
+                                returnObjects: true,
+                              }
+                            )
+                          ).map((exlusion, index) => (
+                            <li key={index}>{exlusion}</li>
+                          ))}
+                        </ul>
+                      </>
+                    )}
                   </Notification>
                 }
               >

--- a/src/domain/event/formSections/languagesSection/LanguagesSection.tsx
+++ b/src/domain/event/formSections/languagesSection/LanguagesSection.tsx
@@ -58,7 +58,11 @@ const LanguagesSection: React.FC<Props> = ({ isEditingAllowed }) => {
               label={t(`event.form.titleInfoLanguages.${eventType}`)}
               type="info"
             >
-              <p>{t(`event.form.infoTextInfoLanguages.${eventType}`)}</p>
+              <p
+                dangerouslySetInnerHTML={{
+                  __html: t(`event.form.infoTextInfoLanguages.${eventType}`),
+                }}
+              />
             </Notification>
           }
         >

--- a/src/domain/event/formSections/typeSection/TypeSection.tsx
+++ b/src/domain/event/formSections/typeSection/TypeSection.tsx
@@ -128,11 +128,11 @@ const TypeSection: React.FC<TypeSectionProps> = ({
               label={t('event.form.notificationTitlePublication')}
               type="info"
             >
-              <p>{t('event.form.infoTextPublication.paragraph1')}</p>
+              <p>{t(`event.form.infoTextPublication.paragraph1.${type}`)}</p>
               <p>{t('event.form.infoTextPublication.paragraph2')}</p>
               <PublicationListLinks links={PUBLICATION_LIST_LINKS[type]} />
               <p>{t('event.form.infoTextPublication.paragraph3')}</p>
-              <p>{t('event.form.infoTextPublication.paragraph4')}</p>
+              <p>{t(`event.form.infoTextPublication.paragraph4.${type}`)}</p>
               <p>{t('event.form.infoTextPublication.paragraph5')}</p>
             </Notification>
           </>

--- a/src/domain/event/formSections/typeSection/TypeSection.tsx
+++ b/src/domain/event/formSections/typeSection/TypeSection.tsx
@@ -128,8 +128,12 @@ const TypeSection: React.FC<TypeSectionProps> = ({
               label={t('event.form.notificationTitlePublication')}
               type="info"
             >
-              <p>{t('event.form.infoTextPublication')}</p>
+              <p>{t('event.form.infoTextPublication.paragraph1')}</p>
+              <p>{t('event.form.infoTextPublication.paragraph2')}</p>
               <PublicationListLinks links={PUBLICATION_LIST_LINKS[type]} />
+              <p>{t('event.form.infoTextPublication.paragraph3')}</p>
+              <p>{t('event.form.infoTextPublication.paragraph4')}</p>
+              <p>{t('event.form.infoTextPublication.paragraph5')}</p>
             </Notification>
           </>
         }

--- a/src/domain/event/formSections/typeSection/publicationListLinks/PublicationListLinks.module.scss
+++ b/src/domain/event/formSections/typeSection/publicationListLinks/PublicationListLinks.module.scss
@@ -1,3 +1,0 @@
-.list {
-  padding-inline-start: var(--spacing-s);
-}

--- a/src/domain/event/formSections/typeSection/publicationListLinks/PublicationListLinks.module.scss
+++ b/src/domain/event/formSections/typeSection/publicationListLinks/PublicationListLinks.module.scss
@@ -1,0 +1,3 @@
+.list {
+  padding-inline-start: var(--spacing-s);
+}

--- a/src/domain/event/formSections/typeSection/publicationListLinks/PublicationListLinks.tsx
+++ b/src/domain/event/formSections/typeSection/publicationListLinks/PublicationListLinks.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import styles from './PublicationListLinks.module.scss';
+
 export type PublicationListLink = {
   href: string;
   text: string;
@@ -11,18 +13,17 @@ type Props = {
 
 const PublicationListLinks: React.FC<Props> = ({ links }) => {
   return (
-    <strong>
-      {links.map(({ href, text }, index, array) => {
+    <ul className={styles.list}>
+      {links.map(({ href, text }) => {
         return (
-          <React.Fragment key={href}>
+          <li key={href}>
             <a href={href} target="_blank" rel="noreferrer">
-              {text}
+              <strong>{text}</strong>
             </a>
-            {index + 1 < array.length && ', '}
-          </React.Fragment>
+          </li>
         );
       })}
-    </strong>
+    </ul>
   );
 };
 

--- a/src/domain/event/formSections/typeSection/publicationListLinks/PublicationListLinks.tsx
+++ b/src/domain/event/formSections/typeSection/publicationListLinks/PublicationListLinks.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 
-import styles from './PublicationListLinks.module.scss';
-
 export type PublicationListLink = {
   href: string;
   text: string;
@@ -13,7 +11,7 @@ type Props = {
 
 const PublicationListLinks: React.FC<Props> = ({ links }) => {
   return (
-    <ul className={styles.list}>
+    <ul style={{ paddingInlineStart: 'var(--spacing-s)' }}>
       {links.map(({ href, text }) => {
         return (
           <li key={href}>


### PR DESCRIPTION
## Description :sparkles:
Changes to event form info texts, which are required after https://github.com/City-of-Helsinki/linkedcomponents-ui/pull/185 external users are enabled for Linked events.

**NOTE:**
https://github.com/City-of-Helsinki/linkedcomponents-ui/pull/185 should be merged first, these changes are not relevant without it.

## Issues :bug:

### Closes :no_good_woman:

**[LINK-1342](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1342):**

### Related :handshake:

## Testing :alembic:

Tested on local machine

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[LINK-1342]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ