### PR TITLE
Fix page layout when maintenance notification is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ Use .env.development.local for development.
 | REACT_APP_SHOW_REGISTRATION                | Flag to show registration related pages, Default true.                                                      |
 | REACT_APP_LOCALIZED_IMAGE                  | Flag to disabled localized image alt texts, Default true.                                                   |
 | REACT_APP_ENABLE_EXTERNAL_USER_EVENTS      | Flag to enable events for users without an organization, Default true.                                      |
+| REACT_APP_MAINTENANCE_SHOW_NOTIFICATION    | Flag to show maintenance notification in each page. Default is false.                                       |
+| REACT_APP_MAINTENANCE_DISABLE_LOGIN        | Flag to disable login and to show toast message instead. Default is false                                   |
 
 ## Feature flags
 

--- a/src/domain/app/layout/pageLayout/PageLayout.tsx
+++ b/src/domain/app/layout/pageLayout/PageLayout.tsx
@@ -85,11 +85,7 @@ const PageLayout: React.FC<React.PropsWithChildren<unknown>> = ({
 
             <Header />
             {MAINTENANCE_SHOW_NOTIFICATION && <MaintenanceNotification />}
-            <div
-              className={cx(styles.pageBody, {
-                [styles.noKoro]: noKoro,
-              })}
-            >
+            <div className={cx(styles.pageBody, { [styles.noKoro]: noKoro })}>
               {children}
             </div>
             <Footer />

--- a/src/domain/app/layout/pageLayout/PageLayout.tsx
+++ b/src/domain/app/layout/pageLayout/PageLayout.tsx
@@ -57,7 +57,8 @@ const PageLayout: React.FC<React.PropsWithChildren<unknown>> = ({
             className={cx(
               styles.pageLayout,
               css(theme.layout),
-              css(theme.root)
+              css(theme.root),
+              MAINTENANCE_SHOW_NOTIFICATION && styles.hasMaintenanceNotification
             )}
           >
             {/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */}
@@ -84,7 +85,11 @@ const PageLayout: React.FC<React.PropsWithChildren<unknown>> = ({
 
             <Header />
             {MAINTENANCE_SHOW_NOTIFICATION && <MaintenanceNotification />}
-            <div className={cx(styles.pageBody, { [styles.noKoro]: noKoro })}>
+            <div
+              className={cx(styles.pageBody, {
+                [styles.noKoro]: noKoro,
+              })}
+            >
               {children}
             </div>
             <Footer />

--- a/src/domain/app/layout/pageLayout/pageLayout.module.scss
+++ b/src/domain/app/layout/pageLayout/pageLayout.module.scss
@@ -6,6 +6,10 @@
   display: grid;
   grid-template-rows: auto 1fr auto;
   position: relative;
+
+  &.hasMaintenanceNotification {
+    grid-template-rows: auto auto 1fr auto;
+  }
 }
 
 .pageBody {


### PR DESCRIPTION
## Description
`grid-template-rows: auto 1fr auto;` in `.pageLayout` css class breaks page layout when REACT_APP_MAINTENANCE_SHOW_NOTIFICATION is enabled. Change it to `grid-template-rows: auto auto 1fr auto;` in that case.
 Document REACT_APP_MAINTENANCE_SHOW_NOTIFICATION and REACT_APP_MAINTENANCE_DISABLE_LOGIN in README.me

## Screenshots
Page layout before change:
<img width="1185" alt="Screenshot 2023-08-25 at 9 56 25" src="https://github.com/City-of-Helsinki/linkedcomponents-ui/assets/24706814/9666a9c3-fc56-404e-b158-1744ed2126c3">

Page layout after change:
<img width="1728" alt="Screenshot 2023-08-25 at 9 56 48" src="https://github.com/City-of-Helsinki/linkedcomponents-ui/assets/24706814/9fbe40c0-c5e3-4be9-8d41-48b8196b74e6">

