### PR TITLE
LINK-1473 | Use @id instead of id when defining in_language for the event

### DIFF
--- a/src/domain/enrolment/enrolmentFormFields/EnrolmentFormFields.tsx
+++ b/src/domain/enrolment/enrolmentFormFields/EnrolmentFormFields.tsx
@@ -29,7 +29,9 @@ const EnrolmentForm: React.FC<Props> = ({ disabled, registration }) => {
   const { t } = useTranslation();
   const notificationOptions = useNotificationOptions();
   const languageOptions = useLanguageOptions();
-  const serviceLanguageOptions = useLanguageOptions({ serviceLanguage: true });
+  const serviceLanguageOptions = useLanguageOptions({
+    variables: { serviceLanguage: true },
+  });
   const [{ value: notifications }] = useField<NOTIFICATIONS>({
     name: ENROLMENT_FIELDS.NOTIFICATIONS,
   });

--- a/src/domain/enrolment/hooks/useLanguageOptions.ts
+++ b/src/domain/enrolment/hooks/useLanguageOptions.ts
@@ -15,9 +15,13 @@ import {
   sortLanguageOptions,
 } from '../../language/utils';
 
-const useLanguageOptions = (
-  variables?: LanguagesQueryVariables
-): OptionType[] => {
+const useLanguageOptions = ({
+  variables,
+  idKey,
+}: {
+  variables?: LanguagesQueryVariables;
+  idKey?: 'atId' | 'id';
+} = {}): OptionType[] => {
   const locale = useLocale();
 
   const { data } = useLanguagesQuery({
@@ -31,12 +35,12 @@ const useLanguageOptions = (
     return getValue(
       data?.languages.data
         ?.map((language) =>
-          getLanguageOption(language as LanguageFieldsFragment, locale)
+          getLanguageOption(language as LanguageFieldsFragment, locale, idKey)
         )
         .sort(sortLanguageOptions),
       []
     );
-  }, [data, locale]);
+  }, [data?.languages.data, idKey, locale]);
 
   return languageOptions;
 };

--- a/src/domain/event/formSections/languagesSection/LanguagesSection.tsx
+++ b/src/domain/event/formSections/languagesSection/LanguagesSection.tsx
@@ -20,7 +20,7 @@ interface Props {
 const LanguagesSection: React.FC<Props> = ({ isEditingAllowed }) => {
   const { t } = useTranslation();
   const [{ value: eventType }] = useField({ name: EVENT_FIELDS.TYPE });
-  const inLanguageOptions = useLanguageOptions();
+  const inLanguageOptions = useLanguageOptions({ idKey: 'atId' });
   const eventInfoLanguageOptions: OptionType[] = ORDERED_LE_DATA_LANGUAGES.map(
     (type) => ({
       label: t(`form.language.${type}`),

--- a/src/domain/language/utils.ts
+++ b/src/domain/language/utils.ts
@@ -11,10 +11,11 @@ import queryBuilder from '../../utils/queryBuilder';
 
 export const getLanguageOption = (
   language: LanguageFieldsFragment,
-  locale: Language
+  locale: Language,
+  idKey: 'atId' | 'id' = 'id'
 ): OptionType => ({
   label: capitalize(getLocalisedString(language.name, locale)),
-  value: getValue(language.id, ''),
+  value: getValue(language[idKey], ''),
 });
 
 export const sortLanguageOptions = (a: OptionType, b: OptionType): number =>

--- a/src/domain/registration/formSections/registrationUserAccessesSection/registrationUserAccess/RegistrationUserAccess.tsx
+++ b/src/domain/registration/formSections/registrationUserAccessesSection/registrationUserAccess/RegistrationUserAccess.tsx
@@ -35,7 +35,9 @@ const RegistrationUserAccess: React.FC<Props> = ({
 }) => {
   const { t } = useTranslation();
 
-  const serviceLanguageOptions = useLanguageOptions({ serviceLanguage: true });
+  const serviceLanguageOptions = useLanguageOptions({
+    variables: { serviceLanguage: true },
+  });
 
   const menuDropdownId = useIdWithPrefix({ prefix: 'menu-dropdown-' });
 


### PR DESCRIPTION
## Description
API is expecting to get @id value when defining in_language for the event. Before this commit UI sent id instead.

## Closes
[LINK-1473](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1473)


## Screenshots
PR fixes this problem:
![image](https://github.com/City-of-Helsinki/linkedcomponents-ui/assets/24706814/6e072b1d-d1b9-4555-9325-dd646636eb48)

[LINK-1473]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ