### PR TITLE
LINK-1374 | Unify format of saving organization users with API

### DIFF
--- a/schema.js
+++ b/schema.js
@@ -385,12 +385,8 @@ module.exports = buildSchema(/* GraphQL */ `
     usage: String
   }
 
-  input OrganizationUsersInput {
-    username: [String]
-  }
-
   input CreateOrganizationMutationInput {
-    adminUsers: OrganizationUsersInput
+    adminUsers: [String]
     affiliatedOrganizations: [String]
     classification: String
     dataSource: String
@@ -401,13 +397,13 @@ module.exports = buildSchema(/* GraphQL */ `
     name: String
     originId: String
     parentOrganization: String
-    regularUsers: OrganizationUsersInput
+    regularUsers: [String]
     replacedBy: String
     subOrganizations: [String]
   }
 
   input UpdateOrganizationMutationInput {
-    adminUsers: OrganizationUsersInput
+    adminUsers: [String]
     affiliatedOrganizations: [String]
     classification: String
     dataSource: String
@@ -417,7 +413,7 @@ module.exports = buildSchema(/* GraphQL */ `
     internalType: String
     name: String
     parentOrganization: String
-    regularUsers: OrganizationUsersInput
+    regularUsers: [String]
     replacedBy: String
     subOrganizations: [String]
   }

--- a/src/domain/event/__tests__/EditEventPage.test.tsx
+++ b/src/domain/event/__tests__/EditEventPage.test.tsx
@@ -305,7 +305,7 @@ test('should update event', async () => {
   await actWait(100);
 });
 
-test.only('should update recurring event', async () => {
+test('should update recurring event', async () => {
   const mocks: MockedResponse[] = [
     ...baseMocks.filter((item) => item.request.query !== EventDocument),
     mockedEventWithSubEventResponse,

--- a/src/domain/organization/__mocks__/createOrganizationPage.ts
+++ b/src/domain/organization/__mocks__/createOrganizationPage.ts
@@ -15,14 +15,14 @@ const organizationValues = {
 };
 
 const payload = {
-  adminUsers: { username: [] },
+  adminUsers: [],
   affiliatedOrganizations: [],
   classification: organizationValues.classification,
   dataSource: organizationValues.dataSource,
   internalType: ORGANIZATION_INTERNAL_TYPE.NORMAL,
   name: organizationValues.name,
   parentOrganization: organizations.data[0]?.atId,
-  regularUsers: { username: [] },
+  regularUsers: [],
   replacedBy: '',
   subOrganizations: [],
   dissolutionDate: null,

--- a/src/domain/organization/__mocks__/editOrganizationPage.ts
+++ b/src/domain/organization/__mocks__/editOrganizationPage.ts
@@ -25,13 +25,13 @@ const mockedDeleteOrganizationResponse: MockedResponse = {
 };
 
 const payload = {
-  adminUsers: { username: [users.data[0]?.username] },
+  adminUsers: [users.data[0]?.username],
   affiliatedOrganizations: [],
   classification: organizationClassification,
   internalType: 'normal',
   name: organizationName,
   parentOrganization: undefined,
-  regularUsers: { username: [] },
+  regularUsers: [],
   replacedBy: organizations.data[0]?.atId,
   subOrganizations: [],
   dataSource: TEST_DATA_SOURCE_ID,

--- a/src/domain/organization/__tests__/utils.test.ts
+++ b/src/domain/organization/__tests__/utils.test.ts
@@ -297,7 +297,7 @@ describe('getOrganizationInitialValues function', () => {
 describe('getOrganizationPayload function', () => {
   it('should return organization payload', () => {
     expect(getOrganizationPayload(ORGANIZATION_INITIAL_VALUES)).toEqual({
-      adminUsers: { username: [] },
+      adminUsers: [],
       affiliatedOrganizations: [],
       classification: '',
       dataSource: LINKED_EVENTS_SYSTEM_DATA_SOURCE,
@@ -308,7 +308,7 @@ describe('getOrganizationPayload function', () => {
       name: '',
       originId: '',
       parentOrganization: undefined,
-      regularUsers: { username: [] },
+      regularUsers: [],
       replacedBy: '',
       subOrganizations: [],
     });
@@ -331,7 +331,7 @@ describe('getOrganizationPayload function', () => {
         subOrganizations: ['organization:sub'],
       })
     ).toEqual({
-      adminUsers: { username: ['admin:1'] },
+      adminUsers: ['admin:1'],
       affiliatedOrganizations: ['organization:affiliated'],
       classification: 'ahjo:1',
       dataSource: 'helsinki',
@@ -342,7 +342,7 @@ describe('getOrganizationPayload function', () => {
       name: 'name',
       originId: '123',
       parentOrganization: 'organization:parent',
-      regularUsers: { username: ['regular:1'] },
+      regularUsers: ['regular:1'],
       replacedBy: 'organization:replaced',
       subOrganizations: ['organization:sub'],
     });

--- a/src/domain/organization/utils.ts
+++ b/src/domain/organization/utils.ts
@@ -351,7 +351,7 @@ export const getOrganizationPayload = (
 
   return {
     ...restFormValues,
-    adminUsers: { username: adminUsers },
+    adminUsers,
     dataSource,
     dissolutionDate: dissolutionDate
       ? formatDate(dissolutionDate, DATE_FORMAT_API)
@@ -362,6 +362,6 @@ export const getOrganizationPayload = (
     id: id || (originId ? `${dataSource}:${originId}` : undefined),
     originId,
     parentOrganization: parentOrganization || undefined,
-    regularUsers: { username: regularUsers },
+    regularUsers,
   };
 };

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -84,7 +84,7 @@ export type CreateKeywordSetMutationInput = {
 };
 
 export type CreateOrganizationMutationInput = {
-  adminUsers?: InputMaybe<OrganizationUsersInput>;
+  adminUsers?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
   affiliatedOrganizations?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
   classification?: InputMaybe<Scalars['String']>;
   dataSource?: InputMaybe<Scalars['String']>;
@@ -95,7 +95,7 @@ export type CreateOrganizationMutationInput = {
   name?: InputMaybe<Scalars['String']>;
   originId?: InputMaybe<Scalars['String']>;
   parentOrganization?: InputMaybe<Scalars['String']>;
-  regularUsers?: InputMaybe<OrganizationUsersInput>;
+  regularUsers?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
   replacedBy?: InputMaybe<Scalars['String']>;
   subOrganizations?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };
@@ -686,10 +686,6 @@ export type OrganizationClassesResponse = {
   meta: Meta;
 };
 
-export type OrganizationUsersInput = {
-  username?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-};
-
 export type OrganizationsResponse = {
   __typename?: 'OrganizationsResponse';
   data: Array<Maybe<Organization>>;
@@ -1116,7 +1112,7 @@ export type UpdateKeywordSetMutationInput = {
 };
 
 export type UpdateOrganizationMutationInput = {
-  adminUsers?: InputMaybe<OrganizationUsersInput>;
+  adminUsers?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
   affiliatedOrganizations?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
   classification?: InputMaybe<Scalars['String']>;
   dataSource?: InputMaybe<Scalars['String']>;
@@ -1126,7 +1122,7 @@ export type UpdateOrganizationMutationInput = {
   internalType?: InputMaybe<Scalars['String']>;
   name?: InputMaybe<Scalars['String']>;
   parentOrganization?: InputMaybe<Scalars['String']>;
-  regularUsers?: InputMaybe<OrganizationUsersInput>;
+  regularUsers?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
   replacedBy?: InputMaybe<Scalars['String']>;
   subOrganizations?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
 };


### PR DESCRIPTION
## Description :sparkles:
Use format 
´´´
{
  "admin_users": [ "u-ui745qfmxmi63dvsbjmavaacea" ],
  "regular_users": [ "u-ui745qfmxmi63dvsbjmavaacea" ],
  ...
}
´´´
instead of
´´´
{
  "admin_users": { "username": [ "u-ui745qfmxmi63dvsbjmavaacea" ] },
  "regular_users": { "username": [ "u-ui745qfmxmi63dvsbjmavaacea" ] },
  ...
}
´´´

NOTE: https://github.com/City-of-Helsinki/linkedevents/pull/609 should be merged before this

## Closes
[LINK-1374](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1374)

[LINK-1374]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ