### PR TITLE
LINK-1363 | Prevent to reserve seats or signup is enrolment is not open

### DIFF
--- a/src/domain/app/i18n/en.json
+++ b/src/domain/app/i18n/en.json
@@ -398,6 +398,7 @@
       "titleSingle": "Send message to the participant"
     },
     "warnings": {
+      "allSeatsReserved": "All seats in the event are currently booked. Please try again later.",
       "capacityInWaitingList": "Registration for this event is still possible, but there are only {{count}} seat left in the queue.",
       "capacityInWaitingList_other": "Registration for this event is still possible, but there are only {{count}} seats left in the queue.",
       "capacityInWaitingListNoLimit": "Registration for this event is still possible, but there are only seats left in the queue.",

--- a/src/domain/app/i18n/fi.json
+++ b/src/domain/app/i18n/fi.json
@@ -399,6 +399,7 @@
       "titleSingle": "Lähetä viesti osallistujalle"
     },
     "warnings": {
+      "allSeatsReserved": "Tapahtuman kaikki paikat ovat tällä hetkellä varatut. Kokeile myöhemmin uudelleen.",
       "capacityInWaitingList": "Ilmoittautuminen tähän tapahtumaan on vielä mahdollista, mutta jonopaikkoja on jäljellä vain {{count}} kpl.",
       "capacityInWaitingList_other": "Ilmoittautuminen tähän tapahtumaan on vielä mahdollista, mutta jonopaikkoja on jäljellä vain {{count}} kpl.",
       "capacityInWaitingListNoLimit": "Ilmoittautuminen tähän tapahtumaan on vielä mahdollista, mutta vain jonopaikkoja on jäljellä.",

--- a/src/domain/app/i18n/sv.json
+++ b/src/domain/app/i18n/sv.json
@@ -399,6 +399,7 @@
       "titleSingle": "Skicka ett meddelande till deltagaren"
     },
     "warnings": {
+      "allSeatsReserved": "Alla platser i evenemanget är för närvarande bokade. Vänligen försök igen senare.",
       "capacityInWaitingList": "Registrering för detta evenemang är fortfarande möjligt, men det är bara {{count}} plats kvar i kön.",
       "capacityInWaitingList_other": "Registrering för detta evenemang är fortfarande möjligt, men det är bara {{count}} platser kvar i kön.",
       "capacityInWaitingListNoLimit": "Registrering till detta evenemang är fortfarande möjlig, men det finns endast platser kvar i kön.",

--- a/src/domain/enrolment/CreateEnrolmentPage.tsx
+++ b/src/domain/enrolment/CreateEnrolmentPage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
 
@@ -14,6 +14,10 @@ import PageWrapper from '../app/layout/pageWrapper/PageWrapper';
 import NotFound from '../notFound/NotFound';
 import useOrganizationAncestors from '../organization/hooks/useOrganizationAncestors';
 import { isRegistrationPossible } from '../registration/utils';
+import {
+  getSeatsReservationData,
+  isSeatsReservationExpired,
+} from '../reserveSeats/utils';
 import useUser from '../user/hooks/useUser';
 import { ENROLMENT_ACTIONS } from './constants';
 import EnrolmentForm from './enrolmentForm/EnrolmentForm';
@@ -39,14 +43,23 @@ const CreateEnrolmentPage: React.FC<Props> = ({ event, registration }) => {
   const { organizationAncestors } = useOrganizationAncestors(publisher);
 
   const initialValues = getEnrolmentDefaultInitialValues(registration);
-  const formDisabled =
-    !isRegistrationPossible(registration) ||
-    !checkCanUserDoAction({
-      action: ENROLMENT_ACTIONS.CREATE,
-      organizationAncestors,
-      publisher,
-      user,
-    });
+
+  const formDisabled = useMemo(() => {
+    const data = getSeatsReservationData(registration.id as string);
+    if (data && !isSeatsReservationExpired(data)) {
+      return false;
+    }
+
+    return (
+      !isRegistrationPossible(registration) ||
+      !checkCanUserDoAction({
+        action: ENROLMENT_ACTIONS.CREATE,
+        organizationAncestors,
+        publisher,
+        user,
+      })
+    );
+  }, [organizationAncestors, publisher, registration, user]);
 
   return (
     <PageWrapper title={`createEnrolmentPage.pageTitle`}>

--- a/src/domain/enrolment/enrolmentForm/EnrolmentForm.tsx
+++ b/src/domain/enrolment/enrolmentForm/EnrolmentForm.tsx
@@ -22,6 +22,7 @@ import extractLatestReturnPath from '../../../utils/extractLatestReturnPath';
 import getValue from '../../../utils/getValue';
 import { showFormErrors } from '../../../utils/validationUtils';
 import Container from '../../app/layout/container/Container';
+import { isRegistrationPossible } from '../../registration/utils';
 import { replaceParamsToRegistrationQueryString } from '../../registrations/utils';
 import { clearSeatsReservationData } from '../../reserveSeats/utils';
 import {
@@ -259,13 +260,13 @@ const EnrolmentForm: React.FC<EnrolmentFormProps> = ({
               {!enrolment && (
                 <RegistrationWarning registration={registration} />
               )}
-              {!enrolment && (
+              {isRegistrationPossible(registration) && !enrolment && (
                 <>
                   <ReservationTimer
                     attendees={attendees}
                     callbacksDisabled={timerCallbacksDisabled.current}
                     disableCallbacks={disableTimerCallbacks}
-                    initReservationData={!enrolment}
+                    initReservationData={true}
                     registration={registration}
                     setAttendees={setAttendees}
                   />

--- a/src/domain/enrolment/enrolmentForm/availableSeatsText/AvailableSeatsText.tsx
+++ b/src/domain/enrolment/enrolmentForm/availableSeatsText/AvailableSeatsText.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FC, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { RegistrationFieldsFragment } from '../../../../generated/graphql';
@@ -7,6 +7,10 @@ import {
   getFreeWaitingListCapacity,
   isAttendeeCapacityUsed,
 } from '../../../registration/utils';
+import {
+  getSeatsReservationData,
+  isSeatsReservationExpired,
+} from '../../../reserveSeats/utils';
 
 type Props = {
   registration: RegistrationFieldsFragment;
@@ -18,18 +22,23 @@ const AvailableSeatsText: FC<Props> = ({ registration }) => {
   const attendeeCapacityUsed = isAttendeeCapacityUsed(registration);
   const freeWaitingListCapacity = getFreeWaitingListCapacity(registration);
 
+  const reservedSeats = useMemo(() => {
+    const data = getSeatsReservationData(registration.id as string);
+    return data && !isSeatsReservationExpired(data) ? data.seats : 0;
+  }, [registration.id]);
+
   return (
     <>
       {typeof freeAttendeeCapacity === 'number' && !attendeeCapacityUsed && (
         <p>
           {t('enrolment.form.freeAttendeeCapacity')}{' '}
-          <strong>{freeAttendeeCapacity}</strong>
+          <strong>{freeAttendeeCapacity + reservedSeats}</strong>
         </p>
       )}
       {attendeeCapacityUsed && typeof freeWaitingListCapacity === 'number' && (
         <p>
           {t('enrolment.form.freeWaitingListCapacity')}{' '}
-          <strong>{freeWaitingListCapacity}</strong>
+          <strong>{freeWaitingListCapacity + reservedSeats}</strong>
         </p>
       )}
     </>

--- a/src/domain/enrolment/enrolmentForm/availableSeatsText/__tests__/AvailableSeatsText.test.tsx
+++ b/src/domain/enrolment/enrolmentForm/availableSeatsText/__tests__/AvailableSeatsText.test.tsx
@@ -1,8 +1,13 @@
 import React from 'react';
 
 import { RegistrationFieldsFragment } from '../../../../../generated/graphql';
-import { fakeRegistration } from '../../../../../utils/mockDataUtils';
+import {
+  fakeRegistration,
+  getMockedSeatsReservationData,
+  setSessionStorageValues,
+} from '../../../../../utils/mockDataUtils';
 import { configure, render, screen } from '../../../../../utils/testUtils';
+import { TEST_REGISTRATION_ID } from '../../../../registration/constants';
 import AvailableSeatsText from '../AvailableSeatsText';
 
 configure({ defaultHidden: true });
@@ -10,7 +15,7 @@ configure({ defaultHidden: true });
 const renderComponent = (registration: RegistrationFieldsFragment) =>
   render(<AvailableSeatsText registration={registration} />);
 
-test('should show amount of free seats ', () => {
+test('should show amount of free seats', () => {
   renderComponent(
     fakeRegistration({
       maximumAttendeeCapacity: 10,
@@ -23,7 +28,7 @@ test('should show amount of free seats ', () => {
   screen.getByText('7');
 });
 
-test('should show amount of remaining seats ', () => {
+test('should show amount of remaining seats', () => {
   renderComponent(
     fakeRegistration({
       maximumAttendeeCapacity: 10,
@@ -34,6 +39,21 @@ test('should show amount of remaining seats ', () => {
 
   screen.getByText('Saatavilla olevia paikkoja');
   screen.getByText('0');
+});
+
+test('should show amount of remaining seats if there ia reservation stored to session storage', () => {
+  const reservation = getMockedSeatsReservationData(1000);
+  const registration = fakeRegistration({
+    id: TEST_REGISTRATION_ID,
+    maximumAttendeeCapacity: 10,
+    currentAttendeeCount: 3,
+    remainingAttendeeCapacity: 0,
+  });
+  setSessionStorageValues(reservation, registration);
+  renderComponent(registration);
+
+  screen.getByText('Saatavilla olevia paikkoja');
+  screen.getByText(reservation.seats);
 });
 
 test('should show amount of free waiting list seats', () => {
@@ -66,4 +86,22 @@ test('should show amount of remaining waiting list seats ', () => {
 
   screen.getByText('Saatavilla olevia jonopaikkoja');
   screen.getByText('0');
+});
+
+test('should show amount of remaining waiting list seats if there ia reservation stored to session storage', () => {
+  const reservation = getMockedSeatsReservationData(1000);
+  const registration = fakeRegistration({
+    id: TEST_REGISTRATION_ID,
+    maximumAttendeeCapacity: 10,
+    currentAttendeeCount: 10,
+    currentWaitingListCount: 3,
+    remainingAttendeeCapacity: 0,
+    remainingWaitingListCapacity: 0,
+    waitingListCapacity: 10,
+  });
+  setSessionStorageValues(reservation, registration);
+  renderComponent(registration);
+
+  screen.getByText('Saatavilla olevia jonopaikkoja');
+  screen.getByText(reservation.seats);
 });

--- a/src/domain/enrolment/participantAmountSelector/__tests__/ParticipantAmountSelector.test.tsx
+++ b/src/domain/enrolment/participantAmountSelector/__tests__/ParticipantAmountSelector.test.tsx
@@ -1,16 +1,17 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 import { MockedResponse } from '@apollo/client/testing';
-import addSeconds from 'date-fns/addSeconds';
-import subSeconds from 'date-fns/subSeconds';
 import { Formik } from 'formik';
 import React from 'react';
 
-import { RESERVATION_NAMES } from '../../../../constants';
 import {
   SeatsReservation,
   UpdateSeatsReservationDocument,
 } from '../../../../generated/graphql';
-import { fakeSeatsReservation } from '../../../../utils/mockDataUtils';
+import {
+  fakeSeatsReservation,
+  getMockedSeatsReservationData,
+  setSessionStorageValues,
+} from '../../../../utils/mockDataUtils';
 import {
   render,
   screen,
@@ -62,33 +63,7 @@ const getElement = (
   }
 };
 
-const setSessionStorageValues = (reservation: SeatsReservation) => {
-  jest.spyOn(sessionStorage, 'getItem').mockImplementation((key: string) => {
-    switch (key) {
-      case `${RESERVATION_NAMES.ENROLMENT_RESERVATION}-${registration.id}`:
-        return reservation ? JSON.stringify(reservation) : '';
-      default:
-        return '';
-    }
-  });
-};
-
 const code = TEST_SEATS_RESERVATION_CODE;
-
-const getReservationData = (expirationOffset: number) => {
-  const now = new Date();
-  let expiration = '';
-
-  if (expirationOffset) {
-    expiration = addSeconds(now, expirationOffset).toISOString();
-  } else {
-    expiration = subSeconds(now, expirationOffset).toISOString();
-  }
-
-  const reservation = fakeSeatsReservation({ code, expiration });
-
-  return reservation;
-};
 
 const getUpdateSeatsReservationMock = (
   seatsReservation: SeatsReservation
@@ -118,8 +93,8 @@ const getUpdateSeatsReservationMock = (
 test('should show modal if the reserved seats are in waiting list', async () => {
   const user = userEvent.setup();
 
-  const reservation = getReservationData(1000);
-  setSessionStorageValues(reservation);
+  const reservation = getMockedSeatsReservationData(1000);
+  setSessionStorageValues(reservation, registration);
 
   const mocks = [
     getUpdateSeatsReservationMock(

--- a/src/domain/enrolment/registrationWarning/RegistrationWarning.tsx
+++ b/src/domain/enrolment/registrationWarning/RegistrationWarning.tsx
@@ -1,9 +1,13 @@
 import { Notification } from 'hds-react';
-import React from 'react';
+import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { RegistrationFieldsFragment } from '../../../generated/graphql';
 import { getRegistrationWarning } from '../../registration/utils';
+import {
+  getSeatsReservationData,
+  isSeatsReservationExpired,
+} from '../../reserveSeats/utils';
 import styles from './registrationWarning.module.scss';
 
 type Props = {
@@ -14,7 +18,12 @@ const RegistrationWarning: React.FC<Props> = ({ registration }) => {
   const { t } = useTranslation();
   const registrationWarning = getRegistrationWarning(registration, t);
 
-  return registrationWarning ? (
+  const hasReservation = useMemo(() => {
+    const data = getSeatsReservationData(registration.id as string);
+    return Boolean(data && !isSeatsReservationExpired(data));
+  }, [registration.id]);
+
+  return registrationWarning && !hasReservation ? (
     <Notification className={styles.warning}>
       {registrationWarning}
     </Notification>

--- a/src/domain/enrolment/registrationWarning/__tests__/RegistrationWarning.test.tsx
+++ b/src/domain/enrolment/registrationWarning/__tests__/RegistrationWarning.test.tsx
@@ -3,29 +3,47 @@ import subDays from 'date-fns/subDays';
 import React from 'react';
 
 import { RegistrationFieldsFragment } from '../../../../generated/graphql';
-import { fakeRegistration } from '../../../../utils/mockDataUtils';
+import {
+  fakeRegistration,
+  getMockedSeatsReservationData,
+  setSessionStorageValues,
+} from '../../../../utils/mockDataUtils';
 import { render, screen } from '../../../../utils/testUtils';
+import { TEST_REGISTRATION_ID } from '../../../registration/constants';
 import RegistrationWarning from '../RegistrationWarning';
 
 const renderComponent = (registration: RegistrationFieldsFragment) =>
   render(<RegistrationWarning registration={registration} />);
 
-test('should show warning if registration is full', async () => {
-  const now = new Date();
-  const enrolmentStartTime = subDays(now, 1).toISOString();
-  const enrolmentEndTime = addDays(now, 1).toISOString();
-  const registration = fakeRegistration({
-    currentAttendeeCount: 10,
-    currentWaitingListCount: 5,
-    enrolmentEndTime,
-    enrolmentStartTime,
-    maximumAttendeeCapacity: 10,
-    waitingListCapacity: 5,
-  });
+const now = new Date();
+const enrolmentStartTime = subDays(now, 1).toISOString();
+const enrolmentEndTime = addDays(now, 1).toISOString();
+const registration = fakeRegistration({
+  currentAttendeeCount: 10,
+  currentWaitingListCount: 5,
+  enrolmentEndTime,
+  enrolmentStartTime,
+  id: TEST_REGISTRATION_ID,
+  maximumAttendeeCapacity: 10,
+  waitingListCapacity: 5,
+});
 
+test('should show warning if registration is full', async () => {
   renderComponent(registration);
 
-  await screen.findByText(
-    'Ilmoittautuminen tähän tapahtumaan on tällä hetkellä suljettu. Kokeile myöhemmin uudelleen.'
+  await screen.getByText(
+    'Tapahtuman kaikki paikat ovat tällä hetkellä varatut. Kokeile myöhemmin uudelleen.'
   );
+});
+
+test('should not show warning if registration is full but user has reservation', async () => {
+  const reservation = getMockedSeatsReservationData(1000);
+  setSessionStorageValues(reservation, registration);
+  renderComponent(registration);
+
+  expect(
+    screen.queryByText(
+      'Tapahtuman kaikki paikat ovat tällä hetkellä varatut. Kokeile myöhemmin uudelleen.'
+    )
+  ).not.toBeInTheDocument();
 });

--- a/src/domain/enrolment/reservationTimer/__tests__/ReservationTimer.test.tsx
+++ b/src/domain/enrolment/reservationTimer/__tests__/ReservationTimer.test.tsx
@@ -1,15 +1,16 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 import { MockedResponse } from '@apollo/client/testing';
-import addSeconds from 'date-fns/addSeconds';
-import subSeconds from 'date-fns/subSeconds';
 import React from 'react';
 
-import { RESERVATION_NAMES } from '../../../../constants';
 import {
   CreateSeatsReservationDocument,
   SeatsReservation,
 } from '../../../../generated/graphql';
-import { fakeSeatsReservation } from '../../../../utils/mockDataUtils';
+import {
+  fakeSeatsReservation,
+  getMockedSeatsReservationData,
+  setSessionStorageValues,
+} from '../../../../utils/mockDataUtils';
 import {
   render,
   screen,
@@ -73,32 +74,6 @@ beforeEach(() => {
   localStorage.clear();
   sessionStorage.clear();
 });
-
-const setSessionStorageValues = (reservation: SeatsReservation) => {
-  jest.spyOn(sessionStorage, 'getItem').mockImplementation((key: string) => {
-    switch (key) {
-      case `${RESERVATION_NAMES.ENROLMENT_RESERVATION}-${registration.id}`:
-        return reservation ? JSON.stringify(reservation) : '';
-      default:
-        return '';
-    }
-  });
-};
-
-const getReservationData = (expirationOffset: number) => {
-  const now = new Date();
-  let expiration = '';
-
-  if (expirationOffset) {
-    expiration = addSeconds(now, expirationOffset).toISOString();
-  } else {
-    expiration = subSeconds(now, expirationOffset).toISOString();
-  }
-
-  const reservation = fakeSeatsReservation({ expiration });
-
-  return reservation;
-};
 
 const getSeatsReservationErrorMock = (error: Error): MockedResponse => {
   return {
@@ -169,7 +144,7 @@ test('should show modal if any of the reserved seats is in waiting list', async 
 test('should route to create enrolment page if reservation is expired', async () => {
   const user = userEvent.setup();
 
-  setSessionStorageValues(getReservationData(-1000));
+  setSessionStorageValues(getMockedSeatsReservationData(-1000), registration);
 
   renderComponent();
   const modal = await screen.findByRole(

--- a/src/domain/events/eventActionsDropdown/EventActionsDropdown.tsx
+++ b/src/domain/events/eventActionsDropdown/EventActionsDropdown.tsx
@@ -67,6 +67,7 @@ const EventActionsDropdown: React.FC<EventActionsDropdownProps> = ({
 
   const sendEmail = () => {
     let targetEmail = '';
+    /* istanbul ignore else */
     if (event.createdBy) {
       targetEmail = event.createdBy.split('-')[1].trim();
     }

--- a/src/domain/registration/__mocks__/registration.ts
+++ b/src/domain/registration/__mocks__/registration.ts
@@ -22,6 +22,8 @@ const registrationOverrides = {
   audienceMaxAge: 18,
   audienceMinAge: 12,
   confirmationMessage: 'Confirmation message',
+  currentAttendeeCount: 0,
+  currentWaitingListCount: 0,
   enrolmentEndTime,
   enrolmentStartTime,
   event,
@@ -30,6 +32,8 @@ const registrationOverrides = {
   maximumAttendeeCapacity: 100,
   minimumAttendeeCapacity: 10,
   publisher: event.publisher,
+  remainingAttendeeCapacity: 100,
+  remainingWaitingListCapacity: 10,
   signups: [],
   waitingListCapacity: 5,
 };

--- a/src/utils/mockDataUtils.ts
+++ b/src/utils/mockDataUtils.ts
@@ -1,9 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { faker } from '@faker-js/faker';
 import addMinutes from 'date-fns/addMinutes';
+import addSeconds from 'date-fns/addSeconds';
 import merge from 'lodash/merge';
 
-import { EXTLINK } from '../constants';
+import { EXTLINK, RESERVATION_NAMES } from '../constants';
 import { TEST_DATA_SOURCE_ID } from '../domain/dataSource/constants';
 import { NOTIFICATION_TYPE } from '../domain/enrolment/constants';
 import { TEST_PUBLISHER_ID } from '../domain/organization/constants';
@@ -44,6 +45,7 @@ import {
   PlacesResponse,
   PublicationStatus,
   Registration,
+  RegistrationFieldsFragment,
   RegistrationsResponse,
   SeatsReservation,
   SendMessageResponse,
@@ -625,4 +627,25 @@ const generateNodeArray = <T extends (...args: any) => any>(
   length: number
 ): ReturnType<T>[] => {
   return Array.from({ length }).map((_, i) => fakeFunc(i));
+};
+
+export const getMockedSeatsReservationData = (expirationOffset: number) => {
+  const now = new Date();
+  const expiration = addSeconds(now, expirationOffset).toISOString();
+
+  return fakeSeatsReservation({ expiration });
+};
+
+export const setSessionStorageValues = (
+  reservation: SeatsReservation,
+  registration: RegistrationFieldsFragment
+) => {
+  jest.spyOn(sessionStorage, 'getItem').mockImplementation((key: string) => {
+    const reservationKey = `${RESERVATION_NAMES.ENROLMENT_RESERVATION}-${registration.id}`;
+
+    if (key === reservationKey) {
+      return reservation ? JSON.stringify(reservation) : '';
+    }
+    return '';
+  });
 };


### PR DESCRIPTION
## Description
- Enrolment is closed if enrolment_start_time is defined and is in the future or enrolment_end_time is defined and is in the past
- Show different warning message if enrolment is open but there is no available seats
- Add reserved seats to available seats amount if there is already reservation in the session storage
- Disable enrolment form also if there is no available places and seats reservation is not stored to session storage

PR for API implementation: https://github.com/City-of-Helsinki/linkedevents/pull/611

## Closes
[LINK-1363](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1363)

[LINK-1363]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ