### PR TITLE
LINK-110 - add start: 'now' as default to

### DIFF
--- a/src/domain/events/__mocks__/eventsPage.ts
+++ b/src/domain/events/__mocks__/eventsPage.ts
@@ -32,6 +32,7 @@ const baseWaitingApprovalEventsVariables = {
   adminUser: true,
   publisher: [organizationId],
   publicationStatus: 'draft',
+  start: 'now',
 };
 const waitingApprovalEventsResponse = {
   data: { events: waitingApprovalEvents },
@@ -45,8 +46,8 @@ const mockedBaseWaitingApprovalEventsResponse: MockedResponse = {
 };
 
 const waitingApprovalEventsVariables = {
-  ...baseWaitingApprovalEventsVariables,
   ...commonSearchVariables,
+  ...baseWaitingApprovalEventsVariables,
 };
 
 const mockedWaitingApprovalEventsResponse: MockedResponse = {

--- a/src/domain/events/eventList/EventList.tsx
+++ b/src/domain/events/eventList/EventList.tsx
@@ -161,8 +161,8 @@ const EventListContainer: React.FC<EventListContainerProps> = (props) => {
   const sortOptions = useEventSortOptions();
 
   const variables = {
-    ...baseVariables,
     ...getEventsQueryVariables(location.search),
+    ...baseVariables,
   };
 
   const { data: eventsData, loading } = useEventsQuery({

--- a/src/domain/events/eventList/EventList.tsx
+++ b/src/domain/events/eventList/EventList.tsx
@@ -161,8 +161,8 @@ const EventListContainer: React.FC<EventListContainerProps> = (props) => {
   const sortOptions = useEventSortOptions();
 
   const variables = {
-    ...getEventsQueryVariables(location.search),
     ...baseVariables,
+    ...getEventsQueryVariables(location.search, baseVariables),
   };
 
   const { data: eventsData, loading } = useEventsQuery({

--- a/src/domain/events/utils.ts
+++ b/src/domain/events/utils.ts
@@ -151,6 +151,7 @@ export const getEventsQueryBaseVariables = ({
         adminUser: true,
         publisher: adminOrganizations,
         publicationStatus: PublicationStatus.Draft,
+        start: 'now',
       };
   }
 };

--- a/src/domain/events/utils.ts
+++ b/src/domain/events/utils.ts
@@ -200,11 +200,13 @@ export const getEventsQueryVariables = (
 ): EventsQueryVariables => {
   const searchParams = new URLSearchParams(search);
 
-  const start = searchParams.get(EVENT_SEARCH_PARAMS.START)
-    ? searchParams.get(EVENT_SEARCH_PARAMS.START)
-    : baseVariables && baseVariables.start
-    ? baseVariables.start
-    : null;
+  let start = null;
+
+  if (searchParams.get(EVENT_SEARCH_PARAMS.START)) {
+    start = searchParams.get(EVENT_SEARCH_PARAMS.START);
+  } else if (baseVariables?.start) {
+    start = baseVariables.start;
+  }
 
   const end = searchParams.get(EVENT_SEARCH_PARAMS.END);
   const places = searchParams.getAll(EVENT_SEARCH_PARAMS.PLACE);

--- a/src/domain/events/utils.ts
+++ b/src/domain/events/utils.ts
@@ -195,13 +195,19 @@ export const getEventSearchInitialValues = (
 };
 
 export const getEventsQueryVariables = (
-  search: string
+  search: string,
+  baseVariables?: EventsQueryVariables
 ): EventsQueryVariables => {
   const searchParams = new URLSearchParams(search);
 
+  const start = searchParams.get(EVENT_SEARCH_PARAMS.START)
+    ? searchParams.get(EVENT_SEARCH_PARAMS.START)
+    : baseVariables && baseVariables.start
+    ? baseVariables.start
+    : null;
+
   const end = searchParams.get(EVENT_SEARCH_PARAMS.END);
   const places = searchParams.getAll(EVENT_SEARCH_PARAMS.PLACE);
-  const start = searchParams.get(EVENT_SEARCH_PARAMS.START);
 
   const { page, sort, text, types } = getEventSearchInitialValues(search);
 


### PR DESCRIPTION
## Description :sparkles:

Add `start: 'now'` as default to `waitingApprovalVariables` and change the order of
combining variables in `EventList` because `getEventsQueryVariables`'s result contains `start: null` which would overwrite `baseVariables`'s start value.

### Related :handshake:
**[LINK-110](https://helsinkisolutionoffice.atlassian.net/browse/LINK-110):**

## Testing :alembic:
- Tested on local machine

[LINK-110]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ