### PR TITLE
LINK-1619 | Update participant amount input value after deleting a signup

### DIFF
--- a/src/domain/signup/EditSignupPage.tsx
+++ b/src/domain/signup/EditSignupPage.tsx
@@ -116,7 +116,7 @@ const EditSignupPageWrapper: React.FC = () => {
   return (
     <LoadingSpinner isLoading={loading}>
       {event && registration && signup ? (
-        <SignupGroupFormProvider>
+        <SignupGroupFormProvider registration={registration}>
           <SignupServerErrorsProvider>
             <EditSignupPage
               event={event}

--- a/src/domain/signup/editSignupButtonPanel/__tests__/EditSignupButtonPanel.test.tsx
+++ b/src/domain/signup/editSignupButtonPanel/__tests__/EditSignupButtonPanel.test.tsx
@@ -54,7 +54,7 @@ const renderComponent = ({
   route?: string;
 } = {}) =>
   render(
-    <SignupGroupFormProvider>
+    <SignupGroupFormProvider registration={registration}>
       <EditSignupButtonPanel {...defaultProps} {...props} />
     </SignupGroupFormProvider>,
     {

--- a/src/domain/signupGroup/CreateSignupGroupPage.tsx
+++ b/src/domain/signupGroup/CreateSignupGroupPage.tsx
@@ -88,7 +88,7 @@ const CreateSignupGroupPageWrapper: React.FC = () => {
   return (
     <LoadingSpinner isLoading={loading}>
       {event && registration ? (
-        <SignupGroupFormProvider>
+        <SignupGroupFormProvider registration={registration}>
           <SignupServerErrorsProvider>
             <CreateSignupGroupPage event={event} registration={registration} />
           </SignupServerErrorsProvider>

--- a/src/domain/signupGroup/EditSignupGroupPage.tsx
+++ b/src/domain/signupGroup/EditSignupGroupPage.tsx
@@ -118,7 +118,7 @@ const EditSignupGroupPageWrapper: React.FC = () => {
   return (
     <LoadingSpinner isLoading={loading}>
       {event && registration && signupGroup ? (
-        <SignupGroupFormProvider>
+        <SignupGroupFormProvider registration={registration}>
           <SignupServerErrorsProvider>
             <EditSignupGroupPage
               event={event}

--- a/src/domain/signupGroup/__tests__/CreateSignupGroupPage.test.tsx
+++ b/src/domain/signupGroup/__tests__/CreateSignupGroupPage.test.tsx
@@ -480,7 +480,7 @@ test('should delete participants by clicking delete participant button', async (
       screen.queryByRole('button', { name: 'Osallistuja 2' })
     ).not.toBeInTheDocument()
   );
-  await actWait(100);
+  expect(participantAmountInput).toHaveValue(1);
 });
 
 test('should show server errors when updating seats reservation fails', async () => {

--- a/src/domain/signupGroup/participantAmountSelector/ParticipantAmountSelector.tsx
+++ b/src/domain/signupGroup/participantAmountSelector/ParticipantAmountSelector.tsx
@@ -6,10 +6,8 @@ import { useTranslation } from 'react-i18next';
 import Button from '../../../common/components/button/Button';
 import NumberInput from '../../../common/components/numberInput/NumberInput';
 import { RegistrationFieldsFragment } from '../../../generated/graphql';
-import getValue from '../../../utils/getValue';
 import { getMaxSeatsAmount } from '../../registration/utils';
 import useSeatsReservationActions from '../../seatsReservation/hooks/useSeatsReservationActions';
-import { getSeatsReservationData } from '../../seatsReservation/utils';
 import { SIGNUP_MODALS } from '../../signup/constants';
 import { useSignupServerErrorsContext } from '../../signup/signupServerErrorsContext/hooks/useSignupServerErrorsContext';
 import { SIGNUP_GROUP_FIELDS } from '../constants';
@@ -35,6 +33,8 @@ const ParticipantAmountSelector: React.FC<Props> = ({
     SignupFormFields[]
   >({ name: SIGNUP_GROUP_FIELDS.SIGNUPS });
 
+  const { participantAmount, setParticipantAmount } =
+    useSignupGroupFormContext();
   const { saving, updateSeatsReservation } = useSeatsReservationActions({
     registration,
     setSignups,
@@ -45,18 +45,6 @@ const ParticipantAmountSelector: React.FC<Props> = ({
     useSignupServerErrorsContext();
 
   const [participantsToDelete, setParticipantsToDelete] = useState(0);
-
-  const registrationId = getValue(registration.id, '');
-
-  const [participantAmount, setParticipantAmount] = useState(
-    disabled
-      ? 1
-      : Math.max(
-          getSeatsReservationData(registrationId)?.seats ??
-            /* istanbul ignore next */ 0,
-          1
-        )
-  );
 
   const handleParticipantAmountChange: React.ChangeEventHandler<
     HTMLInputElement

--- a/src/domain/signupGroup/participantAmountSelector/__tests__/ParticipantAmountSelector.test.tsx
+++ b/src/domain/signupGroup/participantAmountSelector/__tests__/ParticipantAmountSelector.test.tsx
@@ -29,7 +29,7 @@ import ParticipantAmountSelector from '../ParticipantAmountSelector';
 
 const renderComponent = (mocks: MockedResponse[] = []) =>
   render(
-    <SignupGroupFormProvider>
+    <SignupGroupFormProvider registration={registration}>
       <SignupServerErrorsProvider>
         <Formik
           initialValues={{ signups: [{ ...SIGNUP_INITIAL_VALUES }] }}

--- a/src/domain/signupGroup/reservationTimer/__tests__/ReservationTimer.test.tsx
+++ b/src/domain/signupGroup/reservationTimer/__tests__/ReservationTimer.test.tsx
@@ -52,7 +52,7 @@ const renderComponent = (
   mocks: MockedResponse[] = []
 ) =>
   render(
-    <SignupGroupFormProvider>
+    <SignupGroupFormProvider registration={registration}>
       <SignupServerErrorsContext.Provider
         value={{ ...defaultServerErrorsProps, ...serverErrorProps }}
       >

--- a/src/domain/signupGroup/signupGroupFormContext/SignupGroupFormContext.tsx
+++ b/src/domain/signupGroup/signupGroupFormContext/SignupGroupFormContext.tsx
@@ -6,7 +6,9 @@ import React, {
   useState,
 } from 'react';
 
+import { RegistrationFieldsFragment } from '../../../generated/graphql';
 import useMountedState from '../../../hooks/useMountedState';
+import { getSeatsReservationData } from '../../seatsReservation/utils';
 import { SIGNUP_MODALS } from '../../signup/constants';
 // eslint-disable-next-line max-len
 import PersonsAddedToWaitingListModal from '../modals/personsAddedToWaitingListModal/PersonsAddedToWaitingListModal';
@@ -16,9 +18,11 @@ export type SignupGroupFormContextProps = {
   openModal: SIGNUP_MODALS | null;
   openModalId: string | null;
   openParticipant: number | null;
+  participantAmount: number;
   setOpenModal: (state: SIGNUP_MODALS | null) => void;
   setOpenModalId: (state: string | null) => void;
   setOpenParticipant: (index: number | null) => void;
+  setParticipantAmount: (amount: number) => void;
   toggleOpenParticipant: (index: number) => void;
 };
 
@@ -26,11 +30,17 @@ export const SignupGroupFormContext = createContext<
   SignupGroupFormContextProps | undefined
 >(undefined);
 
-export const SignupGroupFormProvider: FC<PropsWithChildren> = ({
-  children,
-}) => {
-  const [openParticipant, setOpenParticipant] = useState<number | null>(0);
+type SignupGroupFormProviderProps = {
+  registration: RegistrationFieldsFragment;
+};
 
+export const SignupGroupFormProvider: FC<
+  PropsWithChildren<SignupGroupFormProviderProps>
+> = ({ children, registration }) => {
+  const [openParticipant, setOpenParticipant] = useState<number | null>(0);
+  const [participantAmount, setParticipantAmount] = useState(
+    Math.max(getSeatsReservationData(registration.id as string)?.seats ?? 0, 1)
+  );
   const [openModal, setOpenModal] = useMountedState<SIGNUP_MODALS | null>(null);
   const [openModalId, setOpenModalId] = useMountedState<string | null>(null);
 
@@ -43,14 +53,23 @@ export const SignupGroupFormProvider: FC<PropsWithChildren> = ({
       openModal,
       openModalId,
       openParticipant,
+      participantAmount,
       setOpenModal,
       setOpenModalId,
       setOpenParticipant,
+      setParticipantAmount,
       toggleOpenParticipant: (newIndex: number) => {
         setOpenParticipant(openParticipant === newIndex ? null : newIndex);
       },
     }),
-    [openModal, openModalId, openParticipant, setOpenModal, setOpenModalId]
+    [
+      openModal,
+      openModalId,
+      openParticipant,
+      participantAmount,
+      setOpenModal,
+      setOpenModalId,
+    ]
   );
 
   return (

--- a/src/domain/signupGroup/signupGroupFormFields/signups/Signups.tsx
+++ b/src/domain/signupGroup/signupGroupFormFields/signups/Signups.tsx
@@ -20,6 +20,7 @@ import { useSignupServerErrorsContext } from '../../../signup/signupServerErrors
 import useUser from '../../../user/hooks/useUser';
 import { SIGNUP_GROUP_FIELDS } from '../../constants';
 import ConfirmDeleteSignupFromFormModal from '../../modals/confirmDeleteSignupFromFormModal/ConfirmDeleteSignupFromFormModal';
+import { useSignupGroupFormContext } from '../../signupGroupFormContext/hooks/useSignupGroupFormContext';
 import { SignupFormFields } from '../../types';
 import { getNewSignups } from '../../utils';
 import Signup from './signup/Signup';
@@ -41,6 +42,7 @@ const Signups: React.FC<Props> = ({ disabled, registration, signupGroup }) => {
   const location = useLocation();
   const { user } = useUser();
 
+  const { setParticipantAmount } = useSignupGroupFormContext();
   const { setServerErrorItems, showServerErrors } =
     useSignupServerErrorsContext();
 
@@ -83,7 +85,7 @@ const Signups: React.FC<Props> = ({ disabled, registration, signupGroup }) => {
       });
 
       setSignups(newSignups);
-
+      setParticipantAmount(newSignups.length);
       setSeatsReservationData(registrationId, seatsReservation);
 
       setSaving(false);

--- a/src/domain/signups/SignupsPage.tsx
+++ b/src/domain/signups/SignupsPage.tsx
@@ -220,7 +220,7 @@ const SignupsPageWrapper: React.FC = () => {
   return (
     <LoadingSpinner isLoading={loading}>
       {registration ? (
-        <SignupGroupFormProvider>
+        <SignupGroupFormProvider registration={registration}>
           <SignupsPage registration={registration} />
         </SignupGroupFormProvider>
       ) : (

--- a/src/domain/signups/signupActionsDropdown/__tests__/SignupActionsDropdown.test.tsx
+++ b/src/domain/signups/signupActionsDropdown/__tests__/SignupActionsDropdown.test.tsx
@@ -64,7 +64,7 @@ const renderComponent = ({
   props?: Partial<SignupActionsDropdownProps>;
 } = {}) =>
   render(
-    <SignupGroupFormProvider>
+    <SignupGroupFormProvider registration={registration}>
       <SignupActionsDropdown {...defaultProps} {...props} />
     </SignupGroupFormProvider>,
     {

--- a/src/domain/signups/signupsTable/__tests__/SignupsTable.test.tsx
+++ b/src/domain/signups/signupsTable/__tests__/SignupsTable.test.tsx
@@ -54,7 +54,7 @@ const signupName = [attendeeNames[0].firstName, attendeeNames[0].lastName].join(
 const authContextValue = fakeAuthenticatedAuthContextValue();
 const renderComponent = (mocks: MockedResponse[] = defaultMocks) => {
   return render(
-    <SignupGroupFormProvider>
+    <SignupGroupFormProvider registration={registration}>
       <SignupsTable {...defaultProps} />
     </SignupGroupFormProvider>,
     { mocks, authContextValue }


### PR DESCRIPTION
## Description
Move participant amount value to SignupGroupFormContext and update it after deleting a signup from the form

## Closes
[LINK-1619](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1619)

## Testing
1. Open create signup group page
2. Input at least 2 to the participant amount input and press update button
3. Delete one of the signups

Expected result:
Participant amount input value should be updated to match number of signups in the form

[LINK-1619]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1619?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ