### PR TITLE
LINK-1520 | 1/4 NotificationProvider component to show several notifications at same time

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "react-router": "^6.16.0",
     "react-router-dom": "^6.16.0",
     "react-scroll": "^1.8.9",
-    "react-toastify": "^9.1.3",
     "sass": "^1.67.0",
     "swagger-ui-react": "^5.7.1",
     "typescript": "~5.2.2",

--- a/src/assets/styles/main.scss
+++ b/src/assets/styles/main.scss
@@ -30,7 +30,6 @@ body {
   --shadow-s: 0 2px 10px rgba(0, 0, 0, 0.07);
   --shadow-m: 0 2px 10px rgba(0, 0, 0, 0.1);
   --shadow-l: 0 2px 20px rgba(0, 0, 0, 0.2);
-  --toastify-color-success: var(--color-success);
 
   h1 {
     font-size: var(--fontsize-heading-l);

--- a/src/common/components/imageUploader/__tests__/ImageUploader.test.tsx
+++ b/src/common/components/imageUploader/__tests__/ImageUploader.test.tsx
@@ -1,6 +1,4 @@
-import { userEvent } from '@testing-library/user-event';
 import React from 'react';
-import { toast } from 'react-toastify';
 
 import { testIds } from '../../../../constants';
 import translations from '../../../../domain/app/i18n/fi.json';
@@ -10,6 +8,7 @@ import {
   mockFile,
   render,
   screen,
+  userEvent,
   waitFor,
 } from '../../../../utils/testUtils';
 import { TEST_PIXEL_CROP } from '../contants';
@@ -41,7 +40,6 @@ const findElement = (key: 'removeImageButton') => {
 };
 
 test('should show error message if trying to enter file with invalid type', async () => {
-  toast.error = vi.fn();
   renderComponent();
 
   const fileInput = screen.getByTestId(testIds.imageUploader.input);
@@ -52,11 +50,9 @@ test('should show error message if trying to enter file with invalid type', asyn
 
   fireEvent.change(fileInput);
 
-  await waitFor(() =>
-    expect(toast.error).toBeCalledWith(
-      translations.common.imageUploader.notAllowedFileFormat
-    )
-  );
+  await screen.findByRole('alert', {
+    name: translations.common.imageUploader.notAllowedFileFormat,
+  });
 });
 
 test('should call onChange', async () => {

--- a/src/common/components/imageUploader/imageDropzone/ImageDropzone.tsx
+++ b/src/common/components/imageUploader/imageDropzone/ImageDropzone.tsx
@@ -2,7 +2,6 @@ import classNames from 'classnames';
 import { IconDownload } from 'hds-react';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { toast } from 'react-toastify';
 
 import {
   ACCEPTED_IMAGE_TYPES,
@@ -11,6 +10,7 @@ import {
   MIN_IMAGE_WIDTH,
   testIds,
 } from '../../../../constants';
+import { useNotificationsContext } from '../../../../domain/app/notificationsContext/hooks/useNotificationsContext';
 import isTestEnv from '../../../../utils/isTestEnv';
 import { getImageDimensions } from '../utils';
 import styles from './imageDropzone.module.scss';
@@ -27,26 +27,34 @@ const ImageDropzone: React.FC<ImageDropzoneProps> = ({
   title,
 }) => {
   const { t } = useTranslation();
+  const { addNotification } = useNotificationsContext();
   const fileInput = React.useRef<HTMLInputElement | null>(null);
   const [hovered, setHovered] = React.useState(false);
 
   const handleFile = async (file: File) => {
     if (!validateImageFileType(file)) {
-      toast.error(t('common.imageUploader.notAllowedFileFormat'));
+      addNotification({
+        label: t('common.imageUploader.notAllowedFileFormat'),
+        type: 'error',
+      });
       return;
     }
 
     if (!validateImageFileNameLength(file)) {
-      toast.error(
-        t('common.imageUploader.tooLongFileName', {
+      addNotification({
+        label: t('common.imageUploader.tooLongFileName', {
           maxLength: MAX_IMAGE_FILE_NAME_LENGTH,
-        })
-      );
+        }),
+        type: 'error',
+      });
       return;
     }
     /* istanbul ignore next */
     if (!isTestEnv && !(await validateImageMinDimensions(file))) {
-      toast.error(t('common.imageUploader.belowMinDimensions'));
+      addNotification({
+        label: t('common.imageUploader.belowMinDimensions'),
+        type: 'error',
+      });
       return;
     }
 

--- a/src/common/components/notification/Notification.tsx
+++ b/src/common/components/notification/Notification.tsx
@@ -1,12 +1,18 @@
 import { ClassNames } from '@emotion/react';
-import { Notification as BaseNotification, NotificationProps } from 'hds-react';
+import {
+  Notification as HdsNotification,
+  NotificationProps as HdsNotificationProps,
+} from 'hds-react';
 import React from 'react';
 
 import { useTheme } from '../../../domain/app/theme/Theme';
 import styles from './notification.module.scss';
 
+export type NotificationProps = { id?: string } & HdsNotificationProps;
+
 const Notification: React.FC<NotificationProps> = ({
   className,
+  id,
   type = 'success',
   ...rest
 }) => {
@@ -15,15 +21,17 @@ const Notification: React.FC<NotificationProps> = ({
   return (
     <ClassNames>
       {({ css, cx }) => (
-        <BaseNotification
-          {...rest}
-          className={cx(
-            styles.notification,
-            className,
-            css(theme.notification.type?.[type])
-          )}
-          type={type}
-        />
+        <div id={id}>
+          <HdsNotification
+            {...rest}
+            className={cx(
+              styles.notification,
+              className,
+              css(theme.notification.type?.[type])
+            )}
+            type={type}
+          />
+        </div>
       )}
     </ClassNames>
   );

--- a/src/domain/app/App.tsx
+++ b/src/domain/app/App.tsx
@@ -1,11 +1,9 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
-import 'react-toastify/dist/ReactToastify.css';
 
 import { ApolloProvider } from '@apollo/client';
 import { createInstance, MatomoProvider } from '@datapunt/matomo-tracker-react';
 import React, { PropsWithChildren, useMemo } from 'react';
 import { BrowserRouter } from 'react-router-dom';
-import { ToastContainer } from 'react-toastify';
 
 import theme from '../../assets/theme/theme';
 import getValue from '../../utils/getValue';
@@ -51,7 +49,6 @@ const App: React.FC = () => {
       <NotificationsProvider>
         <AuthProvider userManager={userManager}>
           <PageSettingsProvider>
-            <ToastContainer hideProgressBar={true} theme="colored" />
             <BrowserRouter>
               {/* @ts-ignore */}
               <MatomoProvider value={instance}>

--- a/src/domain/app/App.tsx
+++ b/src/domain/app/App.tsx
@@ -13,6 +13,7 @@ import { AuthProvider } from '../auth/AuthContext';
 import userManager from '../auth/userManager';
 import apolloClient from './apollo/apolloClient';
 import CookieConsent from './cookieConsent/CookieConsent';
+import { NotificationsProvider } from './notificationsContext/NotificationsContext';
 import { PageSettingsProvider } from './pageSettingsContext/PageSettingsContext';
 import AppRoutes from './routes/appRoutes/AppRoutes';
 import { ThemeProvider } from './theme/Theme';
@@ -34,22 +35,24 @@ const instance = createInstance({
 
 const App: React.FC = () => {
   return (
-    <AuthProvider userManager={userManager}>
-      <PageSettingsProvider>
-        <ThemeProvider initTheme={theme}>
-          <ToastContainer hideProgressBar={true} theme="colored" />
-          <BrowserRouter>
-            {/* @ts-ignore */}
-            <MatomoProvider value={instance}>
-              <ApolloProvider client={apolloClient}>
-                <CookieConsent />
-                <AppRoutes />
-              </ApolloProvider>
-            </MatomoProvider>
-          </BrowserRouter>
-        </ThemeProvider>
-      </PageSettingsProvider>
-    </AuthProvider>
+    <ThemeProvider initTheme={theme}>
+      <NotificationsProvider>
+        <AuthProvider userManager={userManager}>
+          <PageSettingsProvider>
+            <ToastContainer hideProgressBar={true} theme="colored" />
+            <BrowserRouter>
+              {/* @ts-ignore */}
+              <MatomoProvider value={instance}>
+                <ApolloProvider client={apolloClient}>
+                  <CookieConsent />
+                  <AppRoutes />
+                </ApolloProvider>
+              </MatomoProvider>
+            </BrowserRouter>
+          </PageSettingsProvider>
+        </AuthProvider>
+      </NotificationsProvider>
+    </ThemeProvider>
   );
 };
 

--- a/src/domain/app/App.tsx
+++ b/src/domain/app/App.tsx
@@ -3,7 +3,7 @@ import 'react-toastify/dist/ReactToastify.css';
 
 import { ApolloProvider } from '@apollo/client';
 import { createInstance, MatomoProvider } from '@datapunt/matomo-tracker-react';
-import React from 'react';
+import React, { PropsWithChildren, useMemo } from 'react';
 import { BrowserRouter } from 'react-router-dom';
 import { ToastContainer } from 'react-toastify';
 
@@ -11,8 +11,9 @@ import theme from '../../assets/theme/theme';
 import getValue from '../../utils/getValue';
 import { AuthProvider } from '../auth/AuthContext';
 import userManager from '../auth/userManager';
-import apolloClient from './apollo/apolloClient';
+import { createApolloClient } from './apollo/apolloClient';
 import CookieConsent from './cookieConsent/CookieConsent';
+import { useNotificationsContext } from './notificationsContext/hooks/useNotificationsContext';
 import { NotificationsProvider } from './notificationsContext/NotificationsContext';
 import { PageSettingsProvider } from './pageSettingsContext/PageSettingsContext';
 import AppRoutes from './routes/appRoutes/AppRoutes';
@@ -33,6 +34,17 @@ const instance = createInstance({
   siteId: Number(import.meta.env.REACT_APP_MATOMO_SITE_ID),
 });
 
+const ApolloWrapper: React.FC<PropsWithChildren> = ({ children }) => {
+  const { addNotification } = useNotificationsContext();
+
+  const apolloClient = useMemo(
+    () => createApolloClient({ addNotification }),
+    [addNotification]
+  );
+
+  return <ApolloProvider client={apolloClient}>{children}</ApolloProvider>;
+};
+
 const App: React.FC = () => {
   return (
     <ThemeProvider initTheme={theme}>
@@ -43,10 +55,10 @@ const App: React.FC = () => {
             <BrowserRouter>
               {/* @ts-ignore */}
               <MatomoProvider value={instance}>
-                <ApolloProvider client={apolloClient}>
+                <ApolloWrapper>
                   <CookieConsent />
                   <AppRoutes />
-                </ApolloProvider>
+                </ApolloWrapper>
               </MatomoProvider>
             </BrowserRouter>
           </PageSettingsProvider>

--- a/src/domain/app/apollo/apolloClient.ts
+++ b/src/domain/app/apollo/apolloClient.ts
@@ -12,8 +12,8 @@ import * as Sentry from '@sentry/react';
 import { RestLink } from 'apollo-link-rest';
 import { SentryLink } from 'apollo-link-sentry';
 import snakeCase from 'lodash/snakeCase';
-import { toast } from 'react-toastify';
 
+import { NotificationProps } from '../../../common/components/notification/Notification';
 import { DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE } from '../../../constants';
 import {
   DataSource,
@@ -436,62 +436,82 @@ const MUTATIONS_NOT_TO_SHOW_FORBIDDEN_ERROR = [
   'UpdatePlace',
 ];
 
-const errorLink = onError(({ graphQLErrors, networkError, operation }) => {
-  const isMutation = Boolean(
-    operation.query.definitions.find(
-      (definition) =>
-        definition.kind === 'OperationDefinition' &&
-        definition.operation === 'mutation'
-    )
-  );
-  if (graphQLErrors) {
-    graphQLErrors.forEach(({ message, locations, path }) => {
-      const errorMessage = `[GraphQL error]: Message: ${message}, Location: ${locations}, Path: ${path}`;
-      Sentry.captureMessage(errorMessage);
-    });
+const getNetworkErrorKey = (
+  statusCode: number,
+  operationName: string
+): string => {
+  switch (statusCode) {
+    case 400:
+      if (!MUTATIONS_NOT_TO_SHOW_VALIDATION_ERROR.includes(operationName)) {
+        return 'errors.validationError';
+      }
+      break;
+    case 401:
+      return 'errors.authorizationRequired';
+    case 403:
+      if (!MUTATIONS_NOT_TO_SHOW_FORBIDDEN_ERROR.includes(operationName)) {
+        return 'errors.forbidden';
+      }
+      break;
+    case 404:
+      return 'errors.notFound';
+    case 410:
+      return 'errors.deleted';
+    default:
+      if (!MUTATIONS_NOT_TO_SHOW_SERVER_ERROR.includes(operationName)) {
+        return 'errors.serverError';
+      }
   }
 
-  if (
-    (isMutation || QUERIES_TO_SHOW_ERROR.includes(operation.operationName)) &&
-    networkError
-  ) {
-    switch ((networkError as ServerError).statusCode) {
-      case 400:
-        if (
-          !MUTATIONS_NOT_TO_SHOW_VALIDATION_ERROR.includes(
-            operation.operationName
-          )
-        ) {
-          toast.error(getValue(i18n.t('errors.validationError'), ''));
-        }
-        break;
-      case 401:
-        toast.error(getValue(i18n.t('errors.authorizationRequired'), ''));
-        break;
-      case 403:
-        if (
-          !MUTATIONS_NOT_TO_SHOW_FORBIDDEN_ERROR.includes(
-            operation.operationName
-          )
-        ) {
-          toast.error(getValue(i18n.t('errors.forbidden'), ''));
-        }
-        break;
-      case 404:
-        toast.error(getValue(i18n.t('errors.notFound'), ''));
-        break;
-      case 410:
-        toast.error(getValue(i18n.t('errors.deleted'), ''));
-        break;
-      default:
-        if (
-          !MUTATIONS_NOT_TO_SHOW_SERVER_ERROR.includes(operation.operationName)
-        ) {
-          toast.error(getValue(i18n.t('errors.serverError'), ''));
-        }
-    }
+  return '';
+};
+
+const showNetwordErrorNotification = (
+  statusCode: number,
+  operationName: string,
+  addNotification: (props: NotificationProps) => void
+) => {
+  const errorKey = getNetworkErrorKey(statusCode, operationName);
+
+  if (errorKey) {
+    addNotification({
+      label: i18n.t(errorKey),
+      type: 'error',
+    });
   }
-});
+};
+
+const createErrorLink = ({
+  addNotification,
+}: {
+  addNotification: (props: NotificationProps) => void;
+}) =>
+  onError(({ graphQLErrors, networkError, operation }) => {
+    const isMutation = Boolean(
+      operation.query.definitions.find(
+        (definition) =>
+          definition.kind === 'OperationDefinition' &&
+          definition.operation === 'mutation'
+      )
+    );
+    if (graphQLErrors) {
+      graphQLErrors.forEach(({ message, locations, path }) => {
+        const errorMessage = `[GraphQL error]: Message: ${message}, Location: ${locations}, Path: ${path}`;
+        Sentry.captureMessage(errorMessage);
+      });
+    }
+
+    if (
+      (isMutation || QUERIES_TO_SHOW_ERROR.includes(operation.operationName)) &&
+      networkError
+    ) {
+      showNetwordErrorNotification(
+        (networkError as ServerError).statusCode,
+        operation.operationName,
+        addNotification
+      );
+    }
+  });
 
 const sentryLink = new SentryLink({
   attachBreadcrumbs: {
@@ -509,9 +529,17 @@ const sentryLink = new SentryLink({
     ),
 });
 
-const apolloClient = new ApolloClient({
-  cache: createCache(),
-  link: ApolloLink.from([errorLink, sentryLink, authLink, linkedEventsLink]),
-});
-
-export default apolloClient;
+export const createApolloClient = ({
+  addNotification,
+}: {
+  addNotification: (props: NotificationProps) => void;
+}) =>
+  new ApolloClient({
+    cache: createCache(),
+    link: ApolloLink.from([
+      createErrorLink({ addNotification }),
+      sentryLink,
+      authLink,
+      linkedEventsLink,
+    ]),
+  });

--- a/src/domain/app/i18n/en.json
+++ b/src/domain/app/i18n/en.json
@@ -719,6 +719,10 @@
         "general": "Specify recurring event",
         "volunteering": "Specify recurring volunteering"
       },
+      "notificationEventCancelled": "The event has been cancelled",
+      "notificationEventDeleted": "The event has been deleted",
+      "notificationEventPostponed": "The event has been postponed",
+      "notificationEventUpdated": "The event has been saved",
       "notificationTitleCannotEdit": "The event cannot be edited",
       "notificationTitleDescription": {
         "course": "Course description",
@@ -1289,6 +1293,8 @@
       "labelPhotographerName": "Author name",
       "labelPublisher": "Publisher",
       "labelUrl": "Image URL",
+      "notificationImageDeleted": "The image has been deleted",
+      "notificationImageUpdated": "The image has been saved",
       "notificationTitleCannotEdit": "The image cannot be edited",
       "placeholderAltText": "Enter image alt text for screen readers",
       "placeholderName": "Enter image caption",
@@ -1358,6 +1364,8 @@
       "labelOriginId": "Origin ID",
       "labelPublisher": "Publisher",
       "labelReplacedBy": "Replaced by",
+      "notificationKeywordDeleted": "The keyword has been deleted",
+      "notificationKeywordUpdated": "The keyword has been saved",
       "notificationTitleCannotEdit": "The keyword cannot be edited"
     }
   },
@@ -1451,6 +1459,8 @@
       "labelOrganization": "Publisher",
       "labelOriginId": "Origin ID",
       "labelUsage": "Usage",
+      "notificationKeywordSetDeleted": "The keyword set has been deleted",
+      "notificationKeywordSetUpdated": "The keyword set has been saved",
       "notificationTitleCannotEdit": "The keyword set cannot be edited"
     }
   },
@@ -1561,7 +1571,9 @@
       "labelRegistrationAdminUsers": "Registration admin users",
       "labelRegularUsers": "Regular users",
       "labelReplacedBy": "Replaced by",
-      "notificationTitleCannotEdit": "The organization set cannot be edited"
+      "notificationOrganizationDeleted": "The organization has been deleted",
+      "notificationOrganizationUpdated": "The organization has been saved",
+      "notificationTitleCannotEdit": "The organization cannot be edited"
     },
     "internalType": {
       "affiliated": "Affiliated organization",
@@ -1629,6 +1641,8 @@
       "labelPublisher": "Publisher",
       "labelStreetAddress": "Street address ({{langText}})",
       "labelTelephone": "Telephone number ({{langText}})",
+      "notificationPlaceDeleted": "The place has been deleted",
+      "notificationPlaceUpdated": "The place has been saved",
       "notificationTitleCannotEdit": "The place cannot be edited",
       "titleContactInfo": "Contact information",
       "titleLocation": "Position"
@@ -1702,6 +1716,8 @@
         "failedToSendInvitation": "Failed to send invitation",
         "succeededToSendInvitation": "An invitation to the participant list has been sent to {{email}}."
       },
+      "notificationRegistrationDeleted": "The registration has been deleted",
+      "notificationRegistrationUpdated": "The registration has been saved",
       "notificationTitleCannotEdit": "The registration cannot be edited",
       "placeholderConfirmationMessage": "Enter confirmation message for registrants",
       "placeholderEvent": "Select or search for an event",
@@ -1834,6 +1850,10 @@
       "labelSignupExtraInfo": "Additional information (optional)",
       "labelStreetAddress": "Street address",
       "labelZipcode": "Postcode",
+      "notificationSignupDeleted": "The signup has been deleted",
+      "notificationSignupUpdated": "The signup has been saved",
+      "notificationSignupGroupDeleted": "The signup group has been deleted",
+      "notificationSignupGroupUpdated": "The signup group has been saved",
       "notificationTitleCannotEdit": "Participants cannot be edited",
       "placeholderCity": "Enter city",
       "placeholderEmail": "Enter your email address",

--- a/src/domain/app/i18n/fi.json
+++ b/src/domain/app/i18n/fi.json
@@ -720,6 +720,10 @@
         "general": "Määritä toistuva tapahtuma",
         "volunteering": "Määritä toistuva vapaaehtoistehtävä"
       },
+      "notificationEventCancelled": "Tapahtuma on peruttu",
+      "notificationEventDeleted": "Tapahtuma on poistettu",
+      "notificationEventPostponed": "Tapahtuma on lykätty",
+      "notificationEventUpdated": "Tapahtuma on tallennettu",
       "notificationTitleCannotEdit": "Tapahtumaa ei voi muokata",
       "notificationTitleDescription": {
         "course": "Kurssin kuvaus",
@@ -1290,6 +1294,8 @@
       "labelPhotographerName": "Kuvaajan nimi",
       "labelPublisher": "Julkaisija",
       "labelUrl": "Kuvan URL-osoite",
+      "notificationImageDeleted": "Kuva on poistettu",
+      "notificationImageUpdated": "Kuva on tallennettu",
       "notificationTitleCannotEdit": "Kuvaa ei voi muokata",
       "placeholderAltText": "Syötä kuvan alt-teksti",
       "placeholderName": "Syötä kuvateksti",
@@ -1359,6 +1365,8 @@
       "labelOriginId": "Lähdetunniste",
       "labelPublisher": "Julkaisija",
       "labelReplacedBy": "Korvaus",
+      "notificationKeywordDeleted": "Avainsana on poistettu",
+      "notificationKeywordUpdated": "Avainsana on tallennettu",
       "notificationTitleCannotEdit": "Avainsanaa ei voi muokata"
     }
   },
@@ -1452,6 +1460,8 @@
       "labelOrganization": "Julkaisija",
       "labelOriginId": "Lähdetunniste",
       "labelUsage": "Käyttötarkoitus",
+      "notificationKeywordSetDeleted": "Avainsanaryhmä on poistettu",
+      "notificationKeywordSetUpdated": "Avainsanaryhmä on tallennettu",
       "notificationTitleCannotEdit": "Avainsanaryhmää ei voi muokata"
     }
   },
@@ -1562,6 +1572,8 @@
       "labelRegistrationAdminUsers": "Ilmoittautumisen pääkäyttäjät",
       "labelRegularUsers": "Peruskäyttäjät",
       "labelReplacedBy": "Korvaava organisaatio",
+      "notificationOrganizationDeleted": "Organisaatio on poistettu",
+      "notificationOrganizationUpdated": "Organisaatio on tallennettu",
       "notificationTitleCannotEdit": "Organisaatiota ei voi muokata"
     },
     "internalType": {
@@ -1630,6 +1642,8 @@
       "labelPublisher": "Julkaisija",
       "labelStreetAddress": "Katuosoite ({{langText}})",
       "labelTelephone": "Puhelinnumero ({{langText}})",
+      "notificationPlaceDeleted": "Paikka on poistettu",
+      "notificationPlaceUpdated": "Paikka on tallennettu",
       "notificationTitleCannotEdit": "Paikkaa ei voi muokata",
       "titleContactInfo": "Yhteystiedot",
       "titleLocation": "Sijainti"
@@ -1703,6 +1717,8 @@
         "failedToSendInvitation": "Kutsun lähettäminen epäonnistui",
         "succeededToSendInvitation": "Kutsu osallistujalistaan on lähetetty osoitteeseen {{email}}."
       },
+      "notificationRegistrationDeleted": "Ilmoittautuminen on poistettu",
+      "notificationRegistrationUpdated": "Ilmoittautuminen on tallennettu",
       "notificationTitleCannotEdit": "Ilmoittautumista ei voi muokata",
       "placeholderConfirmationMessage": "Syötä vahvistusviesti ilmoittautuneille",
       "placeholderEvent": "Valitse tai hae tapahtuma",
@@ -1835,6 +1851,10 @@
       "labelSignupExtraInfo": "Lisätietoa (valinnainen)",
       "labelStreetAddress": "Katuosoite",
       "labelZipcode": "Postinumero",
+      "notificationSignupDeleted": "Osallistujan tiedot on poistettu",
+      "notificationSignupUpdated": "Osallistujan tiedot on tallennettu",
+      "notificationSignupGroupDeleted": "Osallistujien tiedot on poistettu",
+      "notificationSignupGroupUpdated": "Osallistujien tiedot on tallennettu",
       "notificationTitleCannotEdit": "Osallistujia ei voi muokata",
       "placeholderCity": "Syötä kaupunki",
       "placeholderEmail": "Syötä sähköpostiosoite",

--- a/src/domain/app/i18n/sv.json
+++ b/src/domain/app/i18n/sv.json
@@ -720,6 +720,10 @@
         "general": "Ange återkommande evenemang",
         "volunteering": "Ange återkommande volontärarbete"
       },
+      "notificationEventCancelled": "Evenemanget har ställts in",
+      "notificationEventDeleted": "Evenemanget har tagits bort",
+      "notificationEventPostponed": "Evenemanget har skjutits upp",
+      "notificationEventUpdated": "Evenemanget har sparats",
       "notificationTitleCannotEdit": "Evenemanget kan inte redigeras",
       "notificationTitleDescription": {
         "course": "Kursbeskrivning",
@@ -1290,6 +1294,8 @@
       "labelPhotographerName": "Författarens namn",
       "labelPublisher": "Utgivare",
       "labelUrl": "Bildens URL-webbaddress",
+      "notificationImageDeleted": "Bilden har tagits bort",
+      "notificationImageUpdated": "Bilden har sparats",
       "notificationTitleCannotEdit": "Bilden kan inte redigeras",
       "placeholderAltText": "Ange bildens alt-text för skärmläsare",
       "placeholderName": "Ange bildtext",
@@ -1359,6 +1365,8 @@
       "labelOriginId": "Ursprungs-ID",
       "labelPublisher": "Utgivare",
       "labelReplacedBy": "Ersatt av",
+      "notificationKeywordDeleted": "Nyckelordet har tagits bort",
+      "notificationKeywordUpdated": "Nyckelordet har sparats",
       "notificationTitleCannotEdit": "Nyckelord kan inte redigeras"
     }
   },
@@ -1452,6 +1460,8 @@
       "labelOrganization": "Utgivare",
       "labelOriginId": "Ursprungs-ID",
       "labelUsage": "Användande",
+      "notificationKeywordSetDeleted": "Nyckelordsuppsättning har tagits bort",
+      "notificationKeywordSetUpdated": "Nyckelordsuppsättning har sparats",
       "notificationTitleCannotEdit": "Nyckelordsuppsättning kan inte redigeras"
     }
   },
@@ -1562,6 +1572,8 @@
       "labelRegistrationAdminUsers": "Registrering admin användare",
       "labelRegularUsers": "Regelbundna användare",
       "labelReplacedBy": "Ersatt av",
+      "notificationOrganisationDeleted": "Organisation har tagits bort",
+      "notificationOrganisationUpdated": "Organisation har sparats",
       "notificationTitleCannotEdit": "Organisation kan inte redigeras"
     },
     "internalType": {
@@ -1630,6 +1642,8 @@
       "labelPublisher": "Utgivare",
       "labelStreetAddress": "Gatuadress ({{langText}})",
       "labelTelephone": "Telefonnummer ({{langText}})",
+      "notificationPlaceDeleted": "Platsen har tagits bort",
+      "notificationPlaceUpdated": "Platsen har sparats",
       "notificationTitleCannotEdit": "Platsen kan inte redigeras",
       "titleContactInfo": "Kontaktinformation",
       "titleLocation": "Position"
@@ -1703,6 +1717,8 @@
         "failedToSendInvitation": "Det gick inte att skicka inbjudan",
         "succeededToSendInvitation": "En inbjudan till deltagarlista har skickats till {{email}}."
       },
+      "notificationRegistrationDeleted": "Registreringen har raderats",
+      "notificationRegistrationUpdated": "Registreringen har sparad",
       "notificationTitleCannotEdit": "Registreringet kan inte redigeras",
       "placeholderConfirmationMessage": "Ange ett bekräftelsemeddelande för registranter",
       "placeholderEvent": "Välj eller sök efter evenemanget",
@@ -1835,6 +1851,10 @@
       "labelSignupExtraInfo": "Ytterligare information (valfritt)",
       "labelStreetAddress": "Gatuadress",
       "labelZipcode": "Postnummer",
+      "notificationSignupDeleted": "Deltagarinformation har raderats",
+      "notificationSignupUpdated": "Deltagarinformation har sparad",
+      "notificationSignupGroupDeleted": "Deltagarinformation har raderats",
+      "notificationSignupGroupUpdated": "Deltagarinformation har sparad",
       "notificationTitleCannotEdit": "Deltagaren kan inte redigeras",
       "placeholderCity": "Ange staden",
       "placeholderEmail": "Skriv in din mailadress",

--- a/src/domain/app/notificationsContext/NotificationsContext.tsx
+++ b/src/domain/app/notificationsContext/NotificationsContext.tsx
@@ -1,0 +1,74 @@
+import uniqueId from 'lodash/uniqueId';
+import React, {
+  createContext,
+  FC,
+  PropsWithChildren,
+  useMemo,
+  useState,
+} from 'react';
+
+import Notification, {
+  NotificationProps,
+} from '../../../common/components/notification/Notification';
+
+export type NotificationsContextProps = {
+  addNotification: (props: NotificationProps) => void;
+};
+
+export const NotificationsContext = createContext<
+  NotificationsContextProps | undefined
+>(undefined);
+
+export const NotificationsProvider: FC<PropsWithChildren> = ({ children }) => {
+  const [notifications, setNotifications] = useState<NotificationProps[]>([]);
+
+  const value = useMemo<NotificationsContextProps>(() => {
+    return {
+      addNotification: (props: NotificationProps) =>
+        setNotifications((items) => [
+          ...items,
+          { ...props, id: uniqueId('notification-') },
+        ]),
+    };
+  }, [setNotifications]);
+
+  return (
+    <NotificationsContext.Provider value={value}>
+      {notifications.map((props, index) => {
+        const removeNotification = () =>
+          setNotifications((items) => items.filter((i) => i.id !== props.id));
+        const getNotificationStyle = (): React.CSSProperties => {
+          const offset = 32;
+          let topMargin = offset;
+
+          for (let i = 0; i < index; i = i + 1) {
+            topMargin +=
+              (document.getElementById(notifications[i].id as string)
+                ?.children[0]?.clientHeight ?? 0) + offset;
+          }
+
+          return {
+            top: topMargin,
+            transform: 'translate3d(0px, 0px, 0px)',
+            zIndex: 1000,
+          };
+        };
+        return (
+          <Notification
+            notificationAriaLabel={
+              typeof props.label === 'string' ? props.label : undefined
+            }
+            {...props}
+            style={getNotificationStyle()}
+            key={props.id}
+            size="default"
+            position="top-right"
+            autoClose={true}
+            onClose={removeNotification}
+          />
+        );
+      })}
+      {children}
+    </NotificationsContext.Provider>
+  );
+};

--- a/src/domain/app/notificationsContext/NotificationsContext.tsx
+++ b/src/domain/app/notificationsContext/NotificationsContext.tsx
@@ -32,6 +32,17 @@ export const NotificationsProvider: FC<PropsWithChildren> = ({ children }) => {
     };
   }, [setNotifications]);
 
+  const heights = useMemo(
+    () =>
+      // Height of last added notification is 0 because it's not rendered yet.
+      // In this case it doesn't matter because it's not used for top-margin calculation
+      notifications.map(
+        ({ id }) =>
+          document.getElementById(id as string)?.children[0]?.clientHeight ?? 0
+      ),
+    [notifications]
+  );
+
   return (
     <NotificationsContext.Provider value={value}>
       {notifications.map((props, index) => {
@@ -39,13 +50,9 @@ export const NotificationsProvider: FC<PropsWithChildren> = ({ children }) => {
           setNotifications((items) => items.filter((i) => i.id !== props.id));
         const getNotificationStyle = (): React.CSSProperties => {
           const offset = 32;
-          let topMargin = offset;
-
-          for (let i = 0; i < index; i = i + 1) {
-            topMargin +=
-              (document.getElementById(notifications[i].id as string)
-                ?.children[0]?.clientHeight ?? 0) + offset;
-          }
+          const topMargin = heights
+            .slice(0, -(notifications.length - index))
+            .reduce((acc, curr) => acc + curr + offset, offset);
 
           return {
             top: topMargin,

--- a/src/domain/app/notificationsContext/__tests__/NotificationsContext.test.tsx
+++ b/src/domain/app/notificationsContext/__tests__/NotificationsContext.test.tsx
@@ -1,0 +1,63 @@
+import { configure, render, screen, waitFor } from '@testing-library/react';
+import React, { useEffect } from 'react';
+
+import { ThemeProvider } from '../../theme/Theme';
+import { useNotificationsContext } from '../hooks/useNotificationsContext';
+import { NotificationsProvider } from '../NotificationsContext';
+
+configure({ defaultHidden: true });
+
+it('should show several notifications', async () => {
+  const Component = () => {
+    const { addNotification } = useNotificationsContext();
+
+    useEffect(() => {
+      addNotification({ label: 'Notification 1', type: 'success' });
+      addNotification({ label: 'Notification 2', type: 'error' });
+      addNotification({ label: 'Notification 3', type: 'info' });
+    });
+    return null;
+  };
+
+  render(
+    <ThemeProvider>
+      <NotificationsProvider>
+        <Component />
+      </NotificationsProvider>
+    </ThemeProvider>
+  );
+
+  await screen.findByRole('alert', { name: 'Notification 1' });
+  await screen.findByRole('alert', { name: 'Notification 2' });
+  await screen.findByRole('alert', { name: 'Notification 3' });
+});
+
+it('should automatically hide notification after certain period of time', async () => {
+  const Component = () => {
+    const { addNotification } = useNotificationsContext();
+
+    useEffect(() => {
+      addNotification({
+        autoCloseDuration: 50,
+        label: 'Notification 1',
+        type: 'success',
+      });
+    });
+    return null;
+  };
+
+  render(
+    <ThemeProvider>
+      <NotificationsProvider>
+        <Component />
+      </NotificationsProvider>
+    </ThemeProvider>
+  );
+
+  await screen.findByRole('alert', { name: 'Notification 1' });
+  await waitFor(() =>
+    expect(
+      screen.queryByRole('alert', { name: 'Notification 1' })
+    ).not.toBeInTheDocument()
+  );
+});

--- a/src/domain/app/notificationsContext/hooks/useNotificationsContext.ts
+++ b/src/domain/app/notificationsContext/hooks/useNotificationsContext.ts
@@ -1,0 +1,23 @@
+/* eslint @typescript-eslint/explicit-function-return-type: 0 */
+import { useContext } from 'react';
+
+import {
+  NotificationsContext,
+  NotificationsContextProps,
+} from '../NotificationsContext';
+
+export const useNotificationsContext = (): NotificationsContextProps => {
+  const context = useContext<NotificationsContextProps | undefined>(
+    NotificationsContext
+  );
+
+  /* istanbul ignore next */
+  if (!context) {
+    throw new Error(
+      // eslint-disable-next-line max-len
+      'NotificationsContext context is undefined, please verify you are calling useNotificationsContext() as child of a <NotificationsProvider> component.'
+    );
+  }
+
+  return context;
+};

--- a/src/domain/attendanceList/__tests__/AttendanceListPage.test.tsx
+++ b/src/domain/attendanceList/__tests__/AttendanceListPage.test.tsx
@@ -1,6 +1,5 @@
 import { MockedResponse } from '@apollo/client/testing';
 import React from 'react';
-import { toast } from 'react-toastify';
 
 import { ROUTES } from '../../../constants';
 import { fakeAuthenticatedAuthContextValue } from '../../../utils/mockAuthContextValue';
@@ -11,7 +10,6 @@ import {
   renderWithRoute,
   screen,
   userEvent,
-  waitFor,
 } from '../../../utils/testUtils';
 import { mockedOrganizationAncestorsResponse } from '../../organization/__mocks__/organizationAncestors';
 import { mockedUserResponse } from '../../user/__mocks__/user';
@@ -103,15 +101,14 @@ test('should mark signup as present', async () => {
   await loadingSpinnerIsNotInDocument();
 
   const signupCheckbox = screen.getByRole('checkbox', { name: signUpName });
-  user.click(signupCheckbox);
-  await waitFor(() => expect(signupCheckbox).toBeChecked());
+  await user.click(signupCheckbox);
+  expect(signupCheckbox).toBeChecked();
 
-  user.click(signupCheckbox);
-  await waitFor(() => expect(signupCheckbox).not.toBeChecked());
+  await user.click(signupCheckbox);
+  expect(signupCheckbox).not.toBeChecked();
 });
 
-test('should show toast message if updating presence status fails', async () => {
-  toast.error = vi.fn();
+test('should show notification if updating presence status fails', async () => {
   const user = userEvent.setup();
 
   renderComponent([...baseMocks, mockedInvalidUpdateSignupResponse]);
@@ -119,9 +116,7 @@ test('should show toast message if updating presence status fails', async () => 
 
   const signupCheckbox = screen.getByRole('checkbox', { name: signUpName });
   user.click(signupCheckbox);
-  await waitFor(() =>
-    expect(toast.error).toBeCalledWith(
-      'Läsnäolotiedon päivittäminen epäonnistui'
-    )
-  );
+  await screen.findByRole('alert', {
+    name: 'Läsnäolotiedon päivittäminen epäonnistui',
+  });
 });

--- a/src/domain/attendanceList/attendeeList/AttendeeList.tsx
+++ b/src/domain/attendanceList/attendeeList/AttendeeList.tsx
@@ -2,7 +2,6 @@ import orderBy from 'lodash/orderBy';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router';
-import { toast } from 'react-toastify';
 
 import Checkbox from '../../../common/components/checkbox/Checkbox';
 import {
@@ -17,6 +16,7 @@ import useLocale from '../../../hooks/useLocale';
 import getValue from '../../../utils/getValue';
 import skipFalsyType from '../../../utils/skipFalsyType';
 import AdminSearchRow from '../../admin/layout/adminSearchRow/AdminSearchRow';
+import { useNotificationsContext } from '../../app/notificationsContext/hooks/useNotificationsContext';
 import { reportError } from '../../app/sentry/utils';
 import { getSignupFields } from '../../signups/utils';
 import useUser from '../../user/hooks/useUser';
@@ -29,6 +29,7 @@ const AttendeeList: React.FC<Props> = ({ registration }) => {
   const location = useLocation();
   const locale = useLocale();
   const { user } = useUser();
+  const { addNotification } = useNotificationsContext();
 
   const [saving, setSaving] = useState(false);
   const [search, setSearch] = useState('');
@@ -112,7 +113,10 @@ const AttendeeList: React.FC<Props> = ({ registration }) => {
         payload,
         signup,
       });
-      toast.error(t('attendanceListPage.errors.presenceStatusUpdateFails'));
+      addNotification({
+        label: t('attendanceListPage.errors.presenceStatusUpdateFails'),
+        type: 'error',
+      });
     }
   };
   return (

--- a/src/domain/auth/AuthContext.tsx
+++ b/src/domain/auth/AuthContext.tsx
@@ -12,6 +12,7 @@ import React, {
 import { useTranslation } from 'react-i18next';
 
 import useLocale from '../../hooks/useLocale';
+import { useNotificationsContext } from '../app/notificationsContext/hooks/useNotificationsContext';
 import { oidcInitialState } from './constants';
 import useApiToken from './hooks/useApiToken';
 import { reducers } from './reducers';
@@ -45,6 +46,7 @@ export const AuthProvider: FC<PropsWithChildren<AuthProviderProps>> = ({
   const { t } = useTranslation();
   const locale = useLocale();
   const [userManager] = useState<UserManager>(() => initUserManager(props));
+  const { addNotification } = useNotificationsContext();
 
   const [oidcState, dispatchOidcState] = useReducer(
     reducers.oidcReducer,
@@ -100,7 +102,7 @@ export const AuthProvider: FC<PropsWithChildren<AuthProviderProps>> = ({
   const value = useMemo<AuthContextProps>(() => {
     return {
       signIn: async (path?: string) =>
-        signInFn({ userManager, locale, t, path }),
+        signInFn({ addNotification, userManager, locale, t, path }),
       signOut: async () => signOutFn({ resetApiTokenData, userManager }),
       userManager,
       ...oidcState,
@@ -108,7 +110,15 @@ export const AuthProvider: FC<PropsWithChildren<AuthProviderProps>> = ({
       isAuthenticated: getIsAuthenticated({ apiTokenState, oidcState }),
       isLoading: getIsLoading({ apiTokenState, oidcState }),
     };
-  }, [apiTokenState, locale, oidcState, resetApiTokenData, t, userManager]);
+  }, [
+    addNotification,
+    apiTokenState,
+    locale,
+    oidcState,
+    resetApiTokenData,
+    t,
+    userManager,
+  ]);
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 };

--- a/src/domain/auth/__tests__/AuthContext.test.tsx
+++ b/src/domain/auth/__tests__/AuthContext.test.tsx
@@ -2,8 +2,10 @@
 /* eslint @typescript-eslint/no-explicit-any: 0 */
 /* eslint @typescript-eslint/explicit-function-return-type: 0 */
 import { render, waitFor } from '@testing-library/react';
-import React from 'react';
+import React, { PropsWithChildren } from 'react';
 
+import { NotificationsProvider } from '../../app/notificationsContext/NotificationsContext';
+import { ThemeProvider } from '../../app/theme/Theme';
 import { AuthContext, AuthProvider } from '../AuthContext';
 import { OidcActionTypes } from '../constants';
 import { reducers } from '../reducers';
@@ -39,6 +41,12 @@ vi.mock('oidc-client', () => {
   };
 });
 
+const NotificationsProviderWrapper: React.FC<PropsWithChildren> = ({
+  children,
+}) => {
+  return <NotificationsProvider>{children}</NotificationsProvider>;
+};
+
 describe('AuthContext', () => {
   it('should sign in', async () => {
     const u = {
@@ -48,14 +56,18 @@ describe('AuthContext', () => {
     } as any;
 
     render(
-      <AuthProvider userManager={u}>
-        <AuthContext.Consumer>
-          {(value) => {
-            value?.signIn();
-            return <div />;
-          }}
-        </AuthContext.Consumer>
-      </AuthProvider>
+      <ThemeProvider>
+        <NotificationsProviderWrapper>
+          <AuthProvider userManager={u}>
+            <AuthContext.Consumer>
+              {(value) => {
+                value?.signIn();
+                return <div />;
+              }}
+            </AuthContext.Consumer>
+          </AuthProvider>
+        </NotificationsProviderWrapper>
+      </ThemeProvider>
     );
 
     await waitFor(() => expect(u.getUser).toHaveBeenCalled());
@@ -71,7 +83,13 @@ describe('AuthContext', () => {
       events,
     } as any;
 
-    render(<AuthProvider userManager={userManager} />);
+    render(
+      <ThemeProvider>
+        <NotificationsProviderWrapper>
+          <AuthProvider userManager={userManager} />
+        </NotificationsProviderWrapper>
+      </ThemeProvider>
+    );
 
     await waitFor(() =>
       expect(oidcReducerSpy).toBeCalledWith(expect.objectContaining({}), {
@@ -94,7 +112,13 @@ describe('AuthContext', () => {
       },
     } as any;
 
-    render(<AuthProvider userManager={userManager} />);
+    render(
+      <ThemeProvider>
+        <NotificationsProviderWrapper>
+          <AuthProvider userManager={userManager} />
+        </NotificationsProviderWrapper>
+      </ThemeProvider>
+    );
 
     await waitFor(() =>
       expect(oidcReducerSpy).toBeCalledWith(expect.objectContaining({}), {
@@ -117,7 +141,13 @@ describe('AuthContext', () => {
       events,
     } as any;
 
-    render(<AuthProvider userManager={userManager} />);
+    render(
+      <ThemeProvider>
+        <NotificationsProviderWrapper>
+          <AuthProvider userManager={userManager} />
+        </NotificationsProviderWrapper>
+      </ThemeProvider>
+    );
 
     await waitFor(() =>
       expect(oidcReducerSpy).toBeCalledWith(expect.objectContaining({}), {
@@ -138,7 +168,13 @@ describe('AuthContext', () => {
       events,
     } as any;
 
-    render(<AuthProvider userManager={userManager} />);
+    render(
+      <ThemeProvider>
+        <NotificationsProviderWrapper>
+          <AuthProvider userManager={userManager} />
+        </NotificationsProviderWrapper>
+      </ThemeProvider>
+    );
 
     await waitFor(() =>
       expect(oidcReducerSpy).toBeCalledWith(expect.objectContaining({}), {
@@ -162,14 +198,18 @@ describe('AuthContext', () => {
     } as any;
 
     render(
-      <AuthProvider userManager={u}>
-        <AuthContext.Consumer>
-          {(value) => {
-            value?.signOut();
-            return <div />;
-          }}
-        </AuthContext.Consumer>
-      </AuthProvider>
+      <ThemeProvider>
+        <NotificationsProviderWrapper>
+          <AuthProvider userManager={u}>
+            <AuthContext.Consumer>
+              {(value) => {
+                value?.signOut();
+                return <div />;
+              }}
+            </AuthContext.Consumer>
+          </AuthProvider>
+        </NotificationsProviderWrapper>
+      </ThemeProvider>
     );
 
     await waitFor(() => expect(u.signoutRedirect).toHaveBeenCalled());

--- a/src/domain/auth/hooks/useApiToken.ts
+++ b/src/domain/auth/hooks/useApiToken.ts
@@ -2,6 +2,7 @@
 import React, { useMemo, useReducer } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { useNotificationsContext } from '../../app/notificationsContext/hooks/useNotificationsContext';
 import { API_TOKEN_CHECK_INTERVAL, apiTokenInitialState } from '../constants';
 import { reducers } from '../reducers';
 import { ApiTokenReducerState, OidcReducerState } from '../types';
@@ -20,6 +21,7 @@ export type UseApiTokenState = {
 
 const useApiToken = (oidcState: OidcReducerState): UseApiTokenState => {
   const { t } = useTranslation();
+  const { addNotification } = useNotificationsContext();
   // eslint-disable-next-line no-undef
   const apiTokenTimer = React.useRef<NodeJS.Timeout>();
   const expirationTime = React.useRef<number | null>(null);
@@ -33,13 +35,23 @@ const useApiToken = (oidcState: OidcReducerState): UseApiTokenState => {
   const { getApiToken, renewApiToken, resetApiTokenData } = useMemo(() => {
     return {
       getApiToken: async (accessToken: string) =>
-        getApiTokenFn({ accessToken, dispatchApiTokenState, t }),
+        getApiTokenFn({
+          accessToken,
+          addNotification,
+          dispatchApiTokenState,
+          t,
+        }),
       renewApiToken: async (accessToken: string) =>
-        renewApiTokenFn({ accessToken, dispatchApiTokenState, t }),
+        renewApiTokenFn({
+          accessToken,
+          addNotification,
+          dispatchApiTokenState,
+          t,
+        }),
       resetApiTokenData: async () =>
         resetApiTokenDataFn({ dispatchApiTokenState }),
     };
-  }, [t]);
+  }, [addNotification, t]);
 
   const startApiTimer = () => {
     stopApiTimer();

--- a/src/domain/auth/utils.ts
+++ b/src/domain/auth/utils.ts
@@ -5,11 +5,10 @@ import axios, { AxiosResponse } from 'axios';
 import { TFunction } from 'i18next';
 import { User, UserManager, UserManagerSettings } from 'oidc-client';
 import React from 'react';
-import { toast } from 'react-toastify';
 
+import { NotificationProps } from '../../common/components/notification/Notification';
 import { Language } from '../../types';
 import getUnixTime from '../../utils/getUnixTime';
-import getValue from '../../utils/getValue';
 import {
   API_SCOPE,
   API_TOKEN_EXPIRATION_TIME,
@@ -151,11 +150,13 @@ export const loadUser = async ({
 };
 
 export const signIn = async ({
+  addNotification,
   locale,
   path,
   t,
   userManager,
 }: {
+  addNotification: (props: NotificationProps) => void;
   locale: Language;
   path?: string;
   t: TFunction;
@@ -165,7 +166,7 @@ export const signIn = async ({
     import.meta.env.REACT_APP_MAINTENANCE_DISABLE_LOGIN === 'true';
 
   if (MAINTENANCE_DISABLE_LOGIN) {
-    toast.error(getValue(t('maintenance.toast'), ''));
+    addNotification({ label: t('maintenance.toast'), type: 'error' });
 
     return Promise.resolve();
   }
@@ -177,9 +178,16 @@ export const signIn = async ({
     })
     .catch((error) => {
       if (error.message === 'Network Error') {
-        toast.error(getValue(t('authentication.networkError.message'), ''));
+        addNotification({
+          label: t('authentication.networkError.message'),
+          type: 'error',
+        });
       } else {
-        toast.error(getValue(t('authentication.errorMessage'), ''));
+        addNotification({
+          label: t('authentication.errorMessage'),
+          type: 'error',
+        });
+
         Sentry.captureException(error);
       }
     });
@@ -253,10 +261,12 @@ export const fetchTokenError = ({
 
 export const renewApiToken = async ({
   accessToken,
+  addNotification,
   dispatchApiTokenState,
   t,
 }: {
   accessToken: string;
+  addNotification: (props: NotificationProps) => void;
   dispatchApiTokenState: React.Dispatch<ApiTokenAction>;
   t: TFunction;
 }) => {
@@ -277,21 +287,28 @@ export const renewApiToken = async ({
     fetchTokenSuccess({ apiToken, dispatchApiTokenState });
   } catch (error: any) {
     fetchTokenError({ error, dispatchApiTokenState });
-    toast.error(getValue(t('authentication.errorMessage'), ''));
+    addNotification({ label: t('authentication.errorMessage'), type: 'error' });
   }
 };
 
 export const getApiToken = async ({
   accessToken,
+  addNotification,
   dispatchApiTokenState,
   t,
 }: {
   accessToken: string;
+  addNotification: (props: NotificationProps) => void;
   dispatchApiTokenState: React.Dispatch<ApiTokenAction>;
   t: TFunction;
 }) => {
   startFetchingToken({ dispatchApiTokenState });
-  await renewApiToken({ accessToken, dispatchApiTokenState, t });
+  await renewApiToken({
+    accessToken,
+    addNotification,
+    dispatchApiTokenState,
+    t,
+  });
 };
 
 export const resetApiTokenData = ({

--- a/src/domain/dataSource/hooks/__tests__/useAllDataSources.test.tsx
+++ b/src/domain/dataSource/hooks/__tests__/useAllDataSources.test.tsx
@@ -9,6 +9,7 @@ import { DataSourcesDocument, Meta } from '../../../../generated/graphql';
 import { fakeAuthenticatedAuthContextValue } from '../../../../utils/mockAuthContextValue';
 import { fakeDataSources } from '../../../../utils/mockDataUtils';
 import { createCache } from '../../../app/apollo/apolloClient';
+import { NotificationsProvider } from '../../../app/notificationsContext/NotificationsContext';
 import { AuthContext } from '../../../auth/AuthContext';
 import { mockedUserResponse } from '../../../user/__mocks__/user';
 import { MAX_DATA_SOURCES_PAGE_SIZE } from '../../constants';
@@ -77,11 +78,13 @@ const mocks = [
 
 const getHookWrapper = async () => {
   const wrapper = ({ children }: PropsWithChildren) => (
-    <AuthContext.Provider value={authContextValue}>
-      <MockedProvider cache={createCache()} mocks={mocks}>
-        {children}
-      </MockedProvider>
-    </AuthContext.Provider>
+    <NotificationsProvider>
+      <AuthContext.Provider value={authContextValue}>
+        <MockedProvider cache={createCache()} mocks={mocks}>
+          {children}
+        </MockedProvider>
+      </AuthContext.Provider>
+    </NotificationsProvider>
   );
 
   const { result } = renderHook(() => useAllDataSources(), {

--- a/src/domain/dataSource/hooks/useAllDataSources.ts
+++ b/src/domain/dataSource/hooks/useAllDataSources.ts
@@ -1,6 +1,5 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { toast } from 'react-toastify';
 import { useDebounce } from 'use-debounce';
 
 import {
@@ -12,6 +11,7 @@ import getNextPage from '../../../utils/getNextPage';
 import getPathBuilder from '../../../utils/getPathBuilder';
 import getValue from '../../../utils/getValue';
 import skipFalsyType from '../../../utils/skipFalsyType';
+import { useNotificationsContext } from '../../app/notificationsContext/hooks/useNotificationsContext';
 import useUser from '../../user/hooks/useUser';
 import { MAX_DATA_SOURCES_PAGE_SIZE } from '../constants';
 import { dataSourcesPathBuilder } from '../utils';
@@ -24,6 +24,7 @@ type UseAllDataSourcesState = {
 
 const useAllDataSources = (): UseAllDataSourcesState => {
   const { t } = useTranslation();
+  const { addNotification } = useNotificationsContext();
   const { user } = useUser();
 
   const {
@@ -46,10 +47,10 @@ const useAllDataSources = (): UseAllDataSourcesState => {
       try {
         await fetchMore({ variables: { page } });
       } catch (e) /* istanbul ignore next */ {
-        toast.error(t('common.errorLoadMore'));
+        addNotification({ label: t('common.errorLoadMore'), type: 'error' });
       }
     },
-    [fetchMore, t]
+    [addNotification, fetchMore, t]
   );
 
   React.useEffect(() => {

--- a/src/domain/event/eventForm/EventForm.tsx
+++ b/src/domain/event/eventForm/EventForm.tsx
@@ -26,6 +26,7 @@ import Container from '../../app/layout/container/Container';
 import MainContent from '../../app/layout/mainContent/MainContent';
 import PageWrapper from '../../app/layout/pageWrapper/PageWrapper';
 import Section from '../../app/layout/section/Section';
+import { useNotificationsContext } from '../../app/notificationsContext/hooks/useNotificationsContext';
 import { replaceParamsToEventQueryString } from '../../events/utils';
 import useOrganizationAncestors from '../../organization/hooks/useOrganizationAncestors';
 import useUser from '../../user/hooks/useUser';
@@ -117,6 +118,7 @@ const EventForm: React.FC<EventFormProps> = ({
   isExternalUser,
 }) => {
   const { t } = useTranslation();
+  const { addNotification } = useNotificationsContext();
   const locale = useLocale();
   const location = useLocation();
   const navigate = useNavigate();
@@ -179,6 +181,10 @@ const EventForm: React.FC<EventFormProps> = ({
       onSuccess: async () => {
         refetch && (await refetch());
         window.scrollTo(0, 0);
+        addNotification({
+          label: t('event.form.notificationEventCancelled'),
+          type: 'success',
+        });
       },
     });
   };
@@ -195,7 +201,13 @@ const EventForm: React.FC<EventFormProps> = ({
 
   const handleDelete = () => {
     deleteEvent({
-      onSuccess: () => goToEventsPage(),
+      onSuccess: () => {
+        goToEventsPage();
+        addNotification({
+          label: t('event.form.notificationEventDeleted'),
+          type: 'success',
+        });
+      },
     });
   };
 
@@ -210,6 +222,10 @@ const EventForm: React.FC<EventFormProps> = ({
       onSuccess: async () => {
         refetch && (await refetch());
         window.scrollTo(0, 0);
+        addNotification({
+          label: t('event.form.notificationEventPostponed'),
+          type: 'success',
+        });
       },
     });
   };
@@ -228,6 +244,10 @@ const EventForm: React.FC<EventFormProps> = ({
       onSuccess: async () => {
         refetch && (await refetch());
         window.scrollTo(0, 0);
+        addNotification({
+          label: t('event.form.notificationEventUpdated'),
+          type: 'success',
+        });
       },
     });
   };

--- a/src/domain/events/eventActionsDropdown/EventActionsDropdown.tsx
+++ b/src/domain/events/eventActionsDropdown/EventActionsDropdown.tsx
@@ -15,6 +15,7 @@ import {
   parseEmailFromCreatedBy,
 } from '../../../utils/openMailtoLinkUtils';
 import skipFalsyType from '../../../utils/skipFalsyType';
+import { useNotificationsContext } from '../../app/notificationsContext/hooks/useNotificationsContext';
 import { useAuth } from '../../auth/hooks/useAuth';
 import { EVENT_ACTIONS, EVENT_MODALS } from '../../event/constants';
 import useEventActions from '../../event/hooks/useEventActions';
@@ -39,6 +40,7 @@ const EventActionsDropdown: React.FC<EventActionsDropdownProps> = ({
   event,
 }) => {
   const { t } = useTranslation();
+  const { addNotification } = useNotificationsContext();
   const { isAuthenticated: authenticated } = useAuth();
   const locale = useLocale();
   const navigate = useNavigate();
@@ -127,7 +129,16 @@ const EventActionsDropdown: React.FC<EventActionsDropdownProps> = ({
           isOpen={openModal === EVENT_MODALS.CANCEL}
           isSaving={saving === EVENT_ACTIONS.CANCEL}
           onClose={closeModal}
-          onConfirm={cancelEvent}
+          onConfirm={() =>
+            cancelEvent({
+              onSuccess: () => {
+                addNotification({
+                  label: t('event.form.notificationEventCancelled'),
+                  type: 'success',
+                });
+              },
+            })
+          }
         />
       )}
       {openModal === EVENT_MODALS.DELETE && (
@@ -136,7 +147,16 @@ const EventActionsDropdown: React.FC<EventActionsDropdownProps> = ({
           isOpen={openModal === EVENT_MODALS.DELETE}
           isSaving={saving === EVENT_ACTIONS.DELETE}
           onClose={closeModal}
-          onConfirm={deleteEvent}
+          onConfirm={() =>
+            deleteEvent({
+              onSuccess: () => {
+                addNotification({
+                  label: t('event.form.notificationEventDeleted'),
+                  type: 'success',
+                });
+              },
+            })
+          }
         />
       )}
       {openModal === EVENT_MODALS.POSTPONE && (
@@ -145,7 +165,16 @@ const EventActionsDropdown: React.FC<EventActionsDropdownProps> = ({
           isOpen={openModal === EVENT_MODALS.POSTPONE}
           isSaving={saving === EVENT_ACTIONS.POSTPONE}
           onClose={closeModal}
-          onConfirm={postponeEvent}
+          onConfirm={() =>
+            postponeEvent({
+              onSuccess: () => {
+                addNotification({
+                  label: t('event.form.notificationEventPostponed'),
+                  type: 'success',
+                });
+              },
+            })
+          }
         />
       )}
 

--- a/src/domain/image/EditImagePage.tsx
+++ b/src/domain/image/EditImagePage.tsx
@@ -12,6 +12,7 @@ import getPathBuilder from '../../utils/getPathBuilder';
 import getValue from '../../utils/getValue';
 import PageWrapper from '../app/layout/pageWrapper/PageWrapper';
 import TitleRow from '../app/layout/titleRow/TitleRow';
+import { useNotificationsContext } from '../app/notificationsContext/hooks/useNotificationsContext';
 import { useAuth } from '../auth/hooks/useAuth';
 import NotFound from '../notFound/NotFound';
 import useOrganizationAncestors from '../organization/hooks/useOrganizationAncestors';
@@ -30,6 +31,7 @@ type Props = {
 
 const EditImagePage: React.FC<Props> = ({ image }) => {
   const { t } = useTranslation();
+  const { addNotification } = useNotificationsContext();
   const locale = useLocale();
   const navigate = useNavigate();
   const { publisher } = getImageFields(image, locale);
@@ -48,7 +50,13 @@ const EditImagePage: React.FC<Props> = ({ image }) => {
 
   const handleDelete = () => {
     deleteImage({
-      onSuccess: () => goToImagesPage(),
+      onSuccess: () => {
+        goToImagesPage();
+        addNotification({
+          label: t('image.form.notificationImageDeleted'),
+          type: 'success',
+        });
+      },
     });
   };
 

--- a/src/domain/image/__tests__/CreateImagePage.test.tsx
+++ b/src/domain/image/__tests__/CreateImagePage.test.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { toast } from 'react-toastify';
 
 import { testIds } from '../../../constants';
 import { fakeAuthenticatedAuthContextValue } from '../../../utils/mockAuthContextValue';
@@ -177,7 +176,6 @@ test('should move to images page after creating new image', async () => {
 });
 
 test('should prevent upload on a file name that is too long', async () => {
-  toast.error = vi.fn();
   const user = userEvent.setup();
   renderComponent();
 
@@ -197,7 +195,7 @@ test('should prevent upload on a file name that is too long', async () => {
   const fileWithLongName = mockFile({ name: fileName });
   Object.defineProperty(fileInput, 'files', { value: [fileWithLongName] });
   fireEvent.change(fileInput);
-  expect(toast.error).toBeCalledWith(
-    'Tiedoston nimi on liian pitkä. Nimi voi olla enintään 200 merkkiä.'
-  );
+  await screen.findByRole('alert', {
+    name: 'Tiedoston nimi on liian pitkä. Nimi voi olla enintään 200 merkkiä.',
+  });
 });

--- a/src/domain/image/__tests__/EditImagePage.test.tsx
+++ b/src/domain/image/__tests__/EditImagePage.test.tsx
@@ -92,6 +92,7 @@ test('should delete keyword', async () => {
   await waitFor(() =>
     expect(history.location.pathname).toBe(`/fi/administration/images`)
   );
+  await screen.findByRole('alert', { name: 'Kuva on poistettu' });
 });
 
 test('should update image', async () => {
@@ -109,6 +110,7 @@ test('should update image', async () => {
   await waitFor(() =>
     expect(history.location.pathname).toBe(`/fi/administration/images`)
   );
+  await screen.findByRole('alert', { name: 'Kuva on tallennettu' });
 });
 
 test('should show server errors', async () => {

--- a/src/domain/image/addImageForm/AddImageForm.tsx
+++ b/src/domain/image/addImageForm/AddImageForm.tsx
@@ -2,7 +2,6 @@ import { Field, Form, Formik } from 'formik';
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { PixelCrop } from 'react-image-crop';
-import { toast } from 'react-toastify';
 
 import Button from '../../../common/components/button/Button';
 import ImageSelectorField from '../../../common/components/formFields/imageSelectorField/ImageSelectorField';
@@ -15,6 +14,7 @@ import {
 } from '../../../common/components/imageUploader/utils';
 import { MAX_IMAGE_SIZE_MB } from '../../../constants';
 import { Image } from '../../../generated/graphql';
+import { useNotificationsContext } from '../../app/notificationsContext/hooks/useNotificationsContext';
 import { ADD_IMAGE_FIELDS, ADD_IMAGE_INITIAL_VALUES } from '../constants';
 import useIsImageUploadAllowed from '../hooks/useIsImageUploadAllowed';
 import { AddImageSettings } from '../types';
@@ -38,6 +38,7 @@ const AddImageForm: React.FC<AddImageFormProps> = ({
 }) => {
   const [imageEl, setImageEl] = useState<HTMLImageElement | null>(null);
   const { t } = useTranslation();
+  const { addNotification } = useNotificationsContext();
   const { allowed, warning } = useIsImageUploadAllowed({ publisher });
 
   const validateFileSize = (file: File): boolean => {
@@ -61,11 +62,12 @@ const AddImageForm: React.FC<AddImageFormProps> = ({
           const compressedFile = await getCompressedImageFile(upscaledImage);
 
           if (!validateFileSize(compressedFile)) {
-            toast.error(
-              t('common.imageUploader.tooLargeFileSize', {
+            addNotification({
+              label: t('common.imageUploader.tooLargeFileSize', {
                 maxSize: MAX_IMAGE_SIZE_MB,
-              })
-            );
+              }),
+              type: 'error',
+            });
           } else {
             onAddImageByFile(compressedFile);
           }

--- a/src/domain/image/addImageForm/__tests__/AddImageForm.test.tsx
+++ b/src/domain/image/addImageForm/__tests__/AddImageForm.test.tsx
@@ -1,6 +1,5 @@
 import { MockedResponse } from '@apollo/client/testing';
 import React from 'react';
-import { toast } from 'react-toastify';
 
 import { testIds } from '../../../../constants';
 import getValue from '../../../../utils/getValue';
@@ -131,7 +130,6 @@ test('should call onSubmit by double clicking image', async () => {
 });
 
 test('should show error message if trying to enter too large image file', async () => {
-  toast.error = vi.fn();
   const user = userEvent.setup();
 
   renderComponent({});
@@ -148,10 +146,8 @@ test('should show error message if trying to enter too large image file', async 
   await waitFor(() => expect(addButton).toBeEnabled());
   await user.click(addButton);
 
-  await waitFor(() => {
-    expect(toast.error).toBeCalledWith(
-      'Tiedostokoko on liian suuri. Tiedoston maksimikoko on 2 Mt'
-    );
+  await screen.findByRole('alert', {
+    name: 'Tiedostokoko on liian suuri. Tiedoston maksimikoko on 2 Mt',
   });
 });
 

--- a/src/domain/image/imageForm/ImageForm.tsx
+++ b/src/domain/image/imageForm/ImageForm.tsx
@@ -30,6 +30,7 @@ import {
 } from '../../../utils/validationUtils';
 import styles from '../../admin/layout/form.module.scss';
 import FormRow from '../../admin/layout/formRow/FormRow';
+import { useNotificationsContext } from '../../app/notificationsContext/hooks/useNotificationsContext';
 import useOrganizationAncestors from '../../organization/hooks/useOrganizationAncestors';
 import useUser from '../../user/hooks/useUser';
 import {
@@ -60,6 +61,7 @@ type ImageFormProps = {
 
 const ImageForm: React.FC<ImageFormProps> = ({ image }) => {
   const { t } = useTranslation();
+  const { addNotification } = useNotificationsContext();
   const locale = useLocale();
   const navigate = useNavigate();
   const { user } = useUser();
@@ -111,6 +113,10 @@ const ImageForm: React.FC<ImageFormProps> = ({ image }) => {
       onError: (error: ServerError) => showServerErrors({ error }),
       onSuccess: async () => {
         goToImagesPage();
+        addNotification({
+          label: t('image.form.notificationImageUpdated'),
+          type: 'success',
+        });
       },
     });
   };

--- a/src/domain/images/imageActionsDropdown/ImageActionsDropdown.tsx
+++ b/src/domain/images/imageActionsDropdown/ImageActionsDropdown.tsx
@@ -8,6 +8,7 @@ import { ROUTES } from '../../../constants';
 import { ImageFieldsFragment } from '../../../generated/graphql';
 import useLocale from '../../../hooks/useLocale';
 import skipFalsyType from '../../../utils/skipFalsyType';
+import { useNotificationsContext } from '../../app/notificationsContext/hooks/useNotificationsContext';
 import { useAuth } from '../../auth/hooks/useAuth';
 import { IMAGE_ACTIONS } from '../../image/constants';
 import useImageUpdateActions, {
@@ -29,6 +30,7 @@ const ImageActionsDropdown: React.FC<ImageActionsDropdownProps> = (
   ref
 ) => {
   const { t } = useTranslation();
+  const { addNotification } = useNotificationsContext();
   const locale = useLocale();
   const navigate = useNavigate();
   const { isAuthenticated: authenticated } = useAuth();
@@ -89,7 +91,16 @@ const ImageActionsDropdown: React.FC<ImageActionsDropdownProps> = (
           isOpen={openModal === IMAGE_MODALS.DELETE}
           isSaving={saving === IMAGE_ACTIONS.DELETE}
           onClose={closeModal}
-          onConfirm={deleteImage}
+          onConfirm={() =>
+            deleteImage({
+              onSuccess: () => {
+                addNotification({
+                  label: t('image.form.notificationImageDeleted'),
+                  type: 'success',
+                });
+              },
+            })
+          }
         />
       )}
       <ActionsDropdown className={className} items={actionItems} />

--- a/src/domain/images/imageActionsDropdown/__tests__/ImageActionsDropdown.test.tsx
+++ b/src/domain/images/imageActionsDropdown/__tests__/ImageActionsDropdown.test.tsx
@@ -120,4 +120,5 @@ test('should delete image', async () => {
   await waitFor(() =>
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
   );
+  await screen.findByRole('alert', { name: 'Kuva on poistettu' });
 });

--- a/src/domain/keyword/EditKeywordPage.tsx
+++ b/src/domain/keyword/EditKeywordPage.tsx
@@ -15,6 +15,7 @@ import getPathBuilder from '../../utils/getPathBuilder';
 import getValue from '../../utils/getValue';
 import PageWrapper from '../app/layout/pageWrapper/PageWrapper';
 import TitleRow from '../app/layout/titleRow/TitleRow';
+import { useNotificationsContext } from '../app/notificationsContext/hooks/useNotificationsContext';
 import { useAuth } from '../auth/hooks/useAuth';
 import NotFound from '../notFound/NotFound';
 import useOrganizationAncestors from '../organization/hooks/useOrganizationAncestors';
@@ -37,6 +38,7 @@ type Props = {
 
 const EditKeywordPage: React.FC<Props> = ({ keyword }) => {
   const { t } = useTranslation();
+  const { addNotification } = useNotificationsContext();
   const locale = useLocale();
   const navigate = useNavigate();
   const { publisher } = getKeywordFields(keyword, locale);
@@ -55,7 +57,13 @@ const EditKeywordPage: React.FC<Props> = ({ keyword }) => {
 
   const handleDelete = () => {
     deleteKeyword({
-      onSuccess: () => goToKeywordsPage(),
+      onSuccess: () => {
+        goToKeywordsPage();
+        addNotification({
+          label: t('keyword.form.notificationKeywordDeleted'),
+          type: 'success',
+        });
+      },
     });
   };
 

--- a/src/domain/keyword/__tests__/EditKeywordPage.test.tsx
+++ b/src/domain/keyword/__tests__/EditKeywordPage.test.tsx
@@ -94,6 +94,7 @@ test('should delete keyword', async () => {
   await waitFor(() =>
     expect(history.location.pathname).toBe(`/fi/administration/keywords`)
   );
+  await screen.findByRole('alert', { name: 'Avainsana on poistettu' });
 });
 
 test('should update keyword', async () => {
@@ -111,6 +112,7 @@ test('should update keyword', async () => {
   await waitFor(() =>
     expect(history.location.pathname).toBe(`/fi/administration/keywords`)
   );
+  await screen.findByRole('alert', { name: 'Avainsana on tallennettu' });
 });
 
 test('should show server errors', async () => {

--- a/src/domain/keyword/keywordForm/KeywordForm.tsx
+++ b/src/domain/keyword/keywordForm/KeywordForm.tsx
@@ -26,6 +26,7 @@ import {
 } from '../../../utils/validationUtils';
 import styles from '../../admin/layout/form.module.scss';
 import FormRow from '../../admin/layout/formRow/FormRow';
+import { useNotificationsContext } from '../../app/notificationsContext/hooks/useNotificationsContext';
 import useOrganizationAncestors from '../../organization/hooks/useOrganizationAncestors';
 import useUser from '../../user/hooks/useUser';
 import {
@@ -48,6 +49,7 @@ type KeywordFormProps = {
 
 const KeywordForm: React.FC<KeywordFormProps> = ({ keyword }) => {
   const { t } = useTranslation();
+  const { addNotification } = useNotificationsContext();
   const locale = useLocale();
   const navigate = useNavigate();
   const { user } = useUser();
@@ -87,7 +89,13 @@ const KeywordForm: React.FC<KeywordFormProps> = ({ keyword }) => {
   const onUpdate = async (values: KeywordFormFields) => {
     await updateKeyword(values, {
       onError: (error: ServerError) => showServerErrors({ error }),
-      onSuccess: goToKeywordsPage,
+      onSuccess: () => {
+        goToKeywordsPage();
+        addNotification({
+          label: t('keyword.form.notificationKeywordUpdated'),
+          type: 'success',
+        });
+      },
     });
   };
 

--- a/src/domain/keywordSet/EditKeywordSetPage.tsx
+++ b/src/domain/keywordSet/EditKeywordSetPage.tsx
@@ -17,6 +17,7 @@ import getPathBuilder from '../../utils/getPathBuilder';
 import getValue from '../../utils/getValue';
 import PageWrapper from '../app/layout/pageWrapper/PageWrapper';
 import TitleRow from '../app/layout/titleRow/TitleRow';
+import { useNotificationsContext } from '../app/notificationsContext/hooks/useNotificationsContext';
 import { useAuth } from '../auth/hooks/useAuth';
 import NotFound from '../notFound/NotFound';
 import useOrganizationAncestors from '../organization/hooks/useOrganizationAncestors';
@@ -39,6 +40,7 @@ type Props = {
 
 const EditKeywordSetPage: React.FC<Props> = ({ keywordSet }) => {
   const { t } = useTranslation();
+  const { addNotification } = useNotificationsContext();
   const locale = useLocale();
   const navigate = useNavigate();
   const { isAuthenticated: authenticated } = useAuth();
@@ -57,7 +59,13 @@ const EditKeywordSetPage: React.FC<Props> = ({ keywordSet }) => {
 
   const handleDelete = () => {
     deleteKeywordSet({
-      onSuccess: () => goToKeywordSetsPage(),
+      onSuccess: () => {
+        goToKeywordSetsPage();
+        addNotification({
+          label: t('keywordSet.form.notificationKeywordSetDeleted'),
+          type: 'success',
+        });
+      },
     });
   };
 

--- a/src/domain/keywordSet/__tests__/EditKeywordSetPage.test.tsx
+++ b/src/domain/keywordSet/__tests__/EditKeywordSetPage.test.tsx
@@ -106,6 +106,7 @@ test('should delete keyword', async () => {
   await waitFor(() =>
     expect(history.location.pathname).toBe(`/fi/administration/keyword-sets`)
   );
+  await screen.findByRole('alert', { name: 'Avainsanaryhmä on poistettu' });
 });
 
 test('should update keyword set', async () => {
@@ -125,6 +126,7 @@ test('should update keyword set', async () => {
   await waitFor(() =>
     expect(history.location.pathname).toBe(`/fi/administration/keyword-sets`)
   );
+  await screen.findByRole('alert', { name: 'Avainsanaryhmä on tallennettu' });
 });
 
 test('should show server errors', async () => {

--- a/src/domain/keywordSet/keywordSetForm/KeywordSetForm.tsx
+++ b/src/domain/keywordSet/keywordSetForm/KeywordSetForm.tsx
@@ -26,6 +26,7 @@ import {
 } from '../../../utils/validationUtils';
 import styles from '../../admin/layout/form.module.scss';
 import FormRow from '../../admin/layout/formRow/FormRow';
+import { useNotificationsContext } from '../../app/notificationsContext/hooks/useNotificationsContext';
 import useKeywordSetUsageOptions from '../../keywordSets/hooks/useKeywordSetUsageOptions';
 import useOrganizationAncestors from '../../organization/hooks/useOrganizationAncestors';
 import useUser from '../../user/hooks/useUser';
@@ -49,6 +50,7 @@ type KeywordSetFormProps = {
 
 const KeywordSetForm: React.FC<KeywordSetFormProps> = ({ keywordSet }) => {
   const { t } = useTranslation();
+  const { addNotification } = useNotificationsContext();
   const navigate = useNavigate();
   const locale = useLocale();
   const { user } = useUser();
@@ -87,7 +89,13 @@ const KeywordSetForm: React.FC<KeywordSetFormProps> = ({ keywordSet }) => {
   const onUpdate = async (values: KeywordSetFormFields) => {
     await updateKeywordSet(values, {
       onError: (error: ServerError) => showServerErrors({ error }),
-      onSuccess: goToKeywordSetsPage,
+      onSuccess: () => {
+        goToKeywordSetsPage();
+        addNotification({
+          label: t('keywordSet.form.notificationKeywordSetUpdated'),
+          type: 'success',
+        });
+      },
     });
   };
 

--- a/src/domain/keywordSets/keywordSetActionsDropdown/KeywordSetActionsDropdown.tsx
+++ b/src/domain/keywordSets/keywordSetActionsDropdown/KeywordSetActionsDropdown.tsx
@@ -9,6 +9,7 @@ import { ROUTES } from '../../../constants';
 import { KeywordSetFieldsFragment } from '../../../generated/graphql';
 import useLocale from '../../../hooks/useLocale';
 import skipFalsyType from '../../../utils/skipFalsyType';
+import { useNotificationsContext } from '../../app/notificationsContext/hooks/useNotificationsContext';
 import { useAuth } from '../../auth/hooks/useAuth';
 import { KEYWORD_SET_ACTIONS } from '../../keywordSet/constants';
 import useKeywordSetUpdateActions, {
@@ -33,6 +34,7 @@ const KeywordSetActionsDropdown: React.FC<KeywordSetActionsDropdownProps> = ({
   keywordSet,
 }) => {
   const { t } = useTranslation();
+  const { addNotification } = useNotificationsContext();
   const locale = useLocale();
   const navigate = useNavigate();
   const { isAuthenticated: authenticated } = useAuth();
@@ -94,7 +96,16 @@ const KeywordSetActionsDropdown: React.FC<KeywordSetActionsDropdownProps> = ({
           isOpen={openModal === KEYWORD_SET_MODALS.DELETE}
           isSaving={saving === KEYWORD_SET_ACTIONS.DELETE}
           onClose={closeModal}
-          onConfirm={deleteKeywordSet}
+          onConfirm={() => {
+            deleteKeywordSet({
+              onSuccess: () => {
+                addNotification({
+                  label: t('keywordSet.form.notificationKeywordSetDeleted'),
+                  type: 'success',
+                });
+              },
+            });
+          }}
         />
       )}
       <ActionsDropdown className={className} items={actionItems} />

--- a/src/domain/keywordSets/keywordSetActionsDropdown/__tests__/KeywordSetActionsDropdown.test.tsx
+++ b/src/domain/keywordSets/keywordSetActionsDropdown/__tests__/KeywordSetActionsDropdown.test.tsx
@@ -130,4 +130,5 @@ test('should delete keyword set', async () => {
   await waitFor(() =>
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
   );
+  await screen.findByRole('alert', { name: 'Avainsanaryhmä on poistettu' });
 });

--- a/src/domain/keywords/keywordActionsDropdown/KeywordActionsDropdown.tsx
+++ b/src/domain/keywords/keywordActionsDropdown/KeywordActionsDropdown.tsx
@@ -8,6 +8,7 @@ import { ROUTES } from '../../../constants';
 import { KeywordFieldsFragment } from '../../../generated/graphql';
 import useLocale from '../../../hooks/useLocale';
 import skipFalsyType from '../../../utils/skipFalsyType';
+import { useNotificationsContext } from '../../app/notificationsContext/hooks/useNotificationsContext';
 import { useAuth } from '../../auth/hooks/useAuth';
 import { KEYWORD_ACTIONS } from '../../keyword/constants';
 import useKeywordUpdateActions, {
@@ -29,6 +30,7 @@ const KeywordActionsDropdown: React.FC<KeywordActionsDropdownProps> = ({
   keyword,
 }) => {
   const { t } = useTranslation();
+  const { addNotification } = useNotificationsContext();
   const locale = useLocale();
   const navigate = useNavigate();
   const { isAuthenticated: authenticated } = useAuth();
@@ -89,7 +91,16 @@ const KeywordActionsDropdown: React.FC<KeywordActionsDropdownProps> = ({
           isOpen={openModal === KEYWORD_MODALS.DELETE}
           isSaving={saving === KEYWORD_ACTIONS.DELETE}
           onClose={closeModal}
-          onConfirm={deleteKeyword}
+          onConfirm={() =>
+            deleteKeyword({
+              onSuccess: () => {
+                addNotification({
+                  label: t('keyword.form.notificationKeywordDeleted'),
+                  type: 'success',
+                });
+              },
+            })
+          }
         />
       )}
       <ActionsDropdown className={className} items={actionItems} />

--- a/src/domain/keywords/keywordActionsDropdown/__tests__/KeywordActionsDropdown.test.tsx
+++ b/src/domain/keywords/keywordActionsDropdown/__tests__/KeywordActionsDropdown.test.tsx
@@ -132,4 +132,5 @@ test('should delete keyword', async () => {
   await waitFor(() =>
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
   );
+  await screen.findByRole('alert', { name: 'Avainsana on poistettu' });
 });

--- a/src/domain/organization/EditOrganizationPage.tsx
+++ b/src/domain/organization/EditOrganizationPage.tsx
@@ -15,6 +15,7 @@ import getPathBuilder from '../../utils/getPathBuilder';
 import getValue from '../../utils/getValue';
 import PageWrapper from '../app/layout/pageWrapper/PageWrapper';
 import TitleRow from '../app/layout/titleRow/TitleRow';
+import { useNotificationsContext } from '../app/notificationsContext/hooks/useNotificationsContext';
 import { useAuth } from '../auth/hooks/useAuth';
 import NotFound from '../notFound/NotFound';
 import useUser from '../user/hooks/useUser';
@@ -36,6 +37,7 @@ type Props = {
 
 const EditOrganizationPage: React.FC<Props> = ({ organization }) => {
   const { t } = useTranslation();
+  const { addNotification } = useNotificationsContext();
   const locale = useLocale();
   const navigate = useNavigate();
   const { id } = getOrganizationFields(organization, locale, t);
@@ -53,7 +55,13 @@ const EditOrganizationPage: React.FC<Props> = ({ organization }) => {
 
   const handleDelete = () => {
     deleteOrganization({
-      onSuccess: () => goToOrganizationsPage(),
+      onSuccess: () => {
+        goToOrganizationsPage();
+        addNotification({
+          label: t('organization.form.notificationOrganizationDeleted'),
+          type: 'success',
+        });
+      },
     });
   };
 

--- a/src/domain/organization/__tests__/EditOrganizationPage.test.tsx
+++ b/src/domain/organization/__tests__/EditOrganizationPage.test.tsx
@@ -131,6 +131,7 @@ test('should delete organization', async () => {
   await waitFor(() =>
     expect(history.location.pathname).toBe(`/fi/administration/organizations`)
   );
+  await screen.findByRole('alert', { name: 'Organisaatio on poistettu' });
 });
 
 test('should update organization', async () => {
@@ -149,6 +150,7 @@ test('should update organization', async () => {
   await waitFor(() =>
     expect(history.location.pathname).toBe(`/fi/administration/organizations`)
   );
+  await screen.findByRole('alert', { name: 'Organisaatio on tallennettu' });
 });
 
 test('should show server errors', async () => {

--- a/src/domain/organization/__tests__/utils.test.ts
+++ b/src/domain/organization/__tests__/utils.test.ts
@@ -9,7 +9,7 @@ import {
   fakeUser,
   fakeUsers,
 } from '../../../utils/mockDataUtils';
-import apolloClient from '../../app/apollo/apolloClient';
+import { createApolloClient } from '../../app/apollo/apolloClient';
 import {
   ORGANIZATION_ACTIONS,
   ORGANIZATION_INITIAL_VALUES,
@@ -27,6 +27,8 @@ import {
   organizationPathBuilder,
   organizationsPathBuilder,
 } from '../utils';
+
+const apolloClient = createApolloClient({ addNotification: jest.fn() });
 
 describe('organizationPathBuilder function', () => {
   it('should create correct path for organization class request', () => {

--- a/src/domain/organization/__tests__/utils.test.ts
+++ b/src/domain/organization/__tests__/utils.test.ts
@@ -28,7 +28,7 @@ import {
   organizationsPathBuilder,
 } from '../utils';
 
-const apolloClient = createApolloClient({ addNotification: jest.fn() });
+const apolloClient = createApolloClient({ addNotification: vi.fn() });
 
 describe('organizationPathBuilder function', () => {
   it('should create correct path for organization class request', () => {

--- a/src/domain/organization/hooks/__tests__/useAllOrganizations.test.tsx
+++ b/src/domain/organization/hooks/__tests__/useAllOrganizations.test.tsx
@@ -7,6 +7,7 @@ import React, { PropsWithChildren } from 'react';
 import { Meta, OrganizationsDocument } from '../../../../generated/graphql';
 import { fakeOrganizations } from '../../../../utils/mockDataUtils';
 import { createCache } from '../../../app/apollo/apolloClient';
+import { NotificationsProvider } from '../../../app/notificationsContext/NotificationsContext';
 import { MAX_OGRANIZATIONS_PAGE_SIZE } from '../../constants';
 import useAllOrganizations from '../useAllOrganizations';
 
@@ -67,9 +68,11 @@ const mocks = [mockedOrganizationsResponse, mockedPage2OrganizationsResponse];
 
 const getHookWrapper = () => {
   const wrapper = ({ children }: PropsWithChildren) => (
-    <MockedProvider cache={createCache()} mocks={mocks}>
-      {children}
-    </MockedProvider>
+    <NotificationsProvider>
+      <MockedProvider cache={createCache()} mocks={mocks}>
+        {children}
+      </MockedProvider>
+    </NotificationsProvider>
   );
 
   const { result } = renderHook(() => useAllOrganizations(), {

--- a/src/domain/organization/hooks/useAllOrganizations.ts
+++ b/src/domain/organization/hooks/useAllOrganizations.ts
@@ -1,6 +1,5 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { toast } from 'react-toastify';
 import { useDebounce } from 'use-debounce';
 
 import {
@@ -11,6 +10,7 @@ import getNextPage from '../../../utils/getNextPage';
 import getPathBuilder from '../../../utils/getPathBuilder';
 import getValue from '../../../utils/getValue';
 import skipFalsyType from '../../../utils/skipFalsyType';
+import { useNotificationsContext } from '../../app/notificationsContext/hooks/useNotificationsContext';
 import { MAX_OGRANIZATIONS_PAGE_SIZE } from '../constants';
 import { organizationsPathBuilder } from '../utils';
 
@@ -21,6 +21,7 @@ type UseAllOrganizationsState = {
 
 const useAllOrganizations = (): UseAllOrganizationsState => {
   const { t } = useTranslation();
+  const { addNotification } = useNotificationsContext();
 
   const {
     data: organizationsData,
@@ -41,10 +42,10 @@ const useAllOrganizations = (): UseAllOrganizationsState => {
       try {
         await fetchMore({ variables: { page } });
       } catch (e) /* istanbul ignore next */ {
-        toast.error(t('common.errorLoadMore'));
+        addNotification({ label: t('common.errorLoadMore'), type: 'error' });
       }
     },
-    [fetchMore, t]
+    [addNotification, fetchMore, t]
   );
 
   React.useEffect(() => {

--- a/src/domain/organization/organizationForm/OrganizationForm.tsx
+++ b/src/domain/organization/organizationForm/OrganizationForm.tsx
@@ -33,6 +33,7 @@ import {
 import styles from '../../admin/layout/form.module.scss';
 import FormRow from '../../admin/layout/formRow/FormRow';
 import { clearOrganizationsQueries } from '../../app/apollo/clearCacheUtils';
+import { useNotificationsContext } from '../../app/notificationsContext/hooks/useNotificationsContext';
 import { reportError } from '../../app/sentry/utils';
 import useUser from '../../user/hooks/useUser';
 import {
@@ -63,6 +64,7 @@ const OrganizationForm: React.FC<OrganizationFormProps> = ({
   organization,
 }) => {
   const { t } = useTranslation();
+  const { addNotification } = useNotificationsContext();
   const navigate = useNavigate();
   const location = useLocation();
   const locale = useLocale();
@@ -98,8 +100,12 @@ const OrganizationForm: React.FC<OrganizationFormProps> = ({
   const onUpdate = async (values: OrganizationFormFields) => {
     await updateOrganization(values, {
       onError: (error: ServerError) => showServerErrors({ error }),
-      onSuccess: async () => {
+      onSuccess: () => {
         goToOrganizationsPage();
+        addNotification({
+          label: t('organization.form.notificationOrganizationUpdated'),
+          type: 'success',
+        });
       },
     });
   };

--- a/src/domain/organizationClass/hooks/__tests__/useAllOrganizationClasses.test.tsx
+++ b/src/domain/organizationClass/hooks/__tests__/useAllOrganizationClasses.test.tsx
@@ -12,6 +12,7 @@ import {
 import { fakeAuthenticatedAuthContextValue } from '../../../../utils/mockAuthContextValue';
 import { fakeOrganizationClasses } from '../../../../utils/mockDataUtils';
 import { createCache } from '../../../app/apollo/apolloClient';
+import { NotificationsProvider } from '../../../app/notificationsContext/NotificationsContext';
 import { AuthContext } from '../../../auth/AuthContext';
 import { mockedUserResponse } from '../../../user/__mocks__/user';
 import { MAX_OGRANIZATION_CLASSES_PAGE_SIZE } from '../../constants';
@@ -93,11 +94,13 @@ const authContextValue = fakeAuthenticatedAuthContextValue();
 
 const getHookWrapper = async () => {
   const wrapper = ({ children }: PropsWithChildren) => (
-    <AuthContext.Provider value={authContextValue}>
-      <MockedProvider cache={createCache()} mocks={mocks}>
-        {children}
-      </MockedProvider>
-    </AuthContext.Provider>
+    <NotificationsProvider>
+      <AuthContext.Provider value={authContextValue}>
+        <MockedProvider cache={createCache()} mocks={mocks}>
+          {children}
+        </MockedProvider>
+      </AuthContext.Provider>
+    </NotificationsProvider>
   );
 
   const { result } = renderHook(() => useAllOrganizationClasses(), {

--- a/src/domain/organizationClass/hooks/useAllOrganizationClasses.ts
+++ b/src/domain/organizationClass/hooks/useAllOrganizationClasses.ts
@@ -1,6 +1,5 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { toast } from 'react-toastify';
 import { useDebounce } from 'use-debounce';
 
 import {
@@ -12,6 +11,7 @@ import getNextPage from '../../../utils/getNextPage';
 import getPathBuilder from '../../../utils/getPathBuilder';
 import getValue from '../../../utils/getValue';
 import skipFalsyType from '../../../utils/skipFalsyType';
+import { useNotificationsContext } from '../../app/notificationsContext/hooks/useNotificationsContext';
 import useUser from '../../user/hooks/useUser';
 import { MAX_OGRANIZATION_CLASSES_PAGE_SIZE } from '../constants';
 import { organizationClassesPathBuilder } from '../utils';
@@ -25,6 +25,7 @@ type UseAllOrganizationClassesState = {
 const useAllOrganizationClasses = (): UseAllOrganizationClassesState => {
   const { t } = useTranslation();
   const { user } = useUser();
+  const { addNotification } = useNotificationsContext();
 
   const {
     data: organizationClassesData,
@@ -46,10 +47,10 @@ const useAllOrganizationClasses = (): UseAllOrganizationClassesState => {
       try {
         await fetchMore({ variables: { page } });
       } catch (e) /* istanbul ignore next */ {
-        toast.error(t('common.errorLoadMore'));
+        addNotification({ label: t('common.errorLoadMore'), type: 'error' });
       }
     },
-    [fetchMore, t]
+    [addNotification, fetchMore, t]
   );
 
   React.useEffect(() => {

--- a/src/domain/organizations/organizationActionsDropdown/OrganizationActionsDropdown.tsx
+++ b/src/domain/organizations/organizationActionsDropdown/OrganizationActionsDropdown.tsx
@@ -9,6 +9,7 @@ import { ROUTES } from '../../../constants';
 import { OrganizationFieldsFragment } from '../../../generated/graphql';
 import useLocale from '../../../hooks/useLocale';
 import skipFalsyType from '../../../utils/skipFalsyType';
+import { useNotificationsContext } from '../../app/notificationsContext/hooks/useNotificationsContext';
 import { useAuth } from '../../auth/hooks/useAuth';
 import { ORGANIZATION_ACTIONS } from '../../organization/constants';
 import useOrganizationUpdateActions, {
@@ -32,6 +33,7 @@ const OrganizationActionsDropdown: FC<OrganizationActionsDropdownProps> = ({
   organization,
 }) => {
   const { t } = useTranslation();
+  const { addNotification } = useNotificationsContext();
   const locale = useLocale();
   const navigate = useNavigate();
   const { isAuthenticated: authenticated } = useAuth();
@@ -90,7 +92,16 @@ const OrganizationActionsDropdown: FC<OrganizationActionsDropdownProps> = ({
           isOpen={openModal === ORGANIZATION_MODALS.DELETE}
           isSaving={saving === ORGANIZATION_ACTIONS.DELETE}
           onClose={closeModal}
-          onConfirm={deleteOrganization}
+          onConfirm={() => {
+            deleteOrganization({
+              onSuccess: () => {
+                addNotification({
+                  label: t('organization.form.notificationOrganizationDeleted'),
+                  type: 'success',
+                });
+              },
+            });
+          }}
         />
       )}
       <ActionsDropdown className={className} items={actionItems} />

--- a/src/domain/organizations/organizationActionsDropdown/__tests__/OrganizationActionsDropdown.test.tsx
+++ b/src/domain/organizations/organizationActionsDropdown/__tests__/OrganizationActionsDropdown.test.tsx
@@ -127,4 +127,5 @@ test('should delete organization', async () => {
   await waitFor(() =>
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
   );
+  await screen.findByRole('alert', { name: 'Organisaatio on poistettu' });
 });

--- a/src/domain/place/EditPlacePage.tsx
+++ b/src/domain/place/EditPlacePage.tsx
@@ -12,6 +12,7 @@ import getPathBuilder from '../../utils/getPathBuilder';
 import getValue from '../../utils/getValue';
 import PageWrapper from '../app/layout/pageWrapper/PageWrapper';
 import TitleRow from '../app/layout/titleRow/TitleRow';
+import { useNotificationsContext } from '../app/notificationsContext/hooks/useNotificationsContext';
 import { useAuth } from '../auth/hooks/useAuth';
 import NotFound from '../notFound/NotFound';
 import useOrganizationAncestors from '../organization/hooks/useOrganizationAncestors';
@@ -30,6 +31,7 @@ type Props = {
 
 const EditPlacePage: React.FC<Props> = ({ place }) => {
   const { t } = useTranslation();
+  const { addNotification } = useNotificationsContext();
   const navigate = useNavigate();
   const locale = useLocale();
   const { publisher } = getPlaceFields(place, locale);
@@ -48,7 +50,13 @@ const EditPlacePage: React.FC<Props> = ({ place }) => {
 
   const handleDelete = () => {
     deletePlace({
-      onSuccess: () => goToPlacesPage(),
+      onSuccess: () => {
+        goToPlacesPage();
+        addNotification({
+          label: t('place.form.notificationPlaceDeleted'),
+          type: 'success',
+        });
+      },
     });
   };
 

--- a/src/domain/place/__tests__/EditPlacePage.test.tsx
+++ b/src/domain/place/__tests__/EditPlacePage.test.tsx
@@ -97,6 +97,7 @@ test('should delete place', async () => {
   await waitFor(() =>
     expect(history.location.pathname).toBe(`/fi/administration/places`)
   );
+  await screen.findByRole('alert', { name: 'Paikka on poistettu' });
 });
 
 test('should update place', async () => {
@@ -114,6 +115,7 @@ test('should update place', async () => {
   await waitFor(() =>
     expect(history.location.pathname).toBe(`/fi/administration/places`)
   );
+  await screen.findByRole('alert', { name: 'Paikka on tallennettu' });
 });
 
 test('should show server errors', async () => {

--- a/src/domain/place/placeForm/PlaceForm.tsx
+++ b/src/domain/place/placeForm/PlaceForm.tsx
@@ -38,6 +38,7 @@ import styles from '../../admin/layout/form.module.scss';
 import FormRow from '../../admin/layout/formRow/FormRow';
 import { clearPlacesQueries } from '../../app/apollo/clearCacheUtils';
 import Section from '../../app/layout/section/Section';
+import { useNotificationsContext } from '../../app/notificationsContext/hooks/useNotificationsContext';
 import { reportError } from '../../app/sentry/utils';
 import useOrganizationAncestors from '../../organization/hooks/useOrganizationAncestors';
 import useUser from '../../user/hooks/useUser';
@@ -66,6 +67,7 @@ type PlaceFormProps = {
 
 const PlaceForm: React.FC<PlaceFormProps> = ({ place }) => {
   const { t } = useTranslation();
+  const { addNotification } = useNotificationsContext();
   const locale = useLocale();
   const location = useLocation();
   const navigate = useNavigate();
@@ -101,8 +103,12 @@ const PlaceForm: React.FC<PlaceFormProps> = ({ place }) => {
   const onUpdate = async (values: PlaceFormFields) => {
     await updatePlace(values, {
       onError: (error: ServerError) => showServerErrors({ error }),
-      onSuccess: async () => {
+      onSuccess: () => {
         goToPlacesPage();
+        addNotification({
+          label: t('place.form.notificationPlaceUpdated'),
+          type: 'success',
+        });
       },
     });
   };

--- a/src/domain/places/placeActionsDropdown/PlaceActionsDropdown.tsx
+++ b/src/domain/places/placeActionsDropdown/PlaceActionsDropdown.tsx
@@ -8,6 +8,7 @@ import { ROUTES } from '../../../constants';
 import { PlaceFieldsFragment } from '../../../generated/graphql';
 import useLocale from '../../../hooks/useLocale';
 import skipFalsyType from '../../../utils/skipFalsyType';
+import { useNotificationsContext } from '../../app/notificationsContext/hooks/useNotificationsContext';
 import { useAuth } from '../../auth/hooks/useAuth';
 import useOrganizationAncestors from '../../organization/hooks/useOrganizationAncestors';
 import { PLACE_ACTIONS } from '../../place/constants';
@@ -29,6 +30,7 @@ const PlaceActionsDropdown: React.FC<PlaceActionsDropdownProps> = ({
   place,
 }) => {
   const { t } = useTranslation();
+  const { addNotification } = useNotificationsContext();
   const locale = useLocale();
   const navigate = useNavigate();
   const { isAuthenticated: authenticated } = useAuth();
@@ -89,7 +91,16 @@ const PlaceActionsDropdown: React.FC<PlaceActionsDropdownProps> = ({
           isOpen={openModal === PLACE_MODALS.DELETE}
           isSaving={saving === PLACE_ACTIONS.DELETE}
           onClose={closeModal}
-          onConfirm={deletePlace}
+          onConfirm={() => {
+            deletePlace({
+              onSuccess: () => {
+                addNotification({
+                  label: t('place.form.notificationPlaceDeleted'),
+                  type: 'success',
+                });
+              },
+            });
+          }}
         />
       )}
       <ActionsDropdown className={className} items={actionItems} />

--- a/src/domain/places/placeActionsDropdown/__tests__/PlaceActionsDropdown.test.tsx
+++ b/src/domain/places/placeActionsDropdown/__tests__/PlaceActionsDropdown.test.tsx
@@ -107,7 +107,7 @@ test('should route to edit place page', async () => {
   );
 });
 
-test('should delete keyword', async () => {
+test('should delete place', async () => {
   const user = userEvent.setup();
   renderComponent(undefined, { authContextValue });
 
@@ -125,4 +125,5 @@ test('should delete keyword', async () => {
   await waitFor(() =>
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
   );
+  await screen.findByRole('alert', { name: 'Paikka on poistettu' });
 });

--- a/src/domain/registration/editButtonPanel/EditButtonPanel.tsx
+++ b/src/domain/registration/editButtonPanel/EditButtonPanel.tsx
@@ -15,6 +15,7 @@ import useQueryStringWithReturnPath from '../../../hooks/useQueryStringWithRetur
 import { ActionButtonProps, ButtonType } from '../../../types';
 import getValue from '../../../utils/getValue';
 import skipFalsyType from '../../../utils/skipFalsyType';
+import { useNotificationsContext } from '../../app/notificationsContext/hooks/useNotificationsContext';
 import { useAuth } from '../../auth/hooks/useAuth';
 import useOrganizationAncestors from '../../organization/hooks/useOrganizationAncestors';
 import { REGISTRATION_ACTIONS } from '../../registrations/constants';
@@ -49,6 +50,7 @@ const EditButtonPanel: React.FC<EditButtonPanelProps> = ({
   const { id } = getRegistrationFields(registration, locale);
   const queryStringWithReturnPath = useQueryStringWithReturnPath();
   const { user } = useUser();
+  const { addNotification } = useNotificationsContext();
 
   const { organizationAncestors } = useOrganizationAncestors(publisher);
 
@@ -134,7 +136,7 @@ const EditButtonPanel: React.FC<EditButtonPanelProps> = ({
     getActionItemProps({
       action: REGISTRATION_ACTIONS.COPY_LINK,
       onClick: () => {
-        copySignupLinkToClipboard({ locale, registration, t });
+        copySignupLinkToClipboard({ addNotification, locale, registration, t });
       },
     }),
     getActionItemProps({

--- a/src/domain/registration/editButtonPanel/__tests__/EditButtonPanel.test.tsx
+++ b/src/domain/registration/editButtonPanel/__tests__/EditButtonPanel.test.tsx
@@ -1,6 +1,5 @@
 import copyToClipboard from 'copy-to-clipboard';
 import React from 'react';
-import { toast } from 'react-toastify';
 
 import { ROUTES } from '../../../../constants';
 import { fakeAuthenticatedAuthContextValue } from '../../../../utils/mockAuthContextValue';
@@ -207,7 +206,6 @@ test('should route to create registration page when clicking copy button', async
 });
 
 test('should copy registration link to clipboard', async () => {
-  toast.success = vi.fn();
   const user = userEvent.setup();
   renderComponent({ authContextValue });
 
@@ -217,7 +215,7 @@ test('should copy registration link to clipboard', async () => {
   await user.click(copyLinkButton);
 
   expect(copyToClipboard).toBeCalled();
-  expect(toast.success).toBeCalledWith('Ilmoittautumislinkki kopioitu');
+  await screen.findByRole('alert', { name: 'Ilmoittautumislinkki kopioitu' });
 });
 
 test('should route to search page when clicking back button', async () => {

--- a/src/domain/registration/formSections/registrationUserAccessesSection/__tests__/RegistrationUserAccessesSection.test.tsx
+++ b/src/domain/registration/formSections/registrationUserAccessesSection/__tests__/RegistrationUserAccessesSection.test.tsx
@@ -1,7 +1,6 @@
 import { MockedResponse } from '@apollo/client/testing';
 import { Formik } from 'formik';
 import React from 'react';
-import { toast } from 'react-toastify';
 
 import { SendRegistrationUserAccessInvitationDocument } from '../../../../../generated/graphql';
 import {
@@ -9,7 +8,6 @@ import {
   render,
   screen,
   userEvent,
-  waitFor,
 } from '../../../../../utils/testUtils';
 import { mockedServiceLanguagesResponse } from '../../../../language/__mocks__/language';
 import {
@@ -92,7 +90,6 @@ test('should add and remove registration user assess', async () => {
 });
 
 test('should send invitation to registration user access', async () => {
-  toast.success = vi.fn();
   const user = userEvent.setup();
   const email = 'user@email.com';
   renderRegistrationUserAccessesSection(
@@ -107,15 +104,12 @@ test('should send invitation to registration user access', async () => {
   });
   await user.click(sendInvitationButton);
 
-  await waitFor(() =>
-    expect(toast.success).toBeCalledWith(
-      `Kutsu osallistujalistaan on lähetetty osoitteeseen ${email}.`
-    )
-  );
+  await screen.findByRole('alert', {
+    name: `Kutsu osallistujalistaan on lähetetty osoitteeseen ${email}.`,
+  });
 });
 
-test('should show error message is sending invitation fails', async () => {
-  toast.error = vi.fn();
+test('should notification is sending invitation fails', async () => {
   const user = userEvent.setup();
   const email = 'user@email.com';
   renderRegistrationUserAccessesSection(
@@ -130,7 +124,7 @@ test('should show error message is sending invitation fails', async () => {
   });
   await user.click(sendInvitationButton);
 
-  await waitFor(() =>
-    expect(toast.error).toBeCalledWith('Kutsun lähettäminen epäonnistui')
-  );
+  await screen.findByRole('alert', {
+    name: 'Kutsun lähettäminen epäonnistui',
+  });
 });

--- a/src/domain/registration/formSections/registrationUserAccessesSection/registrationUserAccess/RegistrationUserAccess.tsx
+++ b/src/domain/registration/formSections/registrationUserAccessesSection/registrationUserAccess/RegistrationUserAccess.tsx
@@ -2,7 +2,6 @@ import { Field, useField } from 'formik';
 import { IconCrossCircle, IconEnvelope, IconMenuDots } from 'hds-react';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { toast } from 'react-toastify';
 
 import SingleSelectField from '../../../../../common/components/formFields/singleSelectField/SingleSelectField';
 import TextInputField from '../../../../../common/components/formFields/textInputField/TextInputField';
@@ -11,6 +10,7 @@ import MenuDropdown from '../../../../../common/components/menuDropdown/MenuDrop
 import { MenuItemOptionProps } from '../../../../../common/components/menuDropdown/types';
 import useIdWithPrefix from '../../../../../hooks/useIdWithPrefix';
 import FieldRow from '../../../../app/layout/fieldRow/FieldRow';
+import { useNotificationsContext } from '../../../../app/notificationsContext/hooks/useNotificationsContext';
 import FieldWithButton from '../../../../event/layout/FieldWithButton';
 import useLanguageOptions from '../../../../language/hooks/useLanguageOptions';
 import { REGISTRATION_USER_ACCESS_ACTIONS } from '../../../../registrationUserAccess/constants';
@@ -34,6 +34,7 @@ const RegistrationUserAccess: React.FC<Props> = ({
   registrationUserAccessPath,
 }) => {
   const { t } = useTranslation();
+  const { addNotification } = useNotificationsContext();
 
   const serviceLanguageOptions = useLanguageOptions({
     variables: { serviceLanguage: true },
@@ -93,14 +94,20 @@ const RegistrationUserAccess: React.FC<Props> = ({
       action: REGISTRATION_USER_ACCESS_ACTIONS.SEND_INVITATION,
       onClick: () => {
         sendInvitation({
-          onError: () =>
-            toast.error(t('registration.form.messages.failedToSendInvitation')),
-          onSuccess: () =>
-            toast.success(
-              t('registration.form.messages.succeededToSendInvitation', {
+          onError: () => {
+            addNotification({
+              label: t('registration.form.messages.failedToSendInvitation'),
+              type: 'error',
+            });
+          },
+          onSuccess: async () => {
+            addNotification({
+              label: t('registration.form.messages.succeededToSendInvitation', {
                 email,
-              })
-            ),
+              }),
+              type: 'success',
+            });
+          },
         });
       },
     }),

--- a/src/domain/registration/registrationForm/RegistrationForm.tsx
+++ b/src/domain/registration/registrationForm/RegistrationForm.tsx
@@ -57,6 +57,7 @@ import getValue from '../../../utils/getValue';
 import GroupSizeSection from '../formSections/groupSizeSection/GroupSizeSection';
 import LanguagesSection from '../formSections/languageSection/LanguageSection';
 import RegistrationUserAccessesSection from '../formSections/registrationUserAccessesSection/RegistrationUserAccessesSection';
+import { useNotificationsContext } from '../../app/notificationsContext/hooks/useNotificationsContext';
 
 export type CreateRegistrationFormProps = {
   event?: null;
@@ -81,6 +82,7 @@ const RegistrationForm: React.FC<RegistrationFormProps> = ({
   refetch,
   registration,
 }) => {
+  const { addNotification } = useNotificationsContext();
   const { t } = useTranslation();
   const locale = useLocale();
   const location = useLocation();
@@ -147,7 +149,13 @@ const RegistrationForm: React.FC<RegistrationFormProps> = ({
 
   const handleDelete = () => {
     deleteRegistration({
-      onSuccess: goToRegistrationsPage,
+      onSuccess: () => {
+        goToRegistrationsPage();
+        addNotification({
+          label: t('registration.form.notificationRegistrationDeleted'),
+          type: 'success',
+        });
+      },
     });
   };
 
@@ -157,6 +165,10 @@ const RegistrationForm: React.FC<RegistrationFormProps> = ({
       onSuccess: async () => {
         refetch && (await refetch());
         window.scrollTo(0, 0);
+        addNotification({
+          label: t('registration.form.notificationRegistrationUpdated'),
+          type: 'success',
+        });
       },
     });
   };

--- a/src/domain/registration/utils.ts
+++ b/src/domain/registration/utils.ts
@@ -6,9 +6,9 @@ import { FormikState } from 'formik';
 import { TFunction } from 'i18next';
 import isNil from 'lodash/isNil';
 import isNumber from 'lodash/isNumber';
-import { toast } from 'react-toastify';
 
 import { MenuItemOptionProps } from '../../common/components/menuDropdown/types';
+import { NotificationProps } from '../../common/components/notification/Notification';
 import { FORM_NAMES, ROUTES, TIME_FORMAT_DATA } from '../../constants';
 import {
   CreateRegistrationMutationInput,
@@ -554,14 +554,19 @@ export const getSignupLink = (
   }/${locale}/registration/${registration.id}/signup-group/create`;
 
 export const copySignupLinkToClipboard = ({
+  addNotification,
   locale,
   registration,
   t,
 }: {
+  addNotification: (props: NotificationProps) => void;
   locale: Language;
   registration: RegistrationFieldsFragment;
   t: TFunction;
 }): void => {
   copyToClipboard(getSignupLink(registration, locale));
-  toast.success(getValue(t('registration.registrationLinkCopied'), ''));
+  addNotification({
+    label: t('registration.registrationLinkCopied'),
+    type: 'success',
+  });
 };

--- a/src/domain/registrations/registrationActionsDropdown/RegistrationActionsDropdown.tsx
+++ b/src/domain/registrations/registrationActionsDropdown/RegistrationActionsDropdown.tsx
@@ -11,6 +11,7 @@ import useLocale from '../../../hooks/useLocale';
 import useQueryStringWithReturnPath from '../../../hooks/useQueryStringWithReturnPath';
 import getValue from '../../../utils/getValue';
 import skipFalsyType from '../../../utils/skipFalsyType';
+import { useNotificationsContext } from '../../app/notificationsContext/hooks/useNotificationsContext';
 import { useAuth } from '../../auth/hooks/useAuth';
 import useOrganizationAncestors from '../../organization/hooks/useOrganizationAncestors';
 import { REGISTRATION_MODALS } from '../../registration/constants';
@@ -41,6 +42,7 @@ const RegistrationActionsDropdown: React.FC<
   const publisher = getValue(registration.publisher, '');
   const queryStringWithReturnPath = useQueryStringWithReturnPath();
   const { user } = useUser();
+  const { addNotification } = useNotificationsContext();
 
   const { organizationAncestors } = useOrganizationAncestors(publisher);
 
@@ -114,7 +116,7 @@ const RegistrationActionsDropdown: React.FC<
     getActionItemProps({
       action: REGISTRATION_ACTIONS.COPY_LINK,
       onClick: () => {
-        copySignupLinkToClipboard({ locale, registration, t });
+        copySignupLinkToClipboard({ addNotification, locale, registration, t });
       },
     }),
     getActionItemProps({

--- a/src/domain/registrations/registrationActionsDropdown/RegistrationActionsDropdown.tsx
+++ b/src/domain/registrations/registrationActionsDropdown/RegistrationActionsDropdown.tsx
@@ -132,7 +132,16 @@ const RegistrationActionsDropdown: React.FC<
           isOpen={openModal === REGISTRATION_MODALS.DELETE}
           isSaving={saving === REGISTRATION_ACTIONS.DELETE}
           onClose={closeModal}
-          onConfirm={deleteRegistration}
+          onConfirm={() =>
+            deleteRegistration({
+              onSuccess: () => {
+                addNotification({
+                  label: t('registration.form.notificationRegistrationDeleted'),
+                  type: 'success',
+                });
+              },
+            })
+          }
         />
       )}
       <ActionsDropdown className={className} items={actionItems} />

--- a/src/domain/registrations/registrationActionsDropdown/__tests__/RegistrationActionsDropdown.test.tsx
+++ b/src/domain/registrations/registrationActionsDropdown/__tests__/RegistrationActionsDropdown.test.tsx
@@ -248,4 +248,5 @@ test('should delete registration', async () => {
     () => expect(screen.queryByRole('dialog')).not.toBeInTheDocument(),
     { timeout: 10000 }
   );
+  await screen.findByRole('alert', { name: 'Ilmoittautuminen on poistettu' });
 });

--- a/src/domain/registrations/registrationActionsDropdown/__tests__/RegistrationActionsDropdown.test.tsx
+++ b/src/domain/registrations/registrationActionsDropdown/__tests__/RegistrationActionsDropdown.test.tsx
@@ -1,6 +1,5 @@
 import copyToClipboard from 'copy-to-clipboard';
 import React from 'react';
-import { toast } from 'react-toastify';
 
 import { ROUTES } from '../../../../constants';
 import {
@@ -215,7 +214,6 @@ test('should route to create registration page when clicking copy button', async
 });
 
 test('should copy registration link to clipboard', async () => {
-  toast.success = vi.fn();
   const user = userEvent.setup();
 
   renderComponent();
@@ -226,7 +224,7 @@ test('should copy registration link to clipboard', async () => {
   await user.click(copyLinkButton);
 
   expect(copyToClipboard).toBeCalled();
-  expect(toast.success).toBeCalledWith('Ilmoittautumislinkki kopioitu');
+  await screen.findByRole('alert', { name: 'Ilmoittautumislinkki kopioitu' });
 });
 
 test('should delete registration', async () => {

--- a/src/domain/signupGroup/signupGroupForm/SignupGroupForm.tsx
+++ b/src/domain/signupGroup/signupGroupForm/SignupGroupForm.tsx
@@ -25,6 +25,7 @@ import extractLatestReturnPath from '../../../utils/extractLatestReturnPath';
 import getValue from '../../../utils/getValue';
 import { showFormErrors } from '../../../utils/validationUtils';
 import Container from '../../app/layout/container/Container';
+import { useNotificationsContext } from '../../app/notificationsContext/hooks/useNotificationsContext';
 import { isRegistrationPossible } from '../../registration/utils';
 import { replaceParamsToRegistrationQueryString } from '../../registrations/utils';
 import { clearSeatsReservationData } from '../../seatsReservation/utils';
@@ -110,6 +111,7 @@ type SignupGroupFormProps = Omit<
 const SignupGroupForm: React.FC<SignupGroupFormProps> = ({
   disabled,
   event,
+  refetchSignup,
   refetchSignupGroup,
   registration,
   setErrors,
@@ -120,6 +122,7 @@ const SignupGroupForm: React.FC<SignupGroupFormProps> = ({
 }) => {
   const { t } = useTranslation();
 
+  const { addNotification } = useNotificationsContext();
   const [{ value: signups }, , { setValue: setSignups }] = useField<
     SignupFormFields[]
   >(SIGNUP_GROUP_FIELDS.SIGNUPS);
@@ -219,9 +222,25 @@ const SignupGroupForm: React.FC<SignupGroupFormProps> = ({
 
   const handleDelete = () => {
     if (signupGroup) {
-      deleteSignupGroup({ onSuccess: goToSignupsPage });
+      deleteSignupGroup({
+        onSuccess: () => {
+          goToSignupsPage();
+          addNotification({
+            label: t('signup.form.notificationSignupGroupDeleted'),
+            type: 'success',
+          });
+        },
+      });
     } else {
-      deleteSignup({ onSuccess: goToSignupsPage });
+      deleteSignup({
+        onSuccess: () => {
+          goToSignupsPage();
+          addNotification({
+            label: t('signup.form.notificationSignupDeleted'),
+            type: 'success',
+          });
+        },
+      });
     }
   };
 
@@ -232,14 +251,22 @@ const SignupGroupForm: React.FC<SignupGroupFormProps> = ({
         onSuccess: async () => {
           refetchSignupGroup && (await refetchSignupGroup());
           window.scrollTo(0, 0);
+          addNotification({
+            label: t('signup.form.notificationSignupGroupUpdated'),
+            type: 'success',
+          });
         },
       });
     } else {
       updateSignup(values, {
         onError: (error: any) => showServerErrors({ error }, 'signup'),
         onSuccess: async () => {
-          refetchSignupGroup && (await refetchSignupGroup());
+          refetchSignup && (await refetchSignup());
           window.scrollTo(0, 0);
+          addNotification({
+            label: t('signup.form.notificationSignupUpdated'),
+            type: 'success',
+          });
         },
       });
     }

--- a/src/domain/signupGroup/signupGroupFormFields/SignupGroupFormFields.tsx
+++ b/src/domain/signupGroup/signupGroupFormFields/SignupGroupFormFields.tsx
@@ -1,5 +1,3 @@
-import 'react-toastify/dist/ReactToastify.css';
-
 import { Field, useField } from 'formik';
 import React from 'react';
 import { useTranslation } from 'react-i18next';

--- a/src/domain/signups/signupActionsDropdown/SignupActionsDropdown.tsx
+++ b/src/domain/signups/signupActionsDropdown/SignupActionsDropdown.tsx
@@ -12,6 +12,7 @@ import {
 import useLocale from '../../../hooks/useLocale';
 import getValue from '../../../utils/getValue';
 import skipFalsyType from '../../../utils/skipFalsyType';
+import { useNotificationsContext } from '../../app/notificationsContext/hooks/useNotificationsContext';
 import { useAuth } from '../../auth/hooks/useAuth';
 import useOrganizationAncestors from '../../organization/hooks/useOrganizationAncestors';
 import { addParamsToRegistrationQueryString } from '../../registrations/utils';
@@ -36,6 +37,7 @@ const SignupActionsDropdown: React.FC<SignupActionsDropdownProps> = ({
   signup,
 }) => {
   const { t } = useTranslation();
+  const { addNotification } = useNotificationsContext();
   const locale = useLocale();
   const navigate = useNavigate();
   const { isAuthenticated: authenticated } = useAuth();
@@ -116,7 +118,16 @@ const SignupActionsDropdown: React.FC<SignupActionsDropdownProps> = ({
         <ConfirmDeleteSignupOrSignupGroupModal
           isOpen={openModal === SIGNUP_MODALS.DELETE}
           isSaving={saving === SIGNUP_ACTIONS.DELETE}
-          onConfirm={deleteSignup}
+          onConfirm={() =>
+            deleteSignup({
+              onSuccess: () => {
+                addNotification({
+                  label: t('signup.form.notificationSignupDeleted'),
+                  type: 'success',
+                });
+              },
+            })
+          }
           onClose={closeModal}
           registration={registration}
           signup={signup}

--- a/src/domain/user/hooks/__tests__/useAllUsers.test.tsx
+++ b/src/domain/user/hooks/__tests__/useAllUsers.test.tsx
@@ -10,6 +10,7 @@ import { Meta, UsersDocument } from '../../../../generated/graphql';
 import { fakeAuthenticatedAuthContextValue } from '../../../../utils/mockAuthContextValue';
 import { fakeUsers } from '../../../../utils/mockDataUtils';
 import { createCache } from '../../../app/apollo/apolloClient';
+import { NotificationsProvider } from '../../../app/notificationsContext/NotificationsContext';
 import { AuthContext } from '../../../auth/AuthContext';
 import { mockedUserResponse } from '../../__mocks__/user';
 import useAllUsers from '../useAllUsers';
@@ -74,11 +75,13 @@ const authContextValue = fakeAuthenticatedAuthContextValue();
 
 const getHookWrapper = async () => {
   const wrapper = ({ children }: PropsWithChildren) => (
-    <AuthContext.Provider value={authContextValue}>
-      <MockedProvider cache={createCache()} mocks={mocks}>
-        {children}
-      </MockedProvider>
-    </AuthContext.Provider>
+    <NotificationsProvider>
+      <AuthContext.Provider value={authContextValue}>
+        <MockedProvider cache={createCache()} mocks={mocks}>
+          {children}
+        </MockedProvider>
+      </AuthContext.Provider>
+    </NotificationsProvider>
   );
 
   const { result } = renderHook(() => useAllUsers(), {

--- a/src/domain/user/hooks/useAllUsers.ts
+++ b/src/domain/user/hooks/useAllUsers.ts
@@ -1,6 +1,5 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { toast } from 'react-toastify';
 import { useDebounce } from 'use-debounce';
 
 import { MAX_PAGE_SIZE } from '../../../constants';
@@ -9,6 +8,7 @@ import getNextPage from '../../../utils/getNextPage';
 import getPathBuilder from '../../../utils/getPathBuilder';
 import getValue from '../../../utils/getValue';
 import skipFalsyType from '../../../utils/skipFalsyType';
+import { useNotificationsContext } from '../../app/notificationsContext/hooks/useNotificationsContext';
 import { usersPathBuilder } from '../utils';
 import useUser from './useUser';
 
@@ -20,6 +20,7 @@ type UseAllOrganizationsState = {
 
 const useAllUsers = (): UseAllOrganizationsState => {
   const { t } = useTranslation();
+  const { addNotification } = useNotificationsContext();
   const { user } = useUser();
 
   const {
@@ -42,10 +43,10 @@ const useAllUsers = (): UseAllOrganizationsState => {
       try {
         await fetchMore({ variables: { page } });
       } catch (e) /* istanbul ignore next */ {
-        toast.error(t('common.errorLoadMore'));
+        addNotification({ label: t('common.errorLoadMore'), type: 'error' });
       }
     },
-    [fetchMore, t]
+    [addNotification, fetchMore, t]
   );
 
   React.useEffect(() => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -69,8 +69,8 @@ export type UseServerErrorsState = {
 };
 
 export type MutationCallbacks<ResponseDataType = string> = {
-  onError?: (error: any) => void;
-  onSuccess?: (id?: ResponseDataType) => void;
+  onError?: (error: any) => Promise<void> | void;
+  onSuccess?: (id?: ResponseDataType) => Promise<void> | void;
 };
 
 export type ButtonType = 'button' | 'reset' | 'submit' | undefined;

--- a/src/utils/testUtils.tsx
+++ b/src/utils/testUtils.tsx
@@ -23,6 +23,7 @@ import wait from 'waait';
 
 import { testIds } from '../constants';
 import { createCache } from '../domain/app/apollo/apolloClient';
+import { NotificationsProvider } from '../domain/app/notificationsContext/NotificationsContext';
 import { PageSettingsProvider } from '../domain/app/pageSettingsContext/PageSettingsContext';
 import { ThemeProvider } from '../domain/app/theme/Theme';
 import { AuthContext } from '../domain/auth/AuthContext';
@@ -76,15 +77,17 @@ const customRender: CustomRender = (
   const Wrapper: React.FC<React.PropsWithChildren<unknown>> = ({
     children,
   }) => (
-    <AuthContext.Provider value={authContextValue}>
-      <PageSettingsProvider>
-        <ThemeProvider>
-          <MockedProvider cache={createCache()} mocks={mocks}>
-            <Router history={history as any}>{children}</Router>
-          </MockedProvider>
-        </ThemeProvider>
-      </PageSettingsProvider>
-    </AuthContext.Provider>
+    <ThemeProvider>
+      <NotificationsProvider>
+        <AuthContext.Provider value={authContextValue}>
+          <PageSettingsProvider>
+            <MockedProvider cache={createCache()} mocks={mocks}>
+              <Router history={history as any}>{children}</Router>
+            </MockedProvider>
+          </PageSettingsProvider>
+        </AuthContext.Provider>
+      </NotificationsProvider>
+    </ThemeProvider>
   );
 
   const renderResult = render(ui, { wrapper: Wrapper as any });
@@ -127,19 +130,21 @@ const renderWithRoute: CustomRender = (
   const Wrapper: React.FC<React.PropsWithChildren<unknown>> = ({
     children,
   }) => (
-    <AuthContext.Provider value={authContextValue}>
-      <PageSettingsProvider>
-        <ThemeProvider>
-          <MockedProvider cache={createCache()} mocks={mocks}>
-            <Router history={history as any}>
-              <Routes>
-                <Route path={path} element={children} />
-              </Routes>
-            </Router>
-          </MockedProvider>
-        </ThemeProvider>
-      </PageSettingsProvider>
-    </AuthContext.Provider>
+    <ThemeProvider>
+      <NotificationsProvider>
+        <AuthContext.Provider value={authContextValue}>
+          <PageSettingsProvider>
+            <MockedProvider cache={createCache()} mocks={mocks}>
+              <Router history={history as any}>
+                <Routes>
+                  <Route path={path} element={children} />
+                </Routes>
+              </Router>
+            </MockedProvider>
+          </PageSettingsProvider>
+        </AuthContext.Provider>
+      </NotificationsProvider>
+    </ThemeProvider>
   );
 
   const renderResult = render(ui, { wrapper: Wrapper as any });

--- a/yarn.lock
+++ b/yarn.lock
@@ -9633,13 +9633,6 @@ react-syntax-highlighter@^15.5.0:
     prismjs "^1.27.0"
     refractor "^3.6.0"
 
-react-toastify@^9.1.3:
-  version "9.1.3"
-  resolved "https://registry.yarnpkg.com/react-toastify/-/react-toastify-9.1.3.tgz#1e798d260d606f50e0fab5ee31daaae1d628c5ff"
-  integrity sha512-fPfb8ghtn/XMxw3LkxQBk3IyagNpF/LIKjOBflbexr2AWxAH1MJgvnESwEwBn9liLFXgTKWgBSdZpw9m4OTHTg==
-  dependencies:
-    clsx "^1.1.1"
-
 react-use-measure@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/react-use-measure/-/react-use-measure-2.0.1.tgz#4f23f94c832cd4512da55acb300d1915dcbf3ae8"


### PR DESCRIPTION
## Description :sparkles:
NotificationProvider component to show several notifications at same time

This is the one of 4 PRs that replaces https://github.com/City-of-Helsinki/linkedcomponents-ui/pull/235. The purpose of these PRs is to replace react-toastify package with HDS Notifications. Notifications are also shown after updating or deleting event, image, keyword, keyword set, organization, place, registration, signup or signup group.

The original PR is divided to following parts:
- NotificationProvider component to show several notifications at same time
- Replacing react-toastify with HDS notifications in Apollo Client (https://github.com/City-of-Helsinki/linkedcomponents-ui/pull/241)
- Replacing react-toastify with HDS notifications in rest of the places (https://github.com/City-of-Helsinki/linkedcomponents-ui/pull/242)
- Showing HDS notifitation after updating or deleting instances (https://github.com/City-of-Helsinki/linkedcomponents-ui/pull/243)

## Partially closes
[LINK-1520](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1520)

[LINK-1520]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ