### PR TITLE
LINK-1520 | 2/4 Replace react-toastify with HDS notifications in Apollo client

### DIFF
--- a/src/domain/app/App.tsx
+++ b/src/domain/app/App.tsx
@@ -3,7 +3,7 @@ import 'react-toastify/dist/ReactToastify.css';
 
 import { ApolloProvider } from '@apollo/client';
 import { createInstance, MatomoProvider } from '@datapunt/matomo-tracker-react';
-import React from 'react';
+import React, { PropsWithChildren, useMemo } from 'react';
 import { BrowserRouter } from 'react-router-dom';
 import { ToastContainer } from 'react-toastify';
 
@@ -11,8 +11,9 @@ import theme from '../../assets/theme/theme';
 import getValue from '../../utils/getValue';
 import { AuthProvider } from '../auth/AuthContext';
 import userManager from '../auth/userManager';
-import apolloClient from './apollo/apolloClient';
+import { createApolloClient } from './apollo/apolloClient';
 import CookieConsent from './cookieConsent/CookieConsent';
+import { useNotificationsContext } from './notificationsContext/hooks/useNotificationsContext';
 import { NotificationsProvider } from './notificationsContext/NotificationsContext';
 import { PageSettingsProvider } from './pageSettingsContext/PageSettingsContext';
 import AppRoutes from './routes/appRoutes/AppRoutes';
@@ -33,6 +34,17 @@ const instance = createInstance({
   siteId: Number(process.env.REACT_APP_MATOMO_SITE_ID),
 });
 
+const ApolloWrapper: React.FC<PropsWithChildren> = ({ children }) => {
+  const { addNotification } = useNotificationsContext();
+
+  const apolloClient = useMemo(
+    () => createApolloClient({ addNotification }),
+    [addNotification]
+  );
+
+  return <ApolloProvider client={apolloClient}>{children}</ApolloProvider>;
+};
+
 const App: React.FC = () => {
   return (
     <ThemeProvider initTheme={theme}>
@@ -43,10 +55,10 @@ const App: React.FC = () => {
             <BrowserRouter>
               {/* @ts-ignore */}
               <MatomoProvider value={instance}>
-                <ApolloProvider client={apolloClient}>
+                <ApolloWrapper>
                   <CookieConsent />
                   <AppRoutes />
-                </ApolloProvider>
+                </ApolloWrapper>
               </MatomoProvider>
             </BrowserRouter>
           </PageSettingsProvider>

--- a/src/domain/app/apollo/apolloClient.ts
+++ b/src/domain/app/apollo/apolloClient.ts
@@ -12,8 +12,8 @@ import * as Sentry from '@sentry/react';
 import { RestLink } from 'apollo-link-rest';
 import { SentryLink } from 'apollo-link-sentry';
 import snakeCase from 'lodash/snakeCase';
-import { toast } from 'react-toastify';
 
+import { NotificationProps } from '../../../common/components/notification/Notification';
 import { DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE } from '../../../constants';
 import {
   DataSource,
@@ -436,62 +436,82 @@ const MUTATIONS_NOT_TO_SHOW_FORBIDDEN_ERROR = [
   'UpdatePlace',
 ];
 
-const errorLink = onError(({ graphQLErrors, networkError, operation }) => {
-  const isMutation = Boolean(
-    operation.query.definitions.find(
-      (definition) =>
-        definition.kind === 'OperationDefinition' &&
-        definition.operation === 'mutation'
-    )
-  );
-  if (graphQLErrors) {
-    graphQLErrors.forEach(({ message, locations, path }) => {
-      const errorMessage = `[GraphQL error]: Message: ${message}, Location: ${locations}, Path: ${path}`;
-      Sentry.captureMessage(errorMessage);
-    });
+const getNetworkErrorKey = (
+  statusCode: number,
+  operationName: string
+): string => {
+  switch (statusCode) {
+    case 400:
+      if (!MUTATIONS_NOT_TO_SHOW_VALIDATION_ERROR.includes(operationName)) {
+        return 'errors.validationError';
+      }
+      break;
+    case 401:
+      return 'errors.authorizationRequired';
+    case 403:
+      if (!MUTATIONS_NOT_TO_SHOW_FORBIDDEN_ERROR.includes(operationName)) {
+        return 'errors.forbidden';
+      }
+      break;
+    case 404:
+      return 'errors.notFound';
+    case 410:
+      return 'errors.deleted';
+    default:
+      if (!MUTATIONS_NOT_TO_SHOW_SERVER_ERROR.includes(operationName)) {
+        return 'errors.serverError';
+      }
   }
 
-  if (
-    (isMutation || QUERIES_TO_SHOW_ERROR.includes(operation.operationName)) &&
-    networkError
-  ) {
-    switch ((networkError as ServerError).statusCode) {
-      case 400:
-        if (
-          !MUTATIONS_NOT_TO_SHOW_VALIDATION_ERROR.includes(
-            operation.operationName
-          )
-        ) {
-          toast.error(getValue(i18n.t('errors.validationError'), ''));
-        }
-        break;
-      case 401:
-        toast.error(getValue(i18n.t('errors.authorizationRequired'), ''));
-        break;
-      case 403:
-        if (
-          !MUTATIONS_NOT_TO_SHOW_FORBIDDEN_ERROR.includes(
-            operation.operationName
-          )
-        ) {
-          toast.error(getValue(i18n.t('errors.forbidden'), ''));
-        }
-        break;
-      case 404:
-        toast.error(getValue(i18n.t('errors.notFound'), ''));
-        break;
-      case 410:
-        toast.error(getValue(i18n.t('errors.deleted'), ''));
-        break;
-      default:
-        if (
-          !MUTATIONS_NOT_TO_SHOW_SERVER_ERROR.includes(operation.operationName)
-        ) {
-          toast.error(getValue(i18n.t('errors.serverError'), ''));
-        }
-    }
+  return '';
+};
+
+const showNetwordErrorNotification = (
+  statusCode: number,
+  operationName: string,
+  addNotification: (props: NotificationProps) => void
+) => {
+  const errorKey = getNetworkErrorKey(statusCode, operationName);
+
+  if (errorKey) {
+    addNotification({
+      label: i18n.t(errorKey),
+      type: 'error',
+    });
   }
-});
+};
+
+const createErrorLink = ({
+  addNotification,
+}: {
+  addNotification: (props: NotificationProps) => void;
+}) =>
+  onError(({ graphQLErrors, networkError, operation }) => {
+    const isMutation = Boolean(
+      operation.query.definitions.find(
+        (definition) =>
+          definition.kind === 'OperationDefinition' &&
+          definition.operation === 'mutation'
+      )
+    );
+    if (graphQLErrors) {
+      graphQLErrors.forEach(({ message, locations, path }) => {
+        const errorMessage = `[GraphQL error]: Message: ${message}, Location: ${locations}, Path: ${path}`;
+        Sentry.captureMessage(errorMessage);
+      });
+    }
+
+    if (
+      (isMutation || QUERIES_TO_SHOW_ERROR.includes(operation.operationName)) &&
+      networkError
+    ) {
+      showNetwordErrorNotification(
+        (networkError as ServerError).statusCode,
+        operation.operationName,
+        addNotification
+      );
+    }
+  });
 
 const sentryLink = new SentryLink({
   attachBreadcrumbs: {
@@ -509,9 +529,17 @@ const sentryLink = new SentryLink({
     ),
 });
 
-const apolloClient = new ApolloClient({
-  cache: createCache(),
-  link: ApolloLink.from([errorLink, sentryLink, authLink, linkedEventsLink]),
-});
-
-export default apolloClient;
+export const createApolloClient = ({
+  addNotification,
+}: {
+  addNotification: (props: NotificationProps) => void;
+}) =>
+  new ApolloClient({
+    cache: createCache(),
+    link: ApolloLink.from([
+      createErrorLink({ addNotification }),
+      sentryLink,
+      authLink,
+      linkedEventsLink,
+    ]),
+  });

--- a/src/domain/organization/__tests__/utils.test.ts
+++ b/src/domain/organization/__tests__/utils.test.ts
@@ -9,7 +9,7 @@ import {
   fakeUser,
   fakeUsers,
 } from '../../../utils/mockDataUtils';
-import apolloClient from '../../app/apollo/apolloClient';
+import { createApolloClient } from '../../app/apollo/apolloClient';
 import {
   ORGANIZATION_ACTIONS,
   ORGANIZATION_INITIAL_VALUES,
@@ -27,6 +27,8 @@ import {
   organizationPathBuilder,
   organizationsPathBuilder,
 } from '../utils';
+
+const apolloClient = createApolloClient({ addNotification: jest.fn() });
 
 describe('organizationPathBuilder function', () => {
   it('should create correct path for organization class request', () => {


### PR DESCRIPTION
## Description :sparkles:
Replace react-toastify with HDS notifications in Apollo client

This is the second of 4 PRs that will replace https://github.com/City-of-Helsinki/linkedcomponents-ui/pull/235
The original PR will be splitted to following parts:

- NotificationProvider component to show several notifications at same time (https://github.com/City-of-Helsinki/linkedcomponents-ui/pull/239)
- Replacing react-toastify with HDS notifications in Apollo Client 
- Replacing react-toastify with HDS notifications in rest of the places
- Showing HDS noticitation after updating or deleting instances
## Issues :bug:

## Partially closes
[LINK-1520](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1520)

[LINK-1520]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ