### PR TITLE
LINK-1482 | Define domain for the cookie consent modal cookies

### DIFF
--- a/src/domain/app/cookieConsent/CookieConsent.tsx
+++ b/src/domain/app/cookieConsent/CookieConsent.tsx
@@ -9,7 +9,7 @@ import getValue from '../../../utils/getValue';
 
 type SupportedLanguage = 'en' | 'fi' | 'sv';
 
-const origin = window.location.origin;
+const hostname = window.location.hostname;
 
 const CookieConsent: FC = () => {
   const { t } = useTranslation();
@@ -31,6 +31,7 @@ const CookieConsent: FC = () => {
 
   return (
     <CookieModal
+      cookieDomain={hostname}
       contentSource={{
         siteName: getValue(t('common.cookieConsent.siteName'), ''),
         currentLanguage: language,
@@ -45,7 +46,7 @@ const CookieConsent: FC = () => {
               cookies: [
                 {
                   id: 'eventForm',
-                  hostName: origin,
+                  hostName: hostname,
                   name: getValue(t('common.cookieConsent.eventForm.name'), ''),
                   description: getValue(
                     t('common.cookieConsent.eventForm.description'),
@@ -58,7 +59,7 @@ const CookieConsent: FC = () => {
                 },
                 {
                   id: 'registrationForm',
-                  hostName: origin,
+                  hostName: hostname,
                   name: getValue(
                     t('common.cookieConsent.registrationForm.name'),
                     ''
@@ -74,7 +75,7 @@ const CookieConsent: FC = () => {
                 },
                 {
                   id: 'enrolmentForm',
-                  hostName: origin,
+                  hostName: hostname,
                   name: getValue(
                     t('common.cookieConsent.enrolmentForm.name'),
                     ''


### PR DESCRIPTION
## Description :sparkles:
Define domain for the cookie consent modal cookies. Reason for this is that https://www.hel.fi/fi clear all the cookies that it's not using. So visiting in that site also cleared cookies from Linked Registration UI

## Closes
[LINK-1482](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1482)

[LINK-1482]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ