### PR TITLE
LINK-1366 | Allow only select email as notification type in enrolment

### DIFF
--- a/src/domain/enrolment/__mocks__/createEnrolmentPage.ts
+++ b/src/domain/enrolment/__mocks__/createEnrolmentPage.ts
@@ -39,7 +39,7 @@ const payload: CreateEnrolmentMutationInput = {
       membershipNumber: '',
       name: enrolmentValues.name,
       nativeLanguage: 'fi',
-      notifications: NOTIFICATION_TYPE.SMS_EMAIL,
+      notifications: NOTIFICATION_TYPE.EMAIL,
       phoneNumber: enrolmentValues.phone,
       serviceLanguage: 'fi',
       streetAddress: enrolmentValues.streetAddress,

--- a/src/domain/enrolment/__mocks__/editEnrolmentPage.ts
+++ b/src/domain/enrolment/__mocks__/editEnrolmentPage.ts
@@ -27,7 +27,7 @@ const enrolmentValues = {
   name: 'Participant name',
   nativeLanguage: 'fi',
   notificationLanguage: 'fi',
-  notifications: NOTIFICATION_TYPE.SMS_EMAIL,
+  notifications: NOTIFICATION_TYPE.EMAIL,
   phoneNumber: '+358 44 123 4567',
   serviceLanguage: 'fi',
   streetAddress: 'Street address',

--- a/src/domain/enrolment/__tests__/CreateEnrolmentPage.test.tsx
+++ b/src/domain/enrolment/__tests__/CreateEnrolmentPage.test.tsx
@@ -252,8 +252,6 @@ const enterFormValues = async () => {
   const cityInput = getElement('cityInput');
   const emailInput = getElement('emailInput');
   const phoneInput = getElement('phoneInput');
-  const emailCheckbox = getElement('emailCheckbox');
-  const phoneCheckbox = getElement('phoneCheckbox');
   const nativeLanguageButton = getElement('nativeLanguageButton');
   const serviceLanguageButton = getElement('serviceLanguageButton');
 
@@ -262,9 +260,7 @@ const enterFormValues = async () => {
   await user.type(dateOfBirthInput, enrolmentValues.dateOfBirth);
   await user.type(zipInput, enrolmentValues.zip);
   await user.type(cityInput, enrolmentValues.city);
-  await user.click(emailCheckbox);
   await user.type(emailInput, enrolmentValues.email);
-  await user.click(phoneCheckbox);
   await user.type(phoneInput, enrolmentValues.phone);
   await user.click(nativeLanguageButton);
   const nativeLanguageOption = await screen.findByRole('option', {
@@ -293,8 +289,6 @@ test('should validate enrolment form and focus to invalid field and finally crea
   const cityInput = getElement('cityInput');
   const emailInput = getElement('emailInput');
   const phoneInput = getElement('phoneInput');
-  const emailCheckbox = getElement('emailCheckbox');
-  const phoneCheckbox = getElement('phoneCheckbox');
   const nativeLanguageButton = getElement('nativeLanguageButton');
   const serviceLanguageButton = getElement('serviceLanguageButton');
   const submitButton = await findElement('submitButton');
@@ -311,16 +305,6 @@ test('should validate enrolment form and focus to invalid field and finally crea
   expect(phoneInput).not.toBeRequired();
 
   await user.type(emailInput, enrolmentValues.email);
-  await user.click(submitButton);
-  await waitFor(() => expect(emailCheckbox).toHaveFocus());
-
-  await user.click(emailCheckbox);
-  await user.click(phoneCheckbox);
-  await user.click(submitButton);
-
-  await waitFor(() => expect(phoneInput).toHaveFocus());
-  expect(phoneInput).toBeRequired();
-
   await user.type(phoneInput, enrolmentValues.phone);
   await user.click(submitButton);
 

--- a/src/domain/enrolment/__tests__/EditEnrolmentPage.test.tsx
+++ b/src/domain/enrolment/__tests__/EditEnrolmentPage.test.tsx
@@ -152,14 +152,12 @@ test('should initialize input fields', async () => {
   const emailInput = getElement('emailInput');
   const phoneInput = getElement('phoneInput');
   const emailCheckbox = getElement('emailCheckbox');
-  const phoneCheckbox = getElement('phoneCheckbox');
 
   await waitFor(() => expect(nameInput).toHaveValue(enrolment.name));
   expect(cityInput).toHaveValue(enrolment.city);
   expect(emailInput).toHaveValue(enrolment.email);
   expect(phoneInput).toHaveValue(enrolment.phoneNumber);
   expect(emailCheckbox).toBeChecked();
-  expect(phoneCheckbox).toBeChecked();
 });
 
 test('should cancel enrolment', async () => {

--- a/src/domain/enrolment/__tests__/utils.test.ts
+++ b/src/domain/enrolment/__tests__/utils.test.ts
@@ -118,7 +118,7 @@ describe('getEnrolmentInitialValues function', () => {
     expect(extraInfo).toBe('');
     expect(membershipNumber).toBe('');
     expect(nativeLanguage).toBe('');
-    expect(notifications).toEqual([]);
+    expect(notifications).toEqual([NOTIFICATIONS.EMAIL]);
     expect(phoneNumber).toBe('');
     expect(serviceLanguage).toBe('');
   });
@@ -131,7 +131,7 @@ describe('getEnrolmentInitialValues function', () => {
     const expectedMembershipNumber = 'XXX-XXX-XXX';
     const expectedName = 'Name';
     const expectedNativeLanguage = 'fi';
-    const expectedNotifications = [NOTIFICATIONS.EMAIL, NOTIFICATIONS.SMS];
+    const expectedNotifications = [NOTIFICATIONS.EMAIL];
     const expectedPhoneNumber = '+358 44 123 4567';
     const expectedServiceLanguage = 'sv';
     const expectedStreetAddress = 'Test address';
@@ -155,7 +155,7 @@ describe('getEnrolmentInitialValues function', () => {
         membershipNumber: expectedMembershipNumber,
         name: expectedName,
         nativeLanguage: expectedNativeLanguage,
-        notifications: NOTIFICATION_TYPE.SMS_EMAIL,
+        notifications: NOTIFICATION_TYPE.EMAIL,
         phoneNumber: expectedPhoneNumber,
         serviceLanguage: expectedServiceLanguage,
         streetAddress: expectedStreetAddress,
@@ -244,7 +244,7 @@ describe('getEnrolmentPayload function', () => {
           membershipNumber: '',
           name: '',
           nativeLanguage: null,
-          notifications: 'none',
+          notifications: NOTIFICATION_TYPE.EMAIL,
           phoneNumber: null,
           serviceLanguage: null,
           streetAddress: null,
@@ -331,7 +331,7 @@ describe('getUpdateEnrolmentPayload function', () => {
       membershipNumber: '',
       name: '',
       nativeLanguage: null,
-      notifications: NOTIFICATION_TYPE.NO_NOTIFICATION,
+      notifications: NOTIFICATION_TYPE.EMAIL,
       phoneNumber: null,
       registration: registration.id,
       serviceLanguage: null,

--- a/src/domain/enrolment/__tests__/validation.test.ts
+++ b/src/domain/enrolment/__tests__/validation.test.ts
@@ -5,8 +5,14 @@ import { RegistrationFieldsFragment } from '../../../generated/graphql';
 import { fakeRegistration } from '../../../utils/mockDataUtils';
 import { VALIDATION_MESSAGE_KEYS } from '../../app/i18n/constants';
 import { REGISTRATION_MANDATORY_FIELDS } from '../../registration/constants';
-import { AttendeeFields } from '../types';
-import { getAttendeeSchema, isAboveMinAge, isBelowMaxAge } from '../validation';
+import { NOTIFICATIONS } from '../constants';
+import { AttendeeFields, EnrolmentFormFields } from '../types';
+import {
+  getAttendeeSchema,
+  getEnrolmentSchema,
+  isAboveMinAge,
+  isBelowMaxAge,
+} from '../validation';
 
 afterEach(() => {
   clear();
@@ -56,6 +62,18 @@ const testAttendeeSchema = async (
 ) => {
   try {
     await getAttendeeSchema(registration).validate(attendee);
+    return true;
+  } catch (e) {
+    return false;
+  }
+};
+
+const testEnrolmentSchema = async (
+  registration: RegistrationFieldsFragment,
+  enrolment: EnrolmentFormFields
+) => {
+  try {
+    await getEnrolmentSchema(registration).validate(enrolment);
     return true;
   } catch (e) {
     return false;
@@ -234,6 +252,124 @@ describe('attendeeSchema function', () => {
         ...validAttendee,
         zipcode: '123456',
       })
+    ).toBe(false);
+  });
+});
+
+describe('testEnrolmentSchema function', () => {
+  const registration = fakeRegistration();
+  const validEnrolment: EnrolmentFormFields = {
+    attendees: [],
+    email: 'user@email.com',
+    extraInfo: '',
+    membershipNumber: '',
+    nativeLanguage: 'fi',
+    notifications: [NOTIFICATIONS.EMAIL],
+    phoneNumber: '',
+    serviceLanguage: 'fi',
+  };
+
+  test('should return true if enrolment data is valid', async () => {
+    expect(await testEnrolmentSchema(registration, validEnrolment)).toBe(true);
+  });
+
+  test('should return false if email is missing', async () => {
+    expect(
+      await testEnrolmentSchema(registration, {
+        ...validEnrolment,
+        email: '',
+      })
+    ).toBe(false);
+  });
+
+  test('should return false if email is invalid', async () => {
+    expect(
+      await testEnrolmentSchema(registration, {
+        ...validEnrolment,
+        email: 'user@email.',
+      })
+    ).toBe(false);
+  });
+
+  test('should return false if phone number is missing', async () => {
+    expect(
+      await testEnrolmentSchema(registration, {
+        ...validEnrolment,
+        phoneNumber: '',
+        notifications: [NOTIFICATIONS.SMS],
+      })
+    ).toBe(false);
+  });
+
+  test('should return false if phone number is invalid', async () => {
+    expect(
+      await testEnrolmentSchema(registration, {
+        ...validEnrolment,
+        phoneNumber: 'xxx',
+      })
+    ).toBe(false);
+  });
+
+  test('should return false if notifications is empty array', async () => {
+    expect(
+      await testEnrolmentSchema(registration, {
+        ...validEnrolment,
+        notifications: [],
+      })
+    ).toBe(false);
+  });
+
+  test('should return false if native language is empty', async () => {
+    expect(
+      await testEnrolmentSchema(registration, {
+        ...validEnrolment,
+        nativeLanguage: '',
+      })
+    ).toBe(false);
+  });
+
+  test('should return false if service language is empty', async () => {
+    expect(
+      await testEnrolmentSchema(registration, {
+        ...validEnrolment,
+        serviceLanguage: '',
+      })
+    ).toBe(false);
+  });
+
+  test('should return false if membership number is set as mandatory field but value is empty', async () => {
+    expect(
+      await testEnrolmentSchema(
+        fakeRegistration({ mandatoryFields: ['membership_number'] }),
+        {
+          ...validEnrolment,
+          membershipNumber: '',
+        }
+      )
+    ).toBe(false);
+  });
+
+  test('should return false if extra info is set as mandatory field but value is empty', async () => {
+    expect(
+      await testEnrolmentSchema(
+        fakeRegistration({ mandatoryFields: ['extra_info'] }),
+        {
+          ...validEnrolment,
+          extraInfo: '',
+        }
+      )
+    ).toBe(false);
+  });
+
+  test('should return false if phone number is set as mandatory field but value is empty', async () => {
+    expect(
+      await testEnrolmentSchema(
+        fakeRegistration({ mandatoryFields: ['phone_number'] }),
+        {
+          ...validEnrolment,
+          phoneNumber: '',
+        }
+      )
     ).toBe(false);
   });
 });

--- a/src/domain/enrolment/constants.tsx
+++ b/src/domain/enrolment/constants.tsx
@@ -2,6 +2,18 @@ import { IconCrossCircle, IconEnvelope, IconEye, IconPen } from 'hds-react';
 
 import { AttendeeFields, EnrolmentFormFields } from './types';
 
+export enum NOTIFICATIONS {
+  EMAIL = 'email',
+  SMS = 'sms',
+}
+
+export enum NOTIFICATION_TYPE {
+  NO_NOTIFICATION = 'none',
+  SMS = 'sms',
+  EMAIL = 'email',
+  SMS_EMAIL = 'sms and email',
+}
+
 export enum ATTENDEE_FIELDS {
   CITY = 'city',
   DATE_OF_BIRTH = 'dateOfBirth',
@@ -46,22 +58,10 @@ export const ENROLMENT_INITIAL_VALUES: EnrolmentFormFields = {
   [ENROLMENT_FIELDS.EXTRA_INFO]: '',
   [ENROLMENT_FIELDS.MEMBERSHIP_NUMBER]: '',
   [ENROLMENT_FIELDS.NATIVE_LANGUAGE]: '',
-  [ENROLMENT_FIELDS.NOTIFICATIONS]: [],
+  [ENROLMENT_FIELDS.NOTIFICATIONS]: [NOTIFICATIONS.EMAIL],
   [ENROLMENT_FIELDS.PHONE_NUMBER]: '',
   [ENROLMENT_FIELDS.SERVICE_LANGUAGE]: '',
 };
-
-export enum NOTIFICATIONS {
-  EMAIL = 'email',
-  SMS = 'sms',
-}
-
-export enum NOTIFICATION_TYPE {
-  NO_NOTIFICATION = 'none',
-  SMS = 'sms',
-  EMAIL = 'email',
-  SMS_EMAIL = 'sms and email',
-}
 
 export const ENROLMENT_FORM_SELECT_FIELDS = [
   ENROLMENT_FIELDS.NATIVE_LANGUAGE,

--- a/src/domain/enrolment/enrolmentFormFields/EnrolmentFormFields.tsx
+++ b/src/domain/enrolment/enrolmentFormFields/EnrolmentFormFields.tsx
@@ -75,7 +75,9 @@ const EnrolmentForm: React.FC<Props> = ({ disabled, registration }) => {
             name={ENROLMENT_FIELDS.NOTIFICATIONS}
             className={styles.notifications}
             component={CheckboxGroupField}
-            disabled={disabled}
+            // TODO: At the moment only email notifications are supported
+            disabled={true}
+            // disabled={disabled}
             label={t(`enrolment.form.titleNotifications`)}
             options={notificationOptions}
             required

--- a/src/domain/enrolment/utils.ts
+++ b/src/domain/enrolment/utils.ts
@@ -88,9 +88,11 @@ export const getEnrolmentInitialValues = (
     extraInfo: getValue(enrolment.extraInfo, ''),
     membershipNumber: getValue(enrolment.membershipNumber, ''),
     nativeLanguage: getValue(enrolment.nativeLanguage, ''),
-    notifications: getEnrolmentNotificationTypes(
-      getValue(enrolment.notifications, '')
-    ),
+    // TODO: At the moment only email notifications are supported
+    notifications: [NOTIFICATIONS.EMAIL],
+    // notifications: getEnrolmentNotificationTypes(
+    //   getValue(enrolment.notifications, '')
+    // ),
     phoneNumber: getValue(enrolment.phoneNumber, ''),
     serviceLanguage: getValue(enrolment.serviceLanguage, ''),
   };
@@ -175,7 +177,6 @@ export const getUpdateEnrolmentPayload = ({
     extraInfo,
     membershipNumber,
     nativeLanguage,
-    notifications,
     phoneNumber,
     serviceLanguage,
   } = formValues;
@@ -191,7 +192,9 @@ export const getUpdateEnrolmentPayload = ({
     membershipNumber: membershipNumber,
     name: getValue(name, ''),
     nativeLanguage: getValue(nativeLanguage, null),
-    notifications: getEnrolmentNotificationsCode(notifications),
+    // TODO: At the moment only email notifications are supported
+    notifications: NOTIFICATION_TYPE.EMAIL,
+    // notifications: getEnrolmentNotificationsCode(notifications),
     phoneNumber: getValue(phoneNumber, null),
     registration: getValue(registration.id, ''),
     serviceLanguage: getValue(serviceLanguage, null),


### PR DESCRIPTION
## Description
Allow only select email as notification type in enrolment

## Closes
[LINK-1366](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1366)

## Screenshot
<img width="853" alt="Screenshot 2023-07-03 at 15 57 33" src="https://github.com/City-of-Helsinki/linkedcomponents-ui/assets/24706814/f4bd8a84-0fa3-42e7-b227-1a6e1d071576">

[LINK-1366]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ