### PR TITLE
Add information that Draft will be published/cancelled by moderators

### DIFF
--- a/src/domain/app/i18n/en.json
+++ b/src/domain/app/i18n/en.json
@@ -546,6 +546,7 @@
       "buttonUpdateDraft": "Save draft",
       "buttonUpdatePublic": "Save changes",
       "checkboxIsVerified": "I verify that the information I have provided is correct and I undertake to comply with <a href={{url}} target=\"_blank\" rel=\"noopener noreferrer\" aria-label=\"all instructions and regulations {{openInNewTab}}\">all instructions and regulations</a> concerning the courses and events of the City of Helsinki.",
+      "eventDraftStateInfo": "The saved information will automatically be visible to the moderator as well. However, the information can be edited until the moderator publishes the event. The latter can be avoided by writing \"UNFINISHED\" at the beginning of the event title while editing is in progress.",
       "editButtonPanel": {
         "warningCancelledEvent": "Cancelled events can't be edited.",
         "warningCannotCancelDraft": "Event drafts can't be cancelled.",
@@ -1086,7 +1087,6 @@
     "pageTitleDraftSaved": "Draft saved",
     "pageTitlePublished": "Event published",
     "titleDraftSaved": "Draft successfully saved",
-    "titleDraftSavedInfo": "The saved information will automatically be visible to the moderator as well. However, the information can be edited until the moderator publishes the event. The latter can be avoided by writing \"UNFINISHED\" at the beginning of the event title while editing is in progress.",
     "titlePublished": "Event successfully published"
   },
   "eventsPage": {

--- a/src/domain/app/i18n/en.json
+++ b/src/domain/app/i18n/en.json
@@ -1086,6 +1086,7 @@
     "pageTitleDraftSaved": "Draft saved",
     "pageTitlePublished": "Event published",
     "titleDraftSaved": "Draft successfully saved",
+    "titleDraftSavedInfo": "The saved information will automatically be visible to the moderator as well. However, the information can be edited until the moderator publishes the event. The latter can be avoided by writing \"UNFINISHED\" at the beginning of the event title while editing is in progress.",
     "titlePublished": "Event successfully published"
   },
   "eventsPage": {

--- a/src/domain/app/i18n/fi.json
+++ b/src/domain/app/i18n/fi.json
@@ -546,6 +546,7 @@
       "buttonUpdateDraft": "Tallenna luonnos",
       "buttonUpdatePublic": "Tallenna muutokset",
       "checkboxIsVerified": "Vakuutan, että antamani tiedot ovat oikein ja sitoudun noudattamaan kaikkia Helsingin kaupungin kursseja ja tapahtumia <a href={{url}} target=\"_blank\" rel=\"noopener noreferrer\" aria-label=\"koskevia ohjeita ja säädöksiä {{openInNewTab}}\">koskevia ohjeita ja säädöksiä</a>.",
+      "eventDraftStateInfo": "Tallennetut tiedot tulevat automaattisesti näkyville myös moderoijalle. Tietoja voi kuitenkin muokata, kunnes moderaattori julkaisee tapahtuman. Jälkimmäisen voi välttää kirjoittamalla muokkauksen ajaksi tapahtuman otsikon alkuun \"KESKENERÄINEN\".",
       "editButtonPanel": {
         "warningCancelledEvent": "Peruttuja tapahtumia ei voi muokata.",
         "warningCannotCancelDraft": "Tapahtumaluonnosta ei voi perua.",
@@ -1086,7 +1087,6 @@
     "pageTitleDraftSaved": "Luonnos tallennettu",
     "pageTitlePublished": "Tapahtuma julkaistu",
     "titleDraftSaved": "Luonnos tallennettu onnistuneesti",
-    "titleDraftSavedInfo": "Tallennetut tiedot tulevat automaattisesti näkyville myös moderoijalle. Tietoja voi kuitenkin muokata, kunnes moderaattori julkaisee tapahtuman. Jälkimmäisen voi välttää kirjoittamalla muokkauksen ajaksi tapahtuman otsikon alkuun \"KESKENERÄINEN\".",
     "titlePublished": "Tapahtuma julkaistu onnistuneesti"
   },
   "eventsPage": {

--- a/src/domain/app/i18n/fi.json
+++ b/src/domain/app/i18n/fi.json
@@ -1086,6 +1086,7 @@
     "pageTitleDraftSaved": "Luonnos tallennettu",
     "pageTitlePublished": "Tapahtuma julkaistu",
     "titleDraftSaved": "Luonnos tallennettu onnistuneesti",
+    "titleDraftSavedInfo": "Tallennetut tiedot tulevat automaattisesti näkyville myös moderoijalle. Tietoja voi kuitenkin muokata, kunnes moderaattori julkaisee tapahtuman. Jälkimmäisen voi välttää kirjoittamalla muokkauksen ajaksi tapahtuman otsikon alkuun \"KESKENERÄINEN\".",
     "titlePublished": "Tapahtuma julkaistu onnistuneesti"
   },
   "eventsPage": {

--- a/src/domain/app/i18n/sv.json
+++ b/src/domain/app/i18n/sv.json
@@ -546,6 +546,7 @@
       "buttonUpdateDraft": "Spara utkast",
       "buttonUpdatePublic": "Spara ändringar",
       "checkboxIsVerified": "Jag verifierar att informationen jag har gett är korrekt och jag förbinder mig att följa <a href={{url}} target=\"_blank\" rel=\"noopener noreferrer\" aria-label=\"alla instruktioner och föreskrifter {{openInNewTab}}\">alla instruktioner och föreskrifter</a> som gäller Helsingfors stads kurser och evenemang.",
+      "eventDraftStateInfo": "Den sparade informationen kommer automatiskt att vara synlig även för moderatorn. Informationen kan dock redigeras fram till dess att moderatorn publicerar evenemanget. Det senare kan undvikas genom att skriva \"OFULLBORDAD\" i början av evenemangets titel medan redigeringen pågår.",
       "editButtonPanel": {
         "warningCancelledEvent": "Avbrutna evenemang kan inte redigeras.",
         "warningCannotCancelDraft": "Evenemangs utkast kan inte avbrytas.",
@@ -1086,7 +1087,6 @@
     "pageTitleDraftSaved": "Utkastet har sparats",
     "pageTitlePublished": "Evenemanget har publicerats",
     "titleDraftSaved": "Utkastet har sparats",
-    "titleDraftSavedInfo": "Den sparade informationen kommer automatiskt att vara synlig även för moderatorn. Informationen kan dock redigeras fram till dess att moderatorn publicerar evenemanget. Det senare kan undvikas genom att skriva \"OFULLBORDAD\" i början av evenemangets titel medan redigeringen pågår.",    
     "titlePublished": "Evenemanget har publicerats"
   },
   "eventsPage": {

--- a/src/domain/app/i18n/sv.json
+++ b/src/domain/app/i18n/sv.json
@@ -1086,6 +1086,7 @@
     "pageTitleDraftSaved": "Utkastet har sparats",
     "pageTitlePublished": "Evenemanget har publicerats",
     "titleDraftSaved": "Utkastet har sparats",
+    "titleDraftSavedInfo": "Den sparade informationen kommer automatiskt att vara synlig även för moderatorn. Informationen kan dock redigeras fram till dess att moderatorn publicerar evenemanget. Det senare kan undvikas genom att skriva \"OFULLBORDAD\" i början av evenemangets titel medan redigeringen pågår.",    
     "titlePublished": "Evenemanget har publicerats"
   },
   "eventsPage": {

--- a/src/domain/event/eventForm/EventForm.tsx
+++ b/src/domain/event/eventForm/EventForm.tsx
@@ -47,6 +47,7 @@ import AudienceSection from '../formSections/audienceSection/AudienceSection';
 import ChannelsSection from '../formSections/channelsSection/ChannelsSection';
 import ClassificationSection from '../formSections/classificationSection/ClassificationSection';
 import DescriptionSection from '../formSections/descriptionSection/DescriptionSection';
+import EventStateInfoSection from '../formSections/eventStateInfoSection/EventStateInfoSection';
 import ExternalUserContact from '../formSections/externalUserContact/ExternalUserContact';
 import ImageSection from '../formSections/imageSection/ImageSection';
 import LanguagesSection from '../formSections/languagesSection/LanguagesSection';
@@ -482,7 +483,19 @@ const EventForm: React.FC<EventFormProps> = ({
                   </Section>
                 </>
               ) : (
-                <SummarySection isEditingAllowed={isEditingAllowed} />
+                <>
+                  <SummarySection isEditingAllowed={isEditingAllowed} />
+                  {isExternalUser ? (
+                    <EventStateInfoSection
+                      text={getValue(
+                        t('eventSavedPage.titleDraftSavedInfo'),
+                        ''
+                      )}
+                    />
+                  ) : (
+                    ''
+                  )}
+                </>
               )}
             </Container>
             {event ? (

--- a/src/domain/event/eventForm/EventForm.tsx
+++ b/src/domain/event/eventForm/EventForm.tsx
@@ -487,10 +487,7 @@ const EventForm: React.FC<EventFormProps> = ({
                   <SummarySection isEditingAllowed={isEditingAllowed} />
                   {isExternalUser ? (
                     <EventStateInfoSection
-                      text={getValue(
-                        t('eventSavedPage.titleDraftSavedInfo'),
-                        ''
-                      )}
+                      text={getValue(t('event.form.eventDraftStateInfo'), '')}
                     />
                   ) : (
                     ''

--- a/src/domain/event/formSections/eventStateInfoSection/EventStateInfoSection.tsx
+++ b/src/domain/event/formSections/eventStateInfoSection/EventStateInfoSection.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import styles from './eventStateInfoSection.module.scss';
 
 type EventStateInfoProps = {
-  text?: string;
+  text: string;
 };
 
 const EventStateInfoSection: React.FC<EventStateInfoProps> = ({ text }) => {

--- a/src/domain/event/formSections/eventStateInfoSection/EventStateInfoSection.tsx
+++ b/src/domain/event/formSections/eventStateInfoSection/EventStateInfoSection.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+import styles from './eventStateInfoSection.module.scss';
+
+type EventStateInfoProps = {
+  text?: string;
+};
+
+const EventStateInfoSection: React.FC<EventStateInfoProps> = ({ text }) => {
+  return (
+    <figure className={styles.infoWrapper}>
+      <blockquote className={styles.infoBlock}>
+        <p className={styles.infoText}>{text}</p>
+      </blockquote>
+    </figure>
+  );
+};
+
+export default EventStateInfoSection;

--- a/src/domain/event/formSections/eventStateInfoSection/eventStateInfoSection.module.scss
+++ b/src/domain/event/formSections/eventStateInfoSection/eventStateInfoSection.module.scss
@@ -1,0 +1,20 @@
+.infoWrapper {
+  background-color: var(--color-info-light);
+  border-left: 8px solid var(--color-info);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  margin: 0;
+  margin-bottom: var(--spacing-l);
+  padding: 0 var(--spacing-m);
+}
+.infoBlock {
+  font-size: var(--fontsize-body-m);
+  line-height: 26px;
+  margin: 0;
+  padding: var(--spacing-s);
+}
+.infoText {
+  margin: 0;
+  padding: 0;
+}


### PR DESCRIPTION
## Description 

Adds an informative text to event form page, that Draft will be published/cancelled by moderators.
The texts are in the ticket

### Motivation 

[LINK-1380](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1380)


[LINK-1380]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ