### PR TITLE
Use event @id instead of id when coping event values to registration form

### DIFF
--- a/src/domain/event/__tests__/utils.test.ts
+++ b/src/domain/event/__tests__/utils.test.ts
@@ -1873,7 +1873,7 @@ describe('copyEventInfoToRegistrationSessionStorage function', () => {
     expect(sessionStorage.setItem).toHaveBeenCalledWith(
       FORM_NAMES.REGISTRATION_FORM,
       expect.stringContaining(
-        '"audienceMaxAge":18,"audienceMinAge":12,"confirmationMessage":{"fi":"","sv":"","en":"","ru":"","zhHans":"","ar":""},"enrolmentEndTimeDate":"2021-06-15T12:00:00.000Z","enrolmentEndTimeTime":"12:00","enrolmentStartTimeDate":"2021-06-13T12:00:00.000Z","enrolmentStartTimeTime":"12:00","event":"helmet:222453","infoLanguages":["fi"],"instructions":{"fi":"","sv":"","en":"","ru":"","zhHans":"","ar":""},"mandatoryFields":["first_name","last_name"],"maximumAttendeeCapacity":10,"maximumGroupSize":"","minimumAttendeeCapacity":5,"registrationUserAccesses":[],"waitingListCapacity":""'
+        `"audienceMaxAge":18,"audienceMinAge":12,"confirmationMessage":{"fi":"","sv":"","en":"","ru":"","zhHans":"","ar":""},"enrolmentEndTimeDate":"2021-06-15T12:00:00.000Z","enrolmentEndTimeTime":"12:00","enrolmentStartTimeDate":"2021-06-13T12:00:00.000Z","enrolmentStartTimeTime":"12:00","event":"${event.atId}","infoLanguages":["fi"],"instructions":{"fi":"","sv":"","en":"","ru":"","zhHans":"","ar":""},"mandatoryFields":["first_name","last_name"],"maximumAttendeeCapacity":10,"maximumGroupSize":"","minimumAttendeeCapacity":5,"registrationUserAccesses":[],"waitingListCapacity":""`
       )
     );
   });

--- a/src/domain/event/utils.ts
+++ b/src/domain/event/utils.ts
@@ -1415,7 +1415,7 @@ export const copyEventInfoToRegistrationSessionStorage = async (
       enrolmentEndTimeTime,
       enrolmentStartTimeDate,
       enrolmentStartTimeTime,
-      event: event.id,
+      event: event.atId,
       maximumAttendeeCapacity,
       minimumAttendeeCapacity,
     },


### PR DESCRIPTION
## Description :sparkles:
This PR fixes problem with creating new registration when coping values from a published event.

**Steps to reproduce the bug:**
1. Open a published event without a registration
2. Click add “Registration for event“ button 
3. Enter enrolment start and end dates 
4. Click Save button

**End result:** 
UI shows Event: Epäkelpo linkki - URL ei täsmää. -error

Use event @id instead of id when coping event values to registration form to fix this issue.

## Closes
[LINK-1475](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1475)

## Screenshot
Screenshot of the fixed server error message.
<img width="1436" alt="Screenshot 2023-08-28 at 11 28 40" src="https://github.com/City-of-Helsinki/linkedcomponents-ui/assets/24706814/1a1053bd-af5e-4190-84d9-9e4e6cc9e90c">



[LINK-1475]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1475?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ