### PR TITLE
LINK-1034/add-venue-inside-outside-text.

### DIFF
--- a/src/domain/app/i18n/en.json
+++ b/src/domain/app/i18n/en.json
@@ -660,7 +660,7 @@
       "infoTextLocation3": "If the venue is found on the list, its location does not need to be described separately. However, you can provide additional information for finding the venue, such as the floor number or classroom name.",
       "infoTextLocation4": "If the exact venue is not found on the list, select the nearest street address as the venue, enter the name of the venue or other brief arrival instructions in the additional information field.",
       "infoTextLocation5": "If the location information has changed, update it in the location register. For services other than the city, add or update the information in the <a href=\"https://kaupunkialustana.hel.fi/en/\" target=\"_blank\" rel=\"noopener noreferrer\" aria-label=\"City Platform {{openInNewTab}}\">City Platform</a> service.",
-      "infoTextLocation6": "Select where the event will mainly take place from the Inside/Outside options.",
+      "infoTextLocation6": "Select where the event will mainly take place from the Indoors/Outdoors options.",
       "infoTextMainCategories": {
         "course": "Select at least one main category. Using the correct main categories makes it easier to find the course.",
         "general": "Select at least one main category. Using the correct main categories makes it easier to find the event.",

--- a/src/domain/app/i18n/en.json
+++ b/src/domain/app/i18n/en.json
@@ -660,6 +660,7 @@
       "infoTextLocation3": "If the venue is found on the list, its location does not need to be described separately. However, you can provide additional information for finding the venue, such as the floor number or classroom name.",
       "infoTextLocation4": "If the exact venue is not found on the list, select the nearest street address as the venue, enter the name of the venue or other brief arrival instructions in the additional information field.",
       "infoTextLocation5": "If the location information has changed, update it in the location register. For services other than the city, add or update the information in the <a href=\"https://kaupunkialustana.hel.fi/en/\" target=\"_blank\" rel=\"noopener noreferrer\" aria-label=\"City Platform {{openInNewTab}}\">City Platform</a> service.",
+      "infoTextLocation6": "Select where the event will mainly take place from the Inside/Outside options.",
       "infoTextMainCategories": {
         "course": "Select at least one main category. Using the correct main categories makes it easier to find the course.",
         "general": "Select at least one main category. Using the correct main categories makes it easier to find the event.",

--- a/src/domain/app/i18n/fi.json
+++ b/src/domain/app/i18n/fi.json
@@ -660,6 +660,7 @@
       "infoTextLocation3": "Jos tapahtumapaikka löytyy listasta, sen sijaintia ei tarvitse kuvailla erikseen. Voit kuitenkin antaa lisätietoja tapahtumapaikan löytämiseksi, esimerkiksi kerrosnumeron tai luokkahuoneen nimen.",
       "infoTextLocation4": "Jos tarkkaa tapahtumapaikkaa ei löydy listasta, valitse tapahtumapaikaksi lähin katuosoite ja kirjoita paikan nimi tai muut tarkemmat saapumisohjeet tiiviisti lisätietokenttään.",
       "infoTextLocation5": "Jos paikan tiedot ovat muuttuneet, päivitä ne toimipisterekisterissä. Muiden kuin kaupungin palvelujen osalta, lisää tai päivitä tiedot <a href=\"https://kaupunkialustana.hel.fi/\" target=\"_blank\" rel=\"noopener noreferrer\" aria-label=\"Kaupunki alustana {{openInNewTab}}\">Kaupunki alustana</a> -palvelussa.",
+      "infoTextLocation6": "Valitse tapahtuman pääasiallinen tapahtumapaikka Sisällä/Ulkona-vaihtoehdoista.",
       "infoTextMainCategories": {
         "course": "Valitse vähintään yksi pääluokka (kategoria). Oikeiden pääkategorioiden käyttäminen helpottaa kurssin löytämistä.",
         "general": "Valitse vähintään yksi pääluokka (kategoria). Oikeiden pääkategorioiden käyttäminen helpottaa tapahtuman löytämistä.",

--- a/src/domain/app/i18n/sv.json
+++ b/src/domain/app/i18n/sv.json
@@ -660,6 +660,7 @@
       "infoTextLocation3": "Om platsen finns i listan behöver dess plats inte beskrivas separat. Du kan dock ge ytterligare information för att hitta platsen, till exempel våningsnummer eller klassrumsnamn.",
       "infoTextLocation4": "Om den exakta platsen inte finns i listan, välj närmaste gatuadress som plats och ange platsens namn eller andra detaljerade ankomstinstruktioner i fältet för ytterligare information.",
       "infoTextLocation5": "Om platsinformationen har ändrats, uppdatera den i platsregistret. För tjänster utanför staden, lägg till eller uppdatera information i tjänsten <a href=\"https://kaupunkialustana.hel.fi/sv/\" target=\"_blank\" rel=\"noopener noreferrer\" aria-label=\"Stadsplattform {{openInNewTab}}\">Stadsplattform</a>.",
+      "infoTextLocation6": "Välj var evenemanget huvudsakligen kommer att äga rum från alternativen Inside/Outside.",
       "infoTextMainCategories": {
         "course": "Välj minst en huvudkategori. Rätt huvudkategori gör det lättare att hitta kursen.",
         "general": "Välj minst en huvudkategori. Rätt huvudkategori gör det lättare att hitta evenemanget.",

--- a/src/domain/app/i18n/sv.json
+++ b/src/domain/app/i18n/sv.json
@@ -660,7 +660,7 @@
       "infoTextLocation3": "Om platsen finns i listan behöver dess plats inte beskrivas separat. Du kan dock ge ytterligare information för att hitta platsen, till exempel våningsnummer eller klassrumsnamn.",
       "infoTextLocation4": "Om den exakta platsen inte finns i listan, välj närmaste gatuadress som plats och ange platsens namn eller andra detaljerade ankomstinstruktioner i fältet för ytterligare information.",
       "infoTextLocation5": "Om platsinformationen har ändrats, uppdatera den i platsregistret. För tjänster utanför staden, lägg till eller uppdatera information i tjänsten <a href=\"https://kaupunkialustana.hel.fi/sv/\" target=\"_blank\" rel=\"noopener noreferrer\" aria-label=\"Stadsplattform {{openInNewTab}}\">Stadsplattform</a>.",
-      "infoTextLocation6": "Välj var evenemanget huvudsakligen kommer att äga rum från alternativen Inside/Outside.",
+      "infoTextLocation6": "Välj var evenemanget huvudsakligen kommer att äga rum från alternativen Inomhus/Utomhus.",
       "infoTextMainCategories": {
         "course": "Välj minst en huvudkategori. Rätt huvudkategori gör det lättare att hitta kursen.",
         "general": "Välj minst en huvudkategori. Rätt huvudkategori gör det lättare att hitta evenemanget.",

--- a/src/domain/event/formSections/placeSection/PlaceSection.tsx
+++ b/src/domain/event/formSections/placeSection/PlaceSection.tsx
@@ -62,6 +62,7 @@ const PlaceSection: React.FC<Props> = ({
                 }),
               }}
             />
+            <p>{t(`event.form.infoTextLocation6`)}</p>
           </Notification>
         }
       >


### PR DESCRIPTION
Add more information about the venue inside/outside to the info text.

## Description :sparkles:

Add more information about the venue inside/outside selection to the notification info text.

## Issues :bug:
Part of:
**[LINK-1034](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1034)**

## Screenshots :camera_flash:

The addition is highlighted selecting with the cursor in the below image.

![image](https://github.com/City-of-Helsinki/linkedcomponents-ui/assets/8654955/051f47a2-f2df-4640-8195-babdc71ccafd)


[LINK-1034]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1034?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ