### PR TITLE
LINK-1520 | 4/4 Notifications when updating instances

### DIFF
--- a/src/domain/app/i18n/en.json
+++ b/src/domain/app/i18n/en.json
@@ -719,6 +719,10 @@
         "general": "Specify recurring event",
         "volunteering": "Specify recurring volunteering"
       },
+      "notificationEventCancelled": "The event has been cancelled",
+      "notificationEventDeleted": "The event has been deleted",
+      "notificationEventPostponed": "The event has been postponed",
+      "notificationEventUpdated": "The event has been saved",
       "notificationTitleCannotEdit": "The event cannot be edited",
       "notificationTitleDescription": {
         "course": "Course description",
@@ -1289,6 +1293,8 @@
       "labelPhotographerName": "Author name",
       "labelPublisher": "Publisher",
       "labelUrl": "Image URL",
+      "notificationImageDeleted": "The image has been deleted",
+      "notificationImageUpdated": "The image has been saved",
       "notificationTitleCannotEdit": "The image cannot be edited",
       "placeholderAltText": "Enter image alt text for screen readers",
       "placeholderName": "Enter image caption",
@@ -1358,6 +1364,8 @@
       "labelOriginId": "Origin ID",
       "labelPublisher": "Publisher",
       "labelReplacedBy": "Replaced by",
+      "notificationKeywordDeleted": "The keyword has been deleted",
+      "notificationKeywordUpdated": "The keyword has been saved",
       "notificationTitleCannotEdit": "The keyword cannot be edited"
     }
   },
@@ -1451,6 +1459,8 @@
       "labelOrganization": "Publisher",
       "labelOriginId": "Origin ID",
       "labelUsage": "Usage",
+      "notificationKeywordSetDeleted": "The keyword set has been deleted",
+      "notificationKeywordSetUpdated": "The keyword set has been saved",
       "notificationTitleCannotEdit": "The keyword set cannot be edited"
     }
   },
@@ -1561,7 +1571,9 @@
       "labelRegistrationAdminUsers": "Registration admin users",
       "labelRegularUsers": "Regular users",
       "labelReplacedBy": "Replaced by",
-      "notificationTitleCannotEdit": "The organization set cannot be edited"
+      "notificationOrganizationDeleted": "The organization has been deleted",
+      "notificationOrganizationUpdated": "The organization has been saved",
+      "notificationTitleCannotEdit": "The organization cannot be edited"
     },
     "internalType": {
       "affiliated": "Affiliated organization",
@@ -1629,6 +1641,8 @@
       "labelPublisher": "Publisher",
       "labelStreetAddress": "Street address ({{langText}})",
       "labelTelephone": "Telephone number ({{langText}})",
+      "notificationPlaceDeleted": "The place has been deleted",
+      "notificationPlaceUpdated": "The place has been saved",
       "notificationTitleCannotEdit": "The place cannot be edited",
       "titleContactInfo": "Contact information",
       "titleLocation": "Position"
@@ -1702,6 +1716,8 @@
         "failedToSendInvitation": "Failed to send invitation",
         "succeededToSendInvitation": "An invitation to the participant list has been sent to {{email}}."
       },
+      "notificationRegistrationDeleted": "The registration has been deleted",
+      "notificationRegistrationUpdated": "The registration has been saved",
       "notificationTitleCannotEdit": "The registration cannot be edited",
       "placeholderConfirmationMessage": "Enter confirmation message for registrants",
       "placeholderEvent": "Select or search for an event",
@@ -1834,6 +1850,10 @@
       "labelSignupExtraInfo": "Additional information (optional)",
       "labelStreetAddress": "Street address",
       "labelZipcode": "Postcode",
+      "notificationSignupDeleted": "The signup has been deleted",
+      "notificationSignupUpdated": "The signup has been saved",
+      "notificationSignupGroupDeleted": "The signup group has been deleted",
+      "notificationSignupGroupUpdated": "The signup group has been saved",
       "notificationTitleCannotEdit": "Participants cannot be edited",
       "placeholderCity": "Enter city",
       "placeholderEmail": "Enter your email address",

--- a/src/domain/app/i18n/fi.json
+++ b/src/domain/app/i18n/fi.json
@@ -720,6 +720,10 @@
         "general": "Määritä toistuva tapahtuma",
         "volunteering": "Määritä toistuva vapaaehtoistehtävä"
       },
+      "notificationEventCancelled": "Tapahtuma on peruttu",
+      "notificationEventDeleted": "Tapahtuma on poistettu",
+      "notificationEventPostponed": "Tapahtuma on lykätty",
+      "notificationEventUpdated": "Tapahtuma on tallennettu",
       "notificationTitleCannotEdit": "Tapahtumaa ei voi muokata",
       "notificationTitleDescription": {
         "course": "Kurssin kuvaus",
@@ -1290,6 +1294,8 @@
       "labelPhotographerName": "Kuvaajan nimi",
       "labelPublisher": "Julkaisija",
       "labelUrl": "Kuvan URL-osoite",
+      "notificationImageDeleted": "Kuva on poistettu",
+      "notificationImageUpdated": "Kuva on tallennettu",
       "notificationTitleCannotEdit": "Kuvaa ei voi muokata",
       "placeholderAltText": "Syötä kuvan alt-teksti",
       "placeholderName": "Syötä kuvateksti",
@@ -1359,6 +1365,8 @@
       "labelOriginId": "Lähdetunniste",
       "labelPublisher": "Julkaisija",
       "labelReplacedBy": "Korvaus",
+      "notificationKeywordDeleted": "Avainsana on poistettu",
+      "notificationKeywordUpdated": "Avainsana on tallennettu",
       "notificationTitleCannotEdit": "Avainsanaa ei voi muokata"
     }
   },
@@ -1452,6 +1460,8 @@
       "labelOrganization": "Julkaisija",
       "labelOriginId": "Lähdetunniste",
       "labelUsage": "Käyttötarkoitus",
+      "notificationKeywordSetDeleted": "Avainsanaryhmä on poistettu",
+      "notificationKeywordSetUpdated": "Avainsanaryhmä on tallennettu",
       "notificationTitleCannotEdit": "Avainsanaryhmää ei voi muokata"
     }
   },
@@ -1562,6 +1572,8 @@
       "labelRegistrationAdminUsers": "Ilmoittautumisen pääkäyttäjät",
       "labelRegularUsers": "Peruskäyttäjät",
       "labelReplacedBy": "Korvaava organisaatio",
+      "notificationOrganizationDeleted": "Organisaatio on poistettu",
+      "notificationOrganizationUpdated": "Organisaatio on tallennettu",
       "notificationTitleCannotEdit": "Organisaatiota ei voi muokata"
     },
     "internalType": {
@@ -1630,6 +1642,8 @@
       "labelPublisher": "Julkaisija",
       "labelStreetAddress": "Katuosoite ({{langText}})",
       "labelTelephone": "Puhelinnumero ({{langText}})",
+      "notificationPlaceDeleted": "Paikka on poistettu",
+      "notificationPlaceUpdated": "Paikka on tallennettu",
       "notificationTitleCannotEdit": "Paikkaa ei voi muokata",
       "titleContactInfo": "Yhteystiedot",
       "titleLocation": "Sijainti"
@@ -1703,6 +1717,8 @@
         "failedToSendInvitation": "Kutsun lähettäminen epäonnistui",
         "succeededToSendInvitation": "Kutsu osallistujalistaan on lähetetty osoitteeseen {{email}}."
       },
+      "notificationRegistrationDeleted": "Ilmoittautuminen on poistettu",
+      "notificationRegistrationUpdated": "Ilmoittautuminen on tallennettu",
       "notificationTitleCannotEdit": "Ilmoittautumista ei voi muokata",
       "placeholderConfirmationMessage": "Syötä vahvistusviesti ilmoittautuneille",
       "placeholderEvent": "Valitse tai hae tapahtuma",
@@ -1835,6 +1851,10 @@
       "labelSignupExtraInfo": "Lisätietoa (valinnainen)",
       "labelStreetAddress": "Katuosoite",
       "labelZipcode": "Postinumero",
+      "notificationSignupDeleted": "Osallistujan tiedot on poistettu",
+      "notificationSignupUpdated": "Osallistujan tiedot on tallennettu",
+      "notificationSignupGroupDeleted": "Osallistujien tiedot on poistettu",
+      "notificationSignupGroupUpdated": "Osallistujien tiedot on tallennettu",
       "notificationTitleCannotEdit": "Osallistujia ei voi muokata",
       "placeholderCity": "Syötä kaupunki",
       "placeholderEmail": "Syötä sähköpostiosoite",

--- a/src/domain/app/i18n/sv.json
+++ b/src/domain/app/i18n/sv.json
@@ -720,6 +720,10 @@
         "general": "Ange återkommande evenemang",
         "volunteering": "Ange återkommande volontärarbete"
       },
+      "notificationEventCancelled": "Evenemanget har ställts in",
+      "notificationEventDeleted": "Evenemanget har tagits bort",
+      "notificationEventPostponed": "Evenemanget har skjutits upp",
+      "notificationEventUpdated": "Evenemanget har sparats",
       "notificationTitleCannotEdit": "Evenemanget kan inte redigeras",
       "notificationTitleDescription": {
         "course": "Kursbeskrivning",
@@ -1290,6 +1294,8 @@
       "labelPhotographerName": "Författarens namn",
       "labelPublisher": "Utgivare",
       "labelUrl": "Bildens URL-webbaddress",
+      "notificationImageDeleted": "Bilden har tagits bort",
+      "notificationImageUpdated": "Bilden har sparats",
       "notificationTitleCannotEdit": "Bilden kan inte redigeras",
       "placeholderAltText": "Ange bildens alt-text för skärmläsare",
       "placeholderName": "Ange bildtext",
@@ -1359,6 +1365,8 @@
       "labelOriginId": "Ursprungs-ID",
       "labelPublisher": "Utgivare",
       "labelReplacedBy": "Ersatt av",
+      "notificationKeywordDeleted": "Nyckelordet har tagits bort",
+      "notificationKeywordUpdated": "Nyckelordet har sparats",
       "notificationTitleCannotEdit": "Nyckelord kan inte redigeras"
     }
   },
@@ -1452,6 +1460,8 @@
       "labelOrganization": "Utgivare",
       "labelOriginId": "Ursprungs-ID",
       "labelUsage": "Användande",
+      "notificationKeywordSetDeleted": "Nyckelordsuppsättning har tagits bort",
+      "notificationKeywordSetUpdated": "Nyckelordsuppsättning har sparats",
       "notificationTitleCannotEdit": "Nyckelordsuppsättning kan inte redigeras"
     }
   },
@@ -1562,6 +1572,8 @@
       "labelRegistrationAdminUsers": "Registrering admin användare",
       "labelRegularUsers": "Regelbundna användare",
       "labelReplacedBy": "Ersatt av",
+      "notificationOrganisationDeleted": "Organisation har tagits bort",
+      "notificationOrganisationUpdated": "Organisation har sparats",
       "notificationTitleCannotEdit": "Organisation kan inte redigeras"
     },
     "internalType": {
@@ -1630,6 +1642,8 @@
       "labelPublisher": "Utgivare",
       "labelStreetAddress": "Gatuadress ({{langText}})",
       "labelTelephone": "Telefonnummer ({{langText}})",
+      "notificationPlaceDeleted": "Platsen har tagits bort",
+      "notificationPlaceUpdated": "Platsen har sparats",
       "notificationTitleCannotEdit": "Platsen kan inte redigeras",
       "titleContactInfo": "Kontaktinformation",
       "titleLocation": "Position"
@@ -1703,6 +1717,8 @@
         "failedToSendInvitation": "Det gick inte att skicka inbjudan",
         "succeededToSendInvitation": "En inbjudan till deltagarlista har skickats till {{email}}."
       },
+      "notificationRegistrationDeleted": "Registreringen har raderats",
+      "notificationRegistrationUpdated": "Registreringen har sparad",
       "notificationTitleCannotEdit": "Registreringet kan inte redigeras",
       "placeholderConfirmationMessage": "Ange ett bekräftelsemeddelande för registranter",
       "placeholderEvent": "Välj eller sök efter evenemanget",
@@ -1835,6 +1851,10 @@
       "labelSignupExtraInfo": "Ytterligare information (valfritt)",
       "labelStreetAddress": "Gatuadress",
       "labelZipcode": "Postnummer",
+      "notificationSignupDeleted": "Deltagarinformation har raderats",
+      "notificationSignupUpdated": "Deltagarinformation har sparad",
+      "notificationSignupGroupDeleted": "Deltagarinformation har raderats",
+      "notificationSignupGroupUpdated": "Deltagarinformation har sparad",
       "notificationTitleCannotEdit": "Deltagaren kan inte redigeras",
       "placeholderCity": "Ange staden",
       "placeholderEmail": "Skriv in din mailadress",

--- a/src/domain/event/eventForm/EventForm.tsx
+++ b/src/domain/event/eventForm/EventForm.tsx
@@ -26,6 +26,7 @@ import Container from '../../app/layout/container/Container';
 import MainContent from '../../app/layout/mainContent/MainContent';
 import PageWrapper from '../../app/layout/pageWrapper/PageWrapper';
 import Section from '../../app/layout/section/Section';
+import { useNotificationsContext } from '../../app/notificationsContext/hooks/useNotificationsContext';
 import { replaceParamsToEventQueryString } from '../../events/utils';
 import useOrganizationAncestors from '../../organization/hooks/useOrganizationAncestors';
 import useUser from '../../user/hooks/useUser';
@@ -116,6 +117,7 @@ const EventForm: React.FC<EventFormProps> = ({
   isExternalUser,
 }) => {
   const { t } = useTranslation();
+  const { addNotification } = useNotificationsContext();
   const locale = useLocale();
   const location = useLocation();
   const navigate = useNavigate();
@@ -178,6 +180,10 @@ const EventForm: React.FC<EventFormProps> = ({
       onSuccess: async () => {
         refetch && (await refetch());
         window.scrollTo(0, 0);
+        addNotification({
+          label: t('event.form.notificationEventCancelled'),
+          type: 'success',
+        });
       },
     });
   };
@@ -194,7 +200,13 @@ const EventForm: React.FC<EventFormProps> = ({
 
   const handleDelete = () => {
     deleteEvent({
-      onSuccess: () => goToEventsPage(),
+      onSuccess: () => {
+        goToEventsPage();
+        addNotification({
+          label: t('event.form.notificationEventDeleted'),
+          type: 'success',
+        });
+      },
     });
   };
 
@@ -209,6 +221,10 @@ const EventForm: React.FC<EventFormProps> = ({
       onSuccess: async () => {
         refetch && (await refetch());
         window.scrollTo(0, 0);
+        addNotification({
+          label: t('event.form.notificationEventPostponed'),
+          type: 'success',
+        });
       },
     });
   };
@@ -227,6 +243,10 @@ const EventForm: React.FC<EventFormProps> = ({
       onSuccess: async () => {
         refetch && (await refetch());
         window.scrollTo(0, 0);
+        addNotification({
+          label: t('event.form.notificationEventUpdated'),
+          type: 'success',
+        });
       },
     });
   };

--- a/src/domain/events/eventActionsDropdown/EventActionsDropdown.tsx
+++ b/src/domain/events/eventActionsDropdown/EventActionsDropdown.tsx
@@ -15,6 +15,7 @@ import {
   parseEmailFromCreatedBy,
 } from '../../../utils/openMailtoLinkUtils';
 import skipFalsyType from '../../../utils/skipFalsyType';
+import { useNotificationsContext } from '../../app/notificationsContext/hooks/useNotificationsContext';
 import { useAuth } from '../../auth/hooks/useAuth';
 import { EVENT_ACTIONS, EVENT_MODALS } from '../../event/constants';
 import useEventActions from '../../event/hooks/useEventActions';
@@ -39,6 +40,7 @@ const EventActionsDropdown: React.FC<EventActionsDropdownProps> = ({
   event,
 }) => {
   const { t } = useTranslation();
+  const { addNotification } = useNotificationsContext();
   const { isAuthenticated: authenticated } = useAuth();
   const locale = useLocale();
   const navigate = useNavigate();
@@ -127,7 +129,16 @@ const EventActionsDropdown: React.FC<EventActionsDropdownProps> = ({
           isOpen={openModal === EVENT_MODALS.CANCEL}
           isSaving={saving === EVENT_ACTIONS.CANCEL}
           onClose={closeModal}
-          onConfirm={cancelEvent}
+          onConfirm={() =>
+            cancelEvent({
+              onSuccess: () => {
+                addNotification({
+                  label: t('event.form.notificationEventCancelled'),
+                  type: 'success',
+                });
+              },
+            })
+          }
         />
       )}
       {openModal === EVENT_MODALS.DELETE && (
@@ -136,7 +147,16 @@ const EventActionsDropdown: React.FC<EventActionsDropdownProps> = ({
           isOpen={openModal === EVENT_MODALS.DELETE}
           isSaving={saving === EVENT_ACTIONS.DELETE}
           onClose={closeModal}
-          onConfirm={deleteEvent}
+          onConfirm={() =>
+            deleteEvent({
+              onSuccess: () => {
+                addNotification({
+                  label: t('event.form.notificationEventDeleted'),
+                  type: 'success',
+                });
+              },
+            })
+          }
         />
       )}
       {openModal === EVENT_MODALS.POSTPONE && (
@@ -145,7 +165,16 @@ const EventActionsDropdown: React.FC<EventActionsDropdownProps> = ({
           isOpen={openModal === EVENT_MODALS.POSTPONE}
           isSaving={saving === EVENT_ACTIONS.POSTPONE}
           onClose={closeModal}
-          onConfirm={postponeEvent}
+          onConfirm={() =>
+            postponeEvent({
+              onSuccess: () => {
+                addNotification({
+                  label: t('event.form.notificationEventPostponed'),
+                  type: 'success',
+                });
+              },
+            })
+          }
         />
       )}
 

--- a/src/domain/image/EditImagePage.tsx
+++ b/src/domain/image/EditImagePage.tsx
@@ -12,6 +12,7 @@ import getPathBuilder from '../../utils/getPathBuilder';
 import getValue from '../../utils/getValue';
 import PageWrapper from '../app/layout/pageWrapper/PageWrapper';
 import TitleRow from '../app/layout/titleRow/TitleRow';
+import { useNotificationsContext } from '../app/notificationsContext/hooks/useNotificationsContext';
 import { useAuth } from '../auth/hooks/useAuth';
 import NotFound from '../notFound/NotFound';
 import useOrganizationAncestors from '../organization/hooks/useOrganizationAncestors';
@@ -30,6 +31,7 @@ type Props = {
 
 const EditImagePage: React.FC<Props> = ({ image }) => {
   const { t } = useTranslation();
+  const { addNotification } = useNotificationsContext();
   const locale = useLocale();
   const navigate = useNavigate();
   const { publisher } = getImageFields(image, locale);
@@ -48,7 +50,13 @@ const EditImagePage: React.FC<Props> = ({ image }) => {
 
   const handleDelete = () => {
     deleteImage({
-      onSuccess: () => goToImagesPage(),
+      onSuccess: () => {
+        goToImagesPage();
+        addNotification({
+          label: t('image.form.notificationImageDeleted'),
+          type: 'success',
+        });
+      },
     });
   };
 

--- a/src/domain/image/__tests__/EditImagePage.test.tsx
+++ b/src/domain/image/__tests__/EditImagePage.test.tsx
@@ -92,6 +92,7 @@ test('should delete keyword', async () => {
   await waitFor(() =>
     expect(history.location.pathname).toBe(`/fi/administration/images`)
   );
+  await screen.findByRole('alert', { name: 'Kuva on poistettu' });
 });
 
 test('should update image', async () => {
@@ -109,6 +110,7 @@ test('should update image', async () => {
   await waitFor(() =>
     expect(history.location.pathname).toBe(`/fi/administration/images`)
   );
+  await screen.findByRole('alert', { name: 'Kuva on tallennettu' });
 });
 
 test('should show server errors', async () => {

--- a/src/domain/image/imageForm/ImageForm.tsx
+++ b/src/domain/image/imageForm/ImageForm.tsx
@@ -30,6 +30,7 @@ import {
 } from '../../../utils/validationUtils';
 import styles from '../../admin/layout/form.module.scss';
 import FormRow from '../../admin/layout/formRow/FormRow';
+import { useNotificationsContext } from '../../app/notificationsContext/hooks/useNotificationsContext';
 import useOrganizationAncestors from '../../organization/hooks/useOrganizationAncestors';
 import useUser from '../../user/hooks/useUser';
 import {
@@ -60,6 +61,7 @@ type ImageFormProps = {
 
 const ImageForm: React.FC<ImageFormProps> = ({ image }) => {
   const { t } = useTranslation();
+  const { addNotification } = useNotificationsContext();
   const locale = useLocale();
   const navigate = useNavigate();
   const { user } = useUser();
@@ -111,6 +113,10 @@ const ImageForm: React.FC<ImageFormProps> = ({ image }) => {
       onError: (error: ServerError) => showServerErrors({ error }),
       onSuccess: async () => {
         goToImagesPage();
+        addNotification({
+          label: t('image.form.notificationImageUpdated'),
+          type: 'success',
+        });
       },
     });
   };

--- a/src/domain/images/imageActionsDropdown/ImageActionsDropdown.tsx
+++ b/src/domain/images/imageActionsDropdown/ImageActionsDropdown.tsx
@@ -8,6 +8,7 @@ import { ROUTES } from '../../../constants';
 import { ImageFieldsFragment } from '../../../generated/graphql';
 import useLocale from '../../../hooks/useLocale';
 import skipFalsyType from '../../../utils/skipFalsyType';
+import { useNotificationsContext } from '../../app/notificationsContext/hooks/useNotificationsContext';
 import { useAuth } from '../../auth/hooks/useAuth';
 import { IMAGE_ACTIONS } from '../../image/constants';
 import useImageUpdateActions, {
@@ -29,6 +30,7 @@ const ImageActionsDropdown: React.FC<ImageActionsDropdownProps> = (
   ref
 ) => {
   const { t } = useTranslation();
+  const { addNotification } = useNotificationsContext();
   const locale = useLocale();
   const navigate = useNavigate();
   const { isAuthenticated: authenticated } = useAuth();
@@ -89,7 +91,16 @@ const ImageActionsDropdown: React.FC<ImageActionsDropdownProps> = (
           isOpen={openModal === IMAGE_MODALS.DELETE}
           isSaving={saving === IMAGE_ACTIONS.DELETE}
           onClose={closeModal}
-          onConfirm={deleteImage}
+          onConfirm={() =>
+            deleteImage({
+              onSuccess: () => {
+                addNotification({
+                  label: t('image.form.notificationImageDeleted'),
+                  type: 'success',
+                });
+              },
+            })
+          }
         />
       )}
       <ActionsDropdown className={className} items={actionItems} />

--- a/src/domain/images/imageActionsDropdown/__tests__/ImageActionsDropdown.test.tsx
+++ b/src/domain/images/imageActionsDropdown/__tests__/ImageActionsDropdown.test.tsx
@@ -120,4 +120,5 @@ test('should delete image', async () => {
   await waitFor(() =>
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
   );
+  await screen.findByRole('alert', { name: 'Kuva on poistettu' });
 });

--- a/src/domain/keyword/EditKeywordPage.tsx
+++ b/src/domain/keyword/EditKeywordPage.tsx
@@ -15,6 +15,7 @@ import getPathBuilder from '../../utils/getPathBuilder';
 import getValue from '../../utils/getValue';
 import PageWrapper from '../app/layout/pageWrapper/PageWrapper';
 import TitleRow from '../app/layout/titleRow/TitleRow';
+import { useNotificationsContext } from '../app/notificationsContext/hooks/useNotificationsContext';
 import { useAuth } from '../auth/hooks/useAuth';
 import NotFound from '../notFound/NotFound';
 import useOrganizationAncestors from '../organization/hooks/useOrganizationAncestors';
@@ -37,6 +38,7 @@ type Props = {
 
 const EditKeywordPage: React.FC<Props> = ({ keyword }) => {
   const { t } = useTranslation();
+  const { addNotification } = useNotificationsContext();
   const locale = useLocale();
   const navigate = useNavigate();
   const { publisher } = getKeywordFields(keyword, locale);
@@ -55,7 +57,13 @@ const EditKeywordPage: React.FC<Props> = ({ keyword }) => {
 
   const handleDelete = () => {
     deleteKeyword({
-      onSuccess: () => goToKeywordsPage(),
+      onSuccess: () => {
+        goToKeywordsPage();
+        addNotification({
+          label: t('keyword.form.notificationKeywordDeleted'),
+          type: 'success',
+        });
+      },
     });
   };
 

--- a/src/domain/keyword/__tests__/EditKeywordPage.test.tsx
+++ b/src/domain/keyword/__tests__/EditKeywordPage.test.tsx
@@ -94,6 +94,7 @@ test('should delete keyword', async () => {
   await waitFor(() =>
     expect(history.location.pathname).toBe(`/fi/administration/keywords`)
   );
+  await screen.findByRole('alert', { name: 'Avainsana on poistettu' });
 });
 
 test('should update keyword', async () => {
@@ -111,6 +112,7 @@ test('should update keyword', async () => {
   await waitFor(() =>
     expect(history.location.pathname).toBe(`/fi/administration/keywords`)
   );
+  await screen.findByRole('alert', { name: 'Avainsana on tallennettu' });
 });
 
 test('should show server errors', async () => {

--- a/src/domain/keyword/keywordForm/KeywordForm.tsx
+++ b/src/domain/keyword/keywordForm/KeywordForm.tsx
@@ -26,6 +26,7 @@ import {
 } from '../../../utils/validationUtils';
 import styles from '../../admin/layout/form.module.scss';
 import FormRow from '../../admin/layout/formRow/FormRow';
+import { useNotificationsContext } from '../../app/notificationsContext/hooks/useNotificationsContext';
 import useOrganizationAncestors from '../../organization/hooks/useOrganizationAncestors';
 import useUser from '../../user/hooks/useUser';
 import {
@@ -48,6 +49,7 @@ type KeywordFormProps = {
 
 const KeywordForm: React.FC<KeywordFormProps> = ({ keyword }) => {
   const { t } = useTranslation();
+  const { addNotification } = useNotificationsContext();
   const locale = useLocale();
   const navigate = useNavigate();
   const { user } = useUser();
@@ -87,7 +89,13 @@ const KeywordForm: React.FC<KeywordFormProps> = ({ keyword }) => {
   const onUpdate = async (values: KeywordFormFields) => {
     await updateKeyword(values, {
       onError: (error: ServerError) => showServerErrors({ error }),
-      onSuccess: goToKeywordsPage,
+      onSuccess: () => {
+        goToKeywordsPage();
+        addNotification({
+          label: t('keyword.form.notificationKeywordUpdated'),
+          type: 'success',
+        });
+      },
     });
   };
 

--- a/src/domain/keywordSet/EditKeywordSetPage.tsx
+++ b/src/domain/keywordSet/EditKeywordSetPage.tsx
@@ -17,6 +17,7 @@ import getPathBuilder from '../../utils/getPathBuilder';
 import getValue from '../../utils/getValue';
 import PageWrapper from '../app/layout/pageWrapper/PageWrapper';
 import TitleRow from '../app/layout/titleRow/TitleRow';
+import { useNotificationsContext } from '../app/notificationsContext/hooks/useNotificationsContext';
 import { useAuth } from '../auth/hooks/useAuth';
 import NotFound from '../notFound/NotFound';
 import useOrganizationAncestors from '../organization/hooks/useOrganizationAncestors';
@@ -39,6 +40,7 @@ type Props = {
 
 const EditKeywordSetPage: React.FC<Props> = ({ keywordSet }) => {
   const { t } = useTranslation();
+  const { addNotification } = useNotificationsContext();
   const locale = useLocale();
   const navigate = useNavigate();
   const { isAuthenticated: authenticated } = useAuth();
@@ -57,7 +59,13 @@ const EditKeywordSetPage: React.FC<Props> = ({ keywordSet }) => {
 
   const handleDelete = () => {
     deleteKeywordSet({
-      onSuccess: () => goToKeywordSetsPage(),
+      onSuccess: () => {
+        goToKeywordSetsPage();
+        addNotification({
+          label: t('keywordSet.form.notificationKeywordSetDeleted'),
+          type: 'success',
+        });
+      },
     });
   };
 

--- a/src/domain/keywordSet/__tests__/EditKeywordSetPage.test.tsx
+++ b/src/domain/keywordSet/__tests__/EditKeywordSetPage.test.tsx
@@ -106,6 +106,7 @@ test('should delete keyword', async () => {
   await waitFor(() =>
     expect(history.location.pathname).toBe(`/fi/administration/keyword-sets`)
   );
+  await screen.findByRole('alert', { name: 'Avainsanaryhmä on poistettu' });
 });
 
 test('should update keyword set', async () => {
@@ -125,6 +126,7 @@ test('should update keyword set', async () => {
   await waitFor(() =>
     expect(history.location.pathname).toBe(`/fi/administration/keyword-sets`)
   );
+  await screen.findByRole('alert', { name: 'Avainsanaryhmä on tallennettu' });
 });
 
 test('should show server errors', async () => {

--- a/src/domain/keywordSet/keywordSetForm/KeywordSetForm.tsx
+++ b/src/domain/keywordSet/keywordSetForm/KeywordSetForm.tsx
@@ -26,6 +26,7 @@ import {
 } from '../../../utils/validationUtils';
 import styles from '../../admin/layout/form.module.scss';
 import FormRow from '../../admin/layout/formRow/FormRow';
+import { useNotificationsContext } from '../../app/notificationsContext/hooks/useNotificationsContext';
 import useKeywordSetUsageOptions from '../../keywordSets/hooks/useKeywordSetUsageOptions';
 import useOrganizationAncestors from '../../organization/hooks/useOrganizationAncestors';
 import useUser from '../../user/hooks/useUser';
@@ -49,6 +50,7 @@ type KeywordSetFormProps = {
 
 const KeywordSetForm: React.FC<KeywordSetFormProps> = ({ keywordSet }) => {
   const { t } = useTranslation();
+  const { addNotification } = useNotificationsContext();
   const navigate = useNavigate();
   const locale = useLocale();
   const { user } = useUser();
@@ -87,7 +89,13 @@ const KeywordSetForm: React.FC<KeywordSetFormProps> = ({ keywordSet }) => {
   const onUpdate = async (values: KeywordSetFormFields) => {
     await updateKeywordSet(values, {
       onError: (error: ServerError) => showServerErrors({ error }),
-      onSuccess: goToKeywordSetsPage,
+      onSuccess: () => {
+        goToKeywordSetsPage();
+        addNotification({
+          label: t('keywordSet.form.notificationKeywordSetUpdated'),
+          type: 'success',
+        });
+      },
     });
   };
 

--- a/src/domain/keywordSets/keywordSetActionsDropdown/KeywordSetActionsDropdown.tsx
+++ b/src/domain/keywordSets/keywordSetActionsDropdown/KeywordSetActionsDropdown.tsx
@@ -9,6 +9,7 @@ import { ROUTES } from '../../../constants';
 import { KeywordSetFieldsFragment } from '../../../generated/graphql';
 import useLocale from '../../../hooks/useLocale';
 import skipFalsyType from '../../../utils/skipFalsyType';
+import { useNotificationsContext } from '../../app/notificationsContext/hooks/useNotificationsContext';
 import { useAuth } from '../../auth/hooks/useAuth';
 import { KEYWORD_SET_ACTIONS } from '../../keywordSet/constants';
 import useKeywordSetUpdateActions, {
@@ -33,6 +34,7 @@ const KeywordSetActionsDropdown: React.FC<KeywordSetActionsDropdownProps> = ({
   keywordSet,
 }) => {
   const { t } = useTranslation();
+  const { addNotification } = useNotificationsContext();
   const locale = useLocale();
   const navigate = useNavigate();
   const { isAuthenticated: authenticated } = useAuth();
@@ -94,7 +96,16 @@ const KeywordSetActionsDropdown: React.FC<KeywordSetActionsDropdownProps> = ({
           isOpen={openModal === KEYWORD_SET_MODALS.DELETE}
           isSaving={saving === KEYWORD_SET_ACTIONS.DELETE}
           onClose={closeModal}
-          onConfirm={deleteKeywordSet}
+          onConfirm={() => {
+            deleteKeywordSet({
+              onSuccess: () => {
+                addNotification({
+                  label: t('keywordSet.form.notificationKeywordSetDeleted'),
+                  type: 'success',
+                });
+              },
+            });
+          }}
         />
       )}
       <ActionsDropdown className={className} items={actionItems} />

--- a/src/domain/keywordSets/keywordSetActionsDropdown/__tests__/KeywordSetActionsDropdown.test.tsx
+++ b/src/domain/keywordSets/keywordSetActionsDropdown/__tests__/KeywordSetActionsDropdown.test.tsx
@@ -130,4 +130,5 @@ test('should delete keyword set', async () => {
   await waitFor(() =>
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
   );
+  await screen.findByRole('alert', { name: 'Avainsanaryhmä on poistettu' });
 });

--- a/src/domain/keywords/keywordActionsDropdown/KeywordActionsDropdown.tsx
+++ b/src/domain/keywords/keywordActionsDropdown/KeywordActionsDropdown.tsx
@@ -8,6 +8,7 @@ import { ROUTES } from '../../../constants';
 import { KeywordFieldsFragment } from '../../../generated/graphql';
 import useLocale from '../../../hooks/useLocale';
 import skipFalsyType from '../../../utils/skipFalsyType';
+import { useNotificationsContext } from '../../app/notificationsContext/hooks/useNotificationsContext';
 import { useAuth } from '../../auth/hooks/useAuth';
 import { KEYWORD_ACTIONS } from '../../keyword/constants';
 import useKeywordUpdateActions, {
@@ -29,6 +30,7 @@ const KeywordActionsDropdown: React.FC<KeywordActionsDropdownProps> = ({
   keyword,
 }) => {
   const { t } = useTranslation();
+  const { addNotification } = useNotificationsContext();
   const locale = useLocale();
   const navigate = useNavigate();
   const { isAuthenticated: authenticated } = useAuth();
@@ -89,7 +91,16 @@ const KeywordActionsDropdown: React.FC<KeywordActionsDropdownProps> = ({
           isOpen={openModal === KEYWORD_MODALS.DELETE}
           isSaving={saving === KEYWORD_ACTIONS.DELETE}
           onClose={closeModal}
-          onConfirm={deleteKeyword}
+          onConfirm={() =>
+            deleteKeyword({
+              onSuccess: () => {
+                addNotification({
+                  label: t('keyword.form.notificationKeywordDeleted'),
+                  type: 'success',
+                });
+              },
+            })
+          }
         />
       )}
       <ActionsDropdown className={className} items={actionItems} />

--- a/src/domain/keywords/keywordActionsDropdown/__tests__/KeywordActionsDropdown.test.tsx
+++ b/src/domain/keywords/keywordActionsDropdown/__tests__/KeywordActionsDropdown.test.tsx
@@ -132,4 +132,5 @@ test('should delete keyword', async () => {
   await waitFor(() =>
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
   );
+  await screen.findByRole('alert', { name: 'Avainsana on poistettu' });
 });

--- a/src/domain/organization/EditOrganizationPage.tsx
+++ b/src/domain/organization/EditOrganizationPage.tsx
@@ -15,6 +15,7 @@ import getPathBuilder from '../../utils/getPathBuilder';
 import getValue from '../../utils/getValue';
 import PageWrapper from '../app/layout/pageWrapper/PageWrapper';
 import TitleRow from '../app/layout/titleRow/TitleRow';
+import { useNotificationsContext } from '../app/notificationsContext/hooks/useNotificationsContext';
 import { useAuth } from '../auth/hooks/useAuth';
 import NotFound from '../notFound/NotFound';
 import useUser from '../user/hooks/useUser';
@@ -36,6 +37,7 @@ type Props = {
 
 const EditOrganizationPage: React.FC<Props> = ({ organization }) => {
   const { t } = useTranslation();
+  const { addNotification } = useNotificationsContext();
   const locale = useLocale();
   const navigate = useNavigate();
   const { id } = getOrganizationFields(organization, locale, t);
@@ -53,7 +55,13 @@ const EditOrganizationPage: React.FC<Props> = ({ organization }) => {
 
   const handleDelete = () => {
     deleteOrganization({
-      onSuccess: () => goToOrganizationsPage(),
+      onSuccess: () => {
+        goToOrganizationsPage();
+        addNotification({
+          label: t('organization.form.notificationOrganizationDeleted'),
+          type: 'success',
+        });
+      },
     });
   };
 

--- a/src/domain/organization/__tests__/EditOrganizationPage.test.tsx
+++ b/src/domain/organization/__tests__/EditOrganizationPage.test.tsx
@@ -131,6 +131,7 @@ test('should delete organization', async () => {
   await waitFor(() =>
     expect(history.location.pathname).toBe(`/fi/administration/organizations`)
   );
+  await screen.findByRole('alert', { name: 'Organisaatio on poistettu' });
 });
 
 test('should update organization', async () => {
@@ -149,6 +150,7 @@ test('should update organization', async () => {
   await waitFor(() =>
     expect(history.location.pathname).toBe(`/fi/administration/organizations`)
   );
+  await screen.findByRole('alert', { name: 'Organisaatio on tallennettu' });
 });
 
 test('should show server errors', async () => {

--- a/src/domain/organization/organizationForm/OrganizationForm.tsx
+++ b/src/domain/organization/organizationForm/OrganizationForm.tsx
@@ -33,6 +33,7 @@ import {
 import styles from '../../admin/layout/form.module.scss';
 import FormRow from '../../admin/layout/formRow/FormRow';
 import { clearOrganizationsQueries } from '../../app/apollo/clearCacheUtils';
+import { useNotificationsContext } from '../../app/notificationsContext/hooks/useNotificationsContext';
 import { reportError } from '../../app/sentry/utils';
 import useUser from '../../user/hooks/useUser';
 import {
@@ -63,6 +64,7 @@ const OrganizationForm: React.FC<OrganizationFormProps> = ({
   organization,
 }) => {
   const { t } = useTranslation();
+  const { addNotification } = useNotificationsContext();
   const navigate = useNavigate();
   const location = useLocation();
   const locale = useLocale();
@@ -98,8 +100,12 @@ const OrganizationForm: React.FC<OrganizationFormProps> = ({
   const onUpdate = async (values: OrganizationFormFields) => {
     await updateOrganization(values, {
       onError: (error: ServerError) => showServerErrors({ error }),
-      onSuccess: async () => {
+      onSuccess: () => {
         goToOrganizationsPage();
+        addNotification({
+          label: t('organization.form.notificationOrganizationUpdated'),
+          type: 'success',
+        });
       },
     });
   };

--- a/src/domain/organizations/organizationActionsDropdown/OrganizationActionsDropdown.tsx
+++ b/src/domain/organizations/organizationActionsDropdown/OrganizationActionsDropdown.tsx
@@ -9,6 +9,7 @@ import { ROUTES } from '../../../constants';
 import { OrganizationFieldsFragment } from '../../../generated/graphql';
 import useLocale from '../../../hooks/useLocale';
 import skipFalsyType from '../../../utils/skipFalsyType';
+import { useNotificationsContext } from '../../app/notificationsContext/hooks/useNotificationsContext';
 import { useAuth } from '../../auth/hooks/useAuth';
 import { ORGANIZATION_ACTIONS } from '../../organization/constants';
 import useOrganizationUpdateActions, {
@@ -32,6 +33,7 @@ const OrganizationActionsDropdown: FC<OrganizationActionsDropdownProps> = ({
   organization,
 }) => {
   const { t } = useTranslation();
+  const { addNotification } = useNotificationsContext();
   const locale = useLocale();
   const navigate = useNavigate();
   const { isAuthenticated: authenticated } = useAuth();
@@ -90,7 +92,16 @@ const OrganizationActionsDropdown: FC<OrganizationActionsDropdownProps> = ({
           isOpen={openModal === ORGANIZATION_MODALS.DELETE}
           isSaving={saving === ORGANIZATION_ACTIONS.DELETE}
           onClose={closeModal}
-          onConfirm={deleteOrganization}
+          onConfirm={() => {
+            deleteOrganization({
+              onSuccess: () => {
+                addNotification({
+                  label: t('organization.form.notificationOrganizationDeleted'),
+                  type: 'success',
+                });
+              },
+            });
+          }}
         />
       )}
       <ActionsDropdown className={className} items={actionItems} />

--- a/src/domain/organizations/organizationActionsDropdown/__tests__/OrganizationActionsDropdown.test.tsx
+++ b/src/domain/organizations/organizationActionsDropdown/__tests__/OrganizationActionsDropdown.test.tsx
@@ -127,4 +127,5 @@ test('should delete organization', async () => {
   await waitFor(() =>
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
   );
+  await screen.findByRole('alert', { name: 'Organisaatio on poistettu' });
 });

--- a/src/domain/place/EditPlacePage.tsx
+++ b/src/domain/place/EditPlacePage.tsx
@@ -12,6 +12,7 @@ import getPathBuilder from '../../utils/getPathBuilder';
 import getValue from '../../utils/getValue';
 import PageWrapper from '../app/layout/pageWrapper/PageWrapper';
 import TitleRow from '../app/layout/titleRow/TitleRow';
+import { useNotificationsContext } from '../app/notificationsContext/hooks/useNotificationsContext';
 import { useAuth } from '../auth/hooks/useAuth';
 import NotFound from '../notFound/NotFound';
 import useOrganizationAncestors from '../organization/hooks/useOrganizationAncestors';
@@ -30,6 +31,7 @@ type Props = {
 
 const EditPlacePage: React.FC<Props> = ({ place }) => {
   const { t } = useTranslation();
+  const { addNotification } = useNotificationsContext();
   const navigate = useNavigate();
   const locale = useLocale();
   const { publisher } = getPlaceFields(place, locale);
@@ -48,7 +50,13 @@ const EditPlacePage: React.FC<Props> = ({ place }) => {
 
   const handleDelete = () => {
     deletePlace({
-      onSuccess: () => goToPlacesPage(),
+      onSuccess: () => {
+        goToPlacesPage();
+        addNotification({
+          label: t('place.form.notificationPlaceDeleted'),
+          type: 'success',
+        });
+      },
     });
   };
 

--- a/src/domain/place/__tests__/EditPlacePage.test.tsx
+++ b/src/domain/place/__tests__/EditPlacePage.test.tsx
@@ -97,6 +97,7 @@ test('should delete place', async () => {
   await waitFor(() =>
     expect(history.location.pathname).toBe(`/fi/administration/places`)
   );
+  await screen.findByRole('alert', { name: 'Paikka on poistettu' });
 });
 
 test('should update place', async () => {
@@ -114,6 +115,7 @@ test('should update place', async () => {
   await waitFor(() =>
     expect(history.location.pathname).toBe(`/fi/administration/places`)
   );
+  await screen.findByRole('alert', { name: 'Paikka on tallennettu' });
 });
 
 test('should show server errors', async () => {

--- a/src/domain/place/placeForm/PlaceForm.tsx
+++ b/src/domain/place/placeForm/PlaceForm.tsx
@@ -38,6 +38,7 @@ import styles from '../../admin/layout/form.module.scss';
 import FormRow from '../../admin/layout/formRow/FormRow';
 import { clearPlacesQueries } from '../../app/apollo/clearCacheUtils';
 import Section from '../../app/layout/section/Section';
+import { useNotificationsContext } from '../../app/notificationsContext/hooks/useNotificationsContext';
 import { reportError } from '../../app/sentry/utils';
 import useOrganizationAncestors from '../../organization/hooks/useOrganizationAncestors';
 import useUser from '../../user/hooks/useUser';
@@ -66,6 +67,7 @@ type PlaceFormProps = {
 
 const PlaceForm: React.FC<PlaceFormProps> = ({ place }) => {
   const { t } = useTranslation();
+  const { addNotification } = useNotificationsContext();
   const locale = useLocale();
   const location = useLocation();
   const navigate = useNavigate();
@@ -101,8 +103,12 @@ const PlaceForm: React.FC<PlaceFormProps> = ({ place }) => {
   const onUpdate = async (values: PlaceFormFields) => {
     await updatePlace(values, {
       onError: (error: ServerError) => showServerErrors({ error }),
-      onSuccess: async () => {
+      onSuccess: () => {
         goToPlacesPage();
+        addNotification({
+          label: t('place.form.notificationPlaceUpdated'),
+          type: 'success',
+        });
       },
     });
   };

--- a/src/domain/places/placeActionsDropdown/PlaceActionsDropdown.tsx
+++ b/src/domain/places/placeActionsDropdown/PlaceActionsDropdown.tsx
@@ -8,6 +8,7 @@ import { ROUTES } from '../../../constants';
 import { PlaceFieldsFragment } from '../../../generated/graphql';
 import useLocale from '../../../hooks/useLocale';
 import skipFalsyType from '../../../utils/skipFalsyType';
+import { useNotificationsContext } from '../../app/notificationsContext/hooks/useNotificationsContext';
 import { useAuth } from '../../auth/hooks/useAuth';
 import useOrganizationAncestors from '../../organization/hooks/useOrganizationAncestors';
 import { PLACE_ACTIONS } from '../../place/constants';
@@ -29,6 +30,7 @@ const PlaceActionsDropdown: React.FC<PlaceActionsDropdownProps> = ({
   place,
 }) => {
   const { t } = useTranslation();
+  const { addNotification } = useNotificationsContext();
   const locale = useLocale();
   const navigate = useNavigate();
   const { isAuthenticated: authenticated } = useAuth();
@@ -89,7 +91,16 @@ const PlaceActionsDropdown: React.FC<PlaceActionsDropdownProps> = ({
           isOpen={openModal === PLACE_MODALS.DELETE}
           isSaving={saving === PLACE_ACTIONS.DELETE}
           onClose={closeModal}
-          onConfirm={deletePlace}
+          onConfirm={() => {
+            deletePlace({
+              onSuccess: () => {
+                addNotification({
+                  label: t('place.form.notificationPlaceDeleted'),
+                  type: 'success',
+                });
+              },
+            });
+          }}
         />
       )}
       <ActionsDropdown className={className} items={actionItems} />

--- a/src/domain/places/placeActionsDropdown/__tests__/PlaceActionsDropdown.test.tsx
+++ b/src/domain/places/placeActionsDropdown/__tests__/PlaceActionsDropdown.test.tsx
@@ -107,7 +107,7 @@ test('should route to edit place page', async () => {
   );
 });
 
-test('should delete keyword', async () => {
+test('should delete place', async () => {
   const user = userEvent.setup();
   renderComponent(undefined, { authContextValue });
 
@@ -125,4 +125,5 @@ test('should delete keyword', async () => {
   await waitFor(() =>
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
   );
+  await screen.findByRole('alert', { name: 'Paikka on poistettu' });
 });

--- a/src/domain/registration/registrationForm/RegistrationForm.tsx
+++ b/src/domain/registration/registrationForm/RegistrationForm.tsx
@@ -57,6 +57,7 @@ import getValue from '../../../utils/getValue';
 import GroupSizeSection from '../formSections/groupSizeSection/GroupSizeSection';
 import LanguagesSection from '../formSections/languageSection/LanguageSection';
 import RegistrationUserAccessesSection from '../formSections/registrationUserAccessesSection/RegistrationUserAccessesSection';
+import { useNotificationsContext } from '../../app/notificationsContext/hooks/useNotificationsContext';
 
 export type CreateRegistrationFormProps = {
   event?: null;
@@ -81,6 +82,7 @@ const RegistrationForm: React.FC<RegistrationFormProps> = ({
   refetch,
   registration,
 }) => {
+  const { addNotification } = useNotificationsContext();
   const { t } = useTranslation();
   const locale = useLocale();
   const location = useLocation();
@@ -147,7 +149,13 @@ const RegistrationForm: React.FC<RegistrationFormProps> = ({
 
   const handleDelete = () => {
     deleteRegistration({
-      onSuccess: goToRegistrationsPage,
+      onSuccess: () => {
+        goToRegistrationsPage();
+        addNotification({
+          label: t('registration.form.notificationRegistrationDeleted'),
+          type: 'success',
+        });
+      },
     });
   };
 
@@ -157,6 +165,10 @@ const RegistrationForm: React.FC<RegistrationFormProps> = ({
       onSuccess: async () => {
         refetch && (await refetch());
         window.scrollTo(0, 0);
+        addNotification({
+          label: t('registration.form.notificationRegistrationUpdated'),
+          type: 'success',
+        });
       },
     });
   };

--- a/src/domain/registrations/registrationActionsDropdown/RegistrationActionsDropdown.tsx
+++ b/src/domain/registrations/registrationActionsDropdown/RegistrationActionsDropdown.tsx
@@ -132,7 +132,16 @@ const RegistrationActionsDropdown: React.FC<
           isOpen={openModal === REGISTRATION_MODALS.DELETE}
           isSaving={saving === REGISTRATION_ACTIONS.DELETE}
           onClose={closeModal}
-          onConfirm={deleteRegistration}
+          onConfirm={() =>
+            deleteRegistration({
+              onSuccess: () => {
+                addNotification({
+                  label: t('registration.form.notificationRegistrationDeleted'),
+                  type: 'success',
+                });
+              },
+            })
+          }
         />
       )}
       <ActionsDropdown className={className} items={actionItems} />

--- a/src/domain/registrations/registrationActionsDropdown/__tests__/RegistrationActionsDropdown.test.tsx
+++ b/src/domain/registrations/registrationActionsDropdown/__tests__/RegistrationActionsDropdown.test.tsx
@@ -248,4 +248,5 @@ test('should delete registration', async () => {
     () => expect(screen.queryByRole('dialog')).not.toBeInTheDocument(),
     { timeout: 10000 }
   );
+  await screen.findByRole('alert', { name: 'Ilmoittautuminen on poistettu' });
 });

--- a/src/domain/signupGroup/signupGroupForm/SignupGroupForm.tsx
+++ b/src/domain/signupGroup/signupGroupForm/SignupGroupForm.tsx
@@ -25,6 +25,7 @@ import extractLatestReturnPath from '../../../utils/extractLatestReturnPath';
 import getValue from '../../../utils/getValue';
 import { showFormErrors } from '../../../utils/validationUtils';
 import Container from '../../app/layout/container/Container';
+import { useNotificationsContext } from '../../app/notificationsContext/hooks/useNotificationsContext';
 import { isRegistrationPossible } from '../../registration/utils';
 import { replaceParamsToRegistrationQueryString } from '../../registrations/utils';
 import { clearSeatsReservationData } from '../../seatsReservation/utils';
@@ -110,6 +111,7 @@ type SignupGroupFormProps = Omit<
 const SignupGroupForm: React.FC<SignupGroupFormProps> = ({
   disabled,
   event,
+  refetchSignup,
   refetchSignupGroup,
   registration,
   setErrors,
@@ -120,6 +122,7 @@ const SignupGroupForm: React.FC<SignupGroupFormProps> = ({
 }) => {
   const { t } = useTranslation();
 
+  const { addNotification } = useNotificationsContext();
   const [{ value: signups }, , { setValue: setSignups }] = useField<
     SignupFormFields[]
   >(SIGNUP_GROUP_FIELDS.SIGNUPS);
@@ -219,9 +222,25 @@ const SignupGroupForm: React.FC<SignupGroupFormProps> = ({
 
   const handleDelete = () => {
     if (signupGroup) {
-      deleteSignupGroup({ onSuccess: goToSignupsPage });
+      deleteSignupGroup({
+        onSuccess: () => {
+          goToSignupsPage();
+          addNotification({
+            label: t('signup.form.notificationSignupGroupDeleted'),
+            type: 'success',
+          });
+        },
+      });
     } else {
-      deleteSignup({ onSuccess: goToSignupsPage });
+      deleteSignup({
+        onSuccess: () => {
+          goToSignupsPage();
+          addNotification({
+            label: t('signup.form.notificationSignupDeleted'),
+            type: 'success',
+          });
+        },
+      });
     }
   };
 
@@ -232,14 +251,22 @@ const SignupGroupForm: React.FC<SignupGroupFormProps> = ({
         onSuccess: async () => {
           refetchSignupGroup && (await refetchSignupGroup());
           window.scrollTo(0, 0);
+          addNotification({
+            label: t('signup.form.notificationSignupGroupUpdated'),
+            type: 'success',
+          });
         },
       });
     } else {
       updateSignup(values, {
         onError: (error: any) => showServerErrors({ error }, 'signup'),
         onSuccess: async () => {
-          refetchSignupGroup && (await refetchSignupGroup());
+          refetchSignup && (await refetchSignup());
           window.scrollTo(0, 0);
+          addNotification({
+            label: t('signup.form.notificationSignupUpdated'),
+            type: 'success',
+          });
         },
       });
     }

--- a/src/domain/signups/signupActionsDropdown/SignupActionsDropdown.tsx
+++ b/src/domain/signups/signupActionsDropdown/SignupActionsDropdown.tsx
@@ -12,6 +12,7 @@ import {
 import useLocale from '../../../hooks/useLocale';
 import getValue from '../../../utils/getValue';
 import skipFalsyType from '../../../utils/skipFalsyType';
+import { useNotificationsContext } from '../../app/notificationsContext/hooks/useNotificationsContext';
 import { useAuth } from '../../auth/hooks/useAuth';
 import useOrganizationAncestors from '../../organization/hooks/useOrganizationAncestors';
 import { addParamsToRegistrationQueryString } from '../../registrations/utils';
@@ -36,6 +37,7 @@ const SignupActionsDropdown: React.FC<SignupActionsDropdownProps> = ({
   signup,
 }) => {
   const { t } = useTranslation();
+  const { addNotification } = useNotificationsContext();
   const locale = useLocale();
   const navigate = useNavigate();
   const { isAuthenticated: authenticated } = useAuth();
@@ -116,7 +118,16 @@ const SignupActionsDropdown: React.FC<SignupActionsDropdownProps> = ({
         <ConfirmDeleteSignupOrSignupGroupModal
           isOpen={openModal === SIGNUP_MODALS.DELETE}
           isSaving={saving === SIGNUP_ACTIONS.DELETE}
-          onConfirm={deleteSignup}
+          onConfirm={() =>
+            deleteSignup({
+              onSuccess: () => {
+                addNotification({
+                  label: t('signup.form.notificationSignupDeleted'),
+                  type: 'success',
+                });
+              },
+            })
+          }
           onClose={closeModal}
           registration={registration}
           signup={signup}

--- a/src/types.ts
+++ b/src/types.ts
@@ -69,8 +69,8 @@ export type UseServerErrorsState = {
 };
 
 export type MutationCallbacks<ResponseDataType = string> = {
-  onError?: (error: any) => void;
-  onSuccess?: (id?: ResponseDataType) => void;
+  onError?: (error: any) => Promise<void> | void;
+  onSuccess?: (id?: ResponseDataType) => Promise<void> | void;
 };
 
 export type ButtonType = 'button' | 'reset' | 'submit' | undefined;


### PR DESCRIPTION
## Description :sparkles:
Show notification after updating or deleting event, image, keyword, keyword set, organization, place, registration, signup or signup group

This is the one of 4 PRs that replaces https://github.com/City-of-Helsinki/linkedcomponents-ui/pull/235. The purpose of these PRs is to replace react-toastify package with HDS Notifications. Notifications are also shown after updating or deleting event, image, keyword, keyword set, organization, place, registration, signup or signup group.

The original PR is divided to following parts:
- NotificationProvider component to show several notifications at same time (https://github.com/City-of-Helsinki/linkedcomponents-ui/pull/239)
- Replacing react-toastify with HDS notifications in Apollo Client (https://github.com/City-of-Helsinki/linkedcomponents-ui/pull/241)
- Replacing react-toastify with HDS notifications in rest of the places (https://github.com/City-of-Helsinki/linkedcomponents-ui/pull/242)
- Showing HDS notifitation after updating or deleting instances
## Issues :bug:

## Partially closes
[LINK-1520](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1520)


[LINK-1520]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ