### PR TITLE
LINK-1613 | Hide signup group extra info field when editing a signup

### DIFF
--- a/src/domain/signup/__tests__/EditSignupPage.test.tsx
+++ b/src/domain/signup/__tests__/EditSignupPage.test.tsx
@@ -265,3 +265,14 @@ test('should show server errors', async () => {
   await screen.findByText(/lomakkeella on seuraavat virheet/i);
   screen.getByText(/Nimi on pakollinen./i);
 });
+
+test('signup group extra info field should not be visible', async () => {
+  renderComponent();
+
+  await findElement('firstNameInput');
+  expect(
+    screen.queryByRole('textbox', {
+      name: 'Lisätietoa ilmoittautumisesta (valinnainen)',
+    })
+  ).not.toBeInTheDocument();
+});

--- a/src/domain/signupGroup/__tests__/EditSignupGroupPage.test.tsx
+++ b/src/domain/signupGroup/__tests__/EditSignupGroupPage.test.tsx
@@ -61,6 +61,7 @@ const getElement = (
     | 'phoneCheckbox'
     | 'phoneInput'
     | 'serviceLanguageButton'
+    | 'signupGroupExtraInfoField'
     | 'streetAddressInput'
     | 'submitButton'
     | 'toggle'
@@ -89,6 +90,10 @@ const getElement = (
       return screen.getByLabelText(/puhelinnumero/i);
     case 'serviceLanguageButton':
       return screen.getByRole('button', { name: /asiointikieli/i });
+    case 'signupGroupExtraInfoField':
+      return screen.getByRole('textbox', {
+        name: 'Lisätietoa ilmoittautumisesta (valinnainen)',
+      });
     case 'streetAddressInput':
       return screen.getByLabelText(/katuosoite/i);
     case 'submitButton':
@@ -264,4 +269,11 @@ test('should delete signup group', async () => {
       `/fi/registrations/${registrationId}/signups`
     )
   );
+});
+
+test('signup group extra info field should be visible', async () => {
+  renderComponent();
+
+  await findElement('firstNameInput');
+  expect(getElement('signupGroupExtraInfoField')).toBeInTheDocument();
 });

--- a/src/domain/signupGroup/signupGroupForm/SignupGroupForm.tsx
+++ b/src/domain/signupGroup/signupGroupForm/SignupGroupForm.tsx
@@ -357,6 +357,7 @@ const SignupGroupForm: React.FC<SignupGroupFormProps> = ({
               <SignupGroupFormFields
                 disabled={disabled}
                 registration={registration}
+                signup={signup}
                 signupGroup={signupGroup}
               />
             </FormContainer>

--- a/src/domain/signupGroup/signupGroupFormFields/SignupGroupFormFields.tsx
+++ b/src/domain/signupGroup/signupGroupFormFields/SignupGroupFormFields.tsx
@@ -13,6 +13,7 @@ import TextInputField from '../../../common/components/formFields/textInputField
 import FormGroup from '../../../common/components/formGroup/FormGroup';
 import {
   RegistrationFieldsFragment,
+  SignupFieldsFragment,
   SignupGroupFieldsFragment,
 } from '../../../generated/graphql';
 import useLanguageOptions from '../../language/hooks/useLanguageOptions';
@@ -26,12 +27,14 @@ import Signups from './signups/Signups';
 interface Props {
   disabled?: boolean;
   registration: RegistrationFieldsFragment;
+  signup?: SignupFieldsFragment;
   signupGroup?: SignupGroupFieldsFragment;
 }
 
 const SignupGroupFormFields: React.FC<Props> = ({
   disabled,
   registration,
+  signup,
   signupGroup,
 }) => {
   const { t } = useTranslation();
@@ -137,19 +140,22 @@ const SignupGroupFormFields: React.FC<Props> = ({
             />
           </div>
         </FormGroup>
-        <FormGroup>
-          <Field
-            name={SIGNUP_GROUP_FIELDS.EXTRA_INFO}
-            component={TextAreaField}
-            disabled={disabled}
-            label={t(`signup.form.labelExtraInfo`)}
-            placeholder={t(`signup.form.placeholderExtraInfo`)}
-            required={isSignupFieldRequired(
-              registration,
-              SIGNUP_GROUP_FIELDS.EXTRA_INFO
-            )}
-          />
-        </FormGroup>
+        {/* Don't show signup group extra info field when editing a single signup */}
+        {!signup && (
+          <FormGroup>
+            <Field
+              name={SIGNUP_GROUP_FIELDS.EXTRA_INFO}
+              component={TextAreaField}
+              disabled={disabled}
+              label={t(`signup.form.labelExtraInfo`)}
+              placeholder={t(`signup.form.placeholderExtraInfo`)}
+              required={isSignupFieldRequired(
+                registration,
+                SIGNUP_GROUP_FIELDS.EXTRA_INFO
+              )}
+            />
+          </FormGroup>
+        )}
       </Fieldset>
     </div>
   );


### PR DESCRIPTION
## Description
Hide signup group extra info field when editing a signup

## Closes
[LINK-1613](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1613)

[LINK-1613]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1613?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ