### PR TITLE
LINK-1622  | Don't send sensitive data to Sentry

### DIFF
--- a/src/domain/app/sentry/utils.ts
+++ b/src/domain/app/sentry/utils.ts
@@ -22,7 +22,7 @@ const reportError = ({
         currentUrl: window.location.href,
         location,
         timestamp: new Date(),
-        user,
+        user: user?.username,
         userAgent: navigator.userAgent,
         errorAsString: JSON.stringify(error),
       },

--- a/src/domain/event/__tests__/utils.test.ts
+++ b/src/domain/event/__tests__/utils.test.ts
@@ -10,6 +10,7 @@ import {
   WEEK_DAY,
 } from '../../../constants';
 import {
+  CreateEventMutationInput,
   EventQueryVariables,
   EventStatus,
   EventTypeId,
@@ -58,6 +59,7 @@ import {
   getIsButtonVisible,
   getNewEventTimes,
   getRecurringEventPayload,
+  omitSensitiveDataFromEventPayload,
   sortLanguage,
   sortWeekDays,
 } from '../utils';
@@ -1877,5 +1879,17 @@ describe('copyEventInfoToRegistrationSessionStorage function', () => {
         `"audienceMaxAge":18,"audienceMinAge":12,"confirmationMessage":{"fi":"","sv":"","en":"","ru":"","zhHans":"","ar":""},"enrolmentEndTimeDate":"2021-06-15T12:00:00.000Z","enrolmentEndTimeTime":"12:00","enrolmentStartTimeDate":"2021-06-13T12:00:00.000Z","enrolmentStartTimeTime":"12:00","event":"${event.atId}","infoLanguages":["fi"],"instructions":{"fi":"","sv":"","en":"","ru":"","zhHans":"","ar":""},"mandatoryFields":["first_name","last_name"],"maximumAttendeeCapacity":10,"maximumGroupSize":"","minimumAttendeeCapacity":5,"registrationUserAccesses":[],"waitingListCapacity":""`
       )
     );
+  });
+});
+
+describe('omitSensitiveDataFromEventPayload function', () => {
+  it('should omit sensitive data from payload', () => {
+    const filteredPayload = omitSensitiveDataFromEventPayload(
+      defaultEventExternalUserPayload
+    ) as CreateEventMutationInput;
+
+    expect(filteredPayload.userEmail).toBeUndefined();
+    expect(filteredPayload.userName).toBeUndefined();
+    expect(filteredPayload.userPhoneNumber).toBeUndefined();
   });
 });

--- a/src/domain/event/hooks/__tests__/useUpdateRecurringEventIfNeeded.test.tsx
+++ b/src/domain/event/hooks/__tests__/useUpdateRecurringEventIfNeeded.test.tsx
@@ -17,6 +17,7 @@ import {
 import generateAtId from '../../../../utils/generateAtId';
 import { fakeAuthenticatedAuthContextValue } from '../../../../utils/mockAuthContextValue';
 import { fakeEvent, fakeOrganizations } from '../../../../utils/mockDataUtils';
+import { createCache } from '../../../app/apollo/apolloClient';
 import { AuthContext } from '../../../auth/AuthContext';
 import { mockedOrganizationAncestorsResponse } from '../../../organization/__mocks__/organizationAncestors';
 import {
@@ -89,7 +90,7 @@ const getHookWrapper = (mocks: MockedResponse[] = commonMocks) => {
   const wrapper = ({ children }: PropsWithChildren) => (
     <AuthContext.Provider value={authContextValue}>
       <Router history={createMemoryHistory() as any}>
-        <MockedProvider mocks={mocks} addTypename={false}>
+        <MockedProvider cache={createCache()} mocks={mocks}>
           {children}
         </MockedProvider>
       </Router>
@@ -375,7 +376,6 @@ test('should return new super event if recurring event is updated', async () => 
     mockedUpdateEventResponse,
   ]);
   const event = fakeEvent({ superEvent });
-
   await waitFor(() => expect(result.current.user).toBeDefined());
   await act(async () => {
     const response = await result.current.updateRecurringEventIfNeeded(event);

--- a/src/domain/event/hooks/useEventActions.ts
+++ b/src/domain/event/hooks/useEventActions.ts
@@ -44,6 +44,7 @@ import {
   getNewEventTimes,
   getRecurringEventPayload,
   getRelatedEvents,
+  omitSensitiveDataFromEventPayload,
 } from '../utils';
 import useUpdateImageIfNeeded from './useUpdateImageIfNeeded';
 import useUpdateRecurringEventIfNeeded from './useUpdateRecurringEventIfNeeded';
@@ -193,7 +194,7 @@ const useEventActions = (
       handleError({
         callbacks,
         error,
-        payload,
+        payload: payload.map((data) => omitSensitiveDataFromEventPayload(data)),
         message: 'Failed to cancel event',
         savingFinished,
       });
@@ -246,7 +247,7 @@ const useEventActions = (
       handleError({
         callbacks,
         error,
-        payload: recurringEventPayload,
+        payload: omitSensitiveDataFromEventPayload(recurringEventPayload),
         message: 'Failed to create recurring event',
         savingFinished,
       });
@@ -267,7 +268,7 @@ const useEventActions = (
       handleError({
         callbacks,
         error,
-        payload,
+        payload: omitSensitiveDataFromEventPayload(payload),
         message: 'Failed to create event',
         savingFinished,
       });
@@ -381,7 +382,7 @@ const useEventActions = (
         callbacks,
         error,
         message: 'Failed to postpone event',
-        payload,
+        payload: payload.map((data) => omitSensitiveDataFromEventPayload(data)),
         savingFinished,
       });
     }
@@ -506,7 +507,7 @@ const useEventActions = (
         callbacks,
         error,
         message: 'Failed to update recurring event',
-        payload,
+        payload: payload.map((data) => omitSensitiveDataFromEventPayload(data)),
         savingFinished,
       });
     }
@@ -579,7 +580,7 @@ const useEventActions = (
         callbacks,
         error,
         message: 'Failed to update event',
-        payload,
+        payload: payload.map((data) => omitSensitiveDataFromEventPayload(data)),
         savingFinished,
       });
     }

--- a/src/domain/event/hooks/useEventActions.ts
+++ b/src/domain/event/hooks/useEventActions.ts
@@ -7,7 +7,6 @@ import {
 } from '@apollo/client';
 import map from 'lodash/map';
 import { useTranslation } from 'react-i18next';
-import { useLocation } from 'react-router';
 
 import {
   CreateEventMutationInput,
@@ -23,13 +22,13 @@ import {
   UserFieldsFragment,
   useUpdateEventsMutation,
 } from '../../../generated/graphql';
+import useHandleError from '../../../hooks/useHandleError';
 import useLocale from '../../../hooks/useLocale';
 import useMountedState from '../../../hooks/useMountedState';
 import { MutationCallbacks } from '../../../types';
 import getValue from '../../../utils/getValue';
 import isTestEnv from '../../../utils/isTestEnv';
 import { clearEventsQueries } from '../../app/apollo/clearCacheUtils';
-import { reportError } from '../../app/sentry/utils';
 import { useAuth } from '../../auth/hooks/useAuth';
 import { getOrganizationAncestorsQueryResult } from '../../organization/utils';
 import useUser from '../../user/hooks/useUser';
@@ -79,7 +78,6 @@ const useEventActions = (
   const { isAuthenticated: authenticated } = useAuth();
   const { user } = useUser();
   const locale = useLocale();
-  const location = useLocation();
   const [openModal, setOpenModal] = useMountedState<EVENT_MODALS | null>(null);
   const [saving, setSaving] = useMountedState<EVENT_ACTIONS | null>(null);
 
@@ -146,41 +144,13 @@ const useEventActions = (
     await (callbacks?.onSuccess && callbacks.onSuccess(id));
   };
 
-  const handleError = ({
-    callbacks,
-    data,
-    error,
-    message,
-    payload,
-  }: {
-    callbacks?: MutationCallbacks;
-    data?: Record<string, unknown>;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    error: any;
-    message: string;
-    payload?:
-      | CreateEventMutationInput
-      | CreateEventMutationInput[]
-      | UpdateEventMutationInput[];
-  }) => {
-    savingFinished();
-
-    // Report error to Sentry
-    reportError({
-      data: {
-        ...data,
-        error,
-        event,
-        payloadAsString: payload && JSON.stringify(payload),
-      },
-      location,
-      message,
-      user,
-    });
-
-    // Call callback function if defined
-    callbacks?.onError?.(error);
-  };
+  const { handleError } = useHandleError<
+    | CreateEventMutationInput
+    | CreateEventMutationInput[]
+    | UpdateEventMutationInput[]
+    | Record<string, unknown>,
+    null
+  >();
 
   const cancelEvent = async (callbacks?: MutationCallbacks) => {
     let payload: UpdateEventMutationInput[] = [];
@@ -225,6 +195,7 @@ const useEventActions = (
         error,
         payload,
         message: 'Failed to cancel event',
+        savingFinished,
       });
     }
   };
@@ -247,6 +218,7 @@ const useEventActions = (
         error,
         payload,
         message: 'Failed to create sub-events in recurring event creation',
+        savingFinished,
       });
 
       // Don't save recurring event if sub-event creation fails
@@ -276,6 +248,7 @@ const useEventActions = (
         error,
         payload: recurringEventPayload,
         message: 'Failed to create recurring event',
+        savingFinished,
       });
     }
   };
@@ -296,6 +269,7 @@ const useEventActions = (
         error,
         payload,
         message: 'Failed to create event',
+        savingFinished,
       });
     }
   };
@@ -310,9 +284,10 @@ const useEventActions = (
       await updateImageIfNeeded(values);
     } catch (error) /* istanbul ignore next */ {
       handleError({
-        data: { images: values.images, imageDetails: values.imageDetails },
         error,
         message: 'Failed to update image',
+        payload: { images: values.images, imageDetails: values.imageDetails },
+        savingFinished,
       });
     }
 
@@ -355,11 +330,11 @@ const useEventActions = (
     } catch (error) /* istanbul ignore next */ {
       handleError({
         callbacks,
-        data: {
-          eventIds: deletableEventIds,
-        },
+
         error,
         message: 'Failed to delete event',
+        payload: { eventIds: deletableEventIds },
+        savingFinished,
       });
     }
   };
@@ -407,6 +382,7 @@ const useEventActions = (
         error,
         message: 'Failed to postpone event',
         payload,
+        savingFinished,
       });
     }
   };
@@ -531,6 +507,7 @@ const useEventActions = (
         error,
         message: 'Failed to update recurring event',
         payload,
+        savingFinished,
       });
     }
   };
@@ -546,15 +523,14 @@ const useEventActions = (
       await updateImageIfNeeded(values);
     } catch (error: any) /* istanbul ignore next */ {
       // Report error to Sentry
-      reportError({
-        data: {
-          error,
-          images: values.images,
-          imageDetails: values.imageDetails,
-        },
-        location,
-        message: 'Failed to update image',
-        user,
+      handleError({
+        callbacks,
+        error,
+        message: 'Failed to update event',
+        payload,
+        savingFinished:
+          /* istanbul ignore next */
+          () => undefined,
       });
     }
 
@@ -604,6 +580,7 @@ const useEventActions = (
         error,
         message: 'Failed to update event',
         payload,
+        savingFinished,
       });
     }
   };

--- a/src/domain/event/utils.ts
+++ b/src/domain/event/utils.ts
@@ -15,6 +15,7 @@ import { FormikState } from 'formik';
 import { TFunction } from 'i18next';
 import capitalize from 'lodash/capitalize';
 import isNumber from 'lodash/isNumber';
+import omit from 'lodash/omit';
 import sortBy from 'lodash/sortBy';
 import { MouseEvent } from 'react';
 import { scroller } from 'react-scroll';
@@ -44,6 +45,7 @@ import {
   OrganizationFieldsFragment,
   PublicationStatus,
   SuperEventType,
+  UpdateEventMutationInput,
   UserFieldsFragment,
 } from '../../generated/graphql';
 import {
@@ -1460,3 +1462,8 @@ export const isRecurringEvent = (
   eventTimes: EventTime[],
   recurringEvents: RecurringEventSettings[]
 ): boolean => getNewEventTimes(eventTimes, recurringEvents).length > 1;
+
+export const omitSensitiveDataFromEventPayload = (
+  payload: CreateEventMutationInput | UpdateEventMutationInput
+): Partial<CreateEventMutationInput | UpdateEventMutationInput> =>
+  omit(payload, ['userEmail', 'userName', 'userPhoneNumber']);

--- a/src/domain/feedback/__tests__/utils.test.ts
+++ b/src/domain/feedback/__tests__/utils.test.ts
@@ -1,0 +1,23 @@
+import { FeedbackInput } from '../../../generated/graphql';
+import { omitSensitiveDataFromFeedbackPayload } from '../utils';
+
+describe('omitSensitiveDataFromFeedbackPayload', () => {
+  it('should omit sensitive data from payload', () => {
+    const payload: FeedbackInput = {
+      body: 'Body',
+      email: 'test@email.com',
+      name: 'Name',
+      subject: 'Subject',
+    };
+
+    const filteredPayload = omitSensitiveDataFromFeedbackPayload(
+      payload
+    ) as FeedbackInput;
+    expect(filteredPayload).toEqual({
+      body: 'Body',
+      subject: 'Subject',
+    });
+    expect(filteredPayload.email).toBeUndefined();
+    expect(filteredPayload.name).toBeUndefined();
+  });
+});

--- a/src/domain/feedback/hooks/useFeedbackActions.ts
+++ b/src/domain/feedback/hooks/useFeedbackActions.ts
@@ -9,6 +9,7 @@ import {
 import useHandleError from '../../../hooks/useHandleError';
 import { MutationCallbacks } from '../../../types';
 import { useAuth } from '../../auth/hooks/useAuth';
+import { omitSensitiveDataFromFeedbackPayload } from '../utils';
 
 type UseFeedbackActionsProps = { successId: string };
 
@@ -64,7 +65,7 @@ const useFeedbackActions = ({
         callbacks,
         error,
         message: 'Failed to send feedback',
-        payload,
+        payload: omitSensitiveDataFromFeedbackPayload(payload),
         savingFinished:
           /* istanbul ignore next */
           () => undefined,

--- a/src/domain/feedback/utils.ts
+++ b/src/domain/feedback/utils.ts
@@ -1,0 +1,7 @@
+import omit from 'lodash/omit';
+
+import { FeedbackInput } from '../../generated/graphql';
+
+export const omitSensitiveDataFromFeedbackPayload = (
+  payload: FeedbackInput
+): Partial<FeedbackInput> => omit(payload, ['email', 'name']);

--- a/src/domain/help/pages/askPermissionPage/AskPermissionPage.tsx
+++ b/src/domain/help/pages/askPermissionPage/AskPermissionPage.tsx
@@ -21,6 +21,7 @@ import {
 import AuthenticationNotification from '../../../app/authenticationNotification/AuthenticationNotification';
 import PageWrapper from '../../../app/layout/pageWrapper/PageWrapper';
 import { useAuth } from '../../../auth/hooks/useAuth';
+import useFeedbackActions from '../../../feedback/hooks/useFeedbackActions';
 import useFeedbackServerErrors from '../../../feedback/hooks/useFeedbackServerErrors';
 import useAllOrganizations from '../../../organization/hooks/useAllOrganizations';
 import { getOrganizationFields } from '../../../organization/utils';
@@ -28,7 +29,6 @@ import {
   ASK_PERMISSION_FORM_FIELD,
   CONTACT_FORM_BODY_MAX_LENGTH,
 } from '../../constants';
-import useFeedbackActions from '../../hooks/useFeedbackActions';
 import { AskPermissionFormFields } from '../../types';
 import {
   getAskPermissionFormFocusableFieldId,

--- a/src/domain/help/pages/contactPage/ContactPage.tsx
+++ b/src/domain/help/pages/contactPage/ContactPage.tsx
@@ -19,6 +19,7 @@ import {
 } from '../../../../utils/validationUtils';
 import PageWrapper from '../../../app/layout/pageWrapper/PageWrapper';
 import { useAuth } from '../../../auth/hooks/useAuth';
+import useFeedbackActions from '../../../feedback/hooks/useFeedbackActions';
 import useFeedbackServerErrors from '../../../feedback/hooks/useFeedbackServerErrors';
 import {
   CONTACT_FORM_BODY_MAX_LENGTH,
@@ -31,7 +32,6 @@ import EventFormNotWorkingFaq from '../../faq/eventFormNotWorkingFaq/EventFormNo
 import EventNotShownFaq from '../../faq/eventNotShownFaq/EventNotShownFaq';
 import ImageRightsFaq from '../../faq/imageRightsFaq/ImageRightsFaq';
 import PublishingPermissionsFaq from '../../faq/publishingPermissionsFaq/PublishingPermissionsFaq';
-import useFeedbackActions from '../../hooks/useFeedbackActions';
 import { ContactFormFields } from '../../types';
 import {
   getContactFormFocusableFieldId,

--- a/src/domain/organization/EditOrganizationPage.tsx
+++ b/src/domain/organization/EditOrganizationPage.tsx
@@ -22,7 +22,7 @@ import useUser from '../user/hooks/useUser';
 import { ORGANIZATION_ACTIONS } from './constants';
 import useOrganizationUpdateActions, {
   ORGANIZATION_MODALS,
-} from './hooks/useOrganizationUpdateActions';
+} from './hooks/useOrganizationActions';
 import ConfirmDeleteOrganizationModal from './modals/confirmDeleteOrganizationModal/ConfirmDeleteOrganizationModal';
 import OrganizationForm from './organizationForm/OrganizationForm';
 import {

--- a/src/domain/organization/__tests__/utils.test.ts
+++ b/src/domain/organization/__tests__/utils.test.ts
@@ -3,6 +3,7 @@ import { NetworkStatus } from '@apollo/client';
 import i18n from 'i18next';
 
 import { LINKED_EVENTS_SYSTEM_DATA_SOURCE } from '../../../envVariables';
+import { CreateOrganizationMutationInput } from '../../../generated/graphql';
 import {
   fakeOrganization,
   fakeOrganizations,
@@ -10,6 +11,7 @@ import {
   fakeUsers,
 } from '../../../utils/mockDataUtils';
 import { createApolloClient } from '../../app/apollo/apolloClient';
+import { TEST_DATA_SOURCE_ID } from '../../dataSource/constants';
 import {
   ORGANIZATION_ACTIONS,
   ORGANIZATION_INITIAL_VALUES,
@@ -24,6 +26,7 @@ import {
   getOrganizationFullName,
   getOrganizationInitialValues,
   getOrganizationPayload,
+  omitSensitiveDataFromOrganizationPayload,
   organizationPathBuilder,
   organizationsPathBuilder,
 } from '../utils';
@@ -357,5 +360,48 @@ describe('getOrganizationPayload function', () => {
       replacedBy: 'organization:replaced',
       subOrganizations: ['organization:sub'],
     });
+  });
+});
+
+describe('omitSensitiveDataFromOrganizationPayload', () => {
+  it('should omit sensitive data from payload', () => {
+    const payload: CreateOrganizationMutationInput = {
+      adminUsers: ['admin'],
+      affiliatedOrganizations: ['affiliatedOrganization'],
+      classification: 'classification',
+      dataSource: TEST_DATA_SOURCE_ID,
+      dissolutionDate: '2021-10-10',
+      foundingDate: '2011-10-10',
+      id: TEST_PUBLISHER_ID,
+      internalType: 'internalType',
+      name: 'name',
+      originId: `${TEST_DATA_SOURCE_ID}:${TEST_PUBLISHER_ID}`,
+      parentOrganization: 'parent',
+      registrationAdminUsers: ['registrationAdmin'],
+      regularUsers: ['regularUser'],
+      replacedBy: 'replacedBy',
+      subOrganizations: ['subOrganization'],
+    };
+
+    const filteredPayload = omitSensitiveDataFromOrganizationPayload(
+      payload
+    ) as CreateOrganizationMutationInput;
+    expect(filteredPayload).toEqual({
+      affiliatedOrganizations: ['affiliatedOrganization'],
+      classification: 'classification',
+      dataSource: TEST_DATA_SOURCE_ID,
+      dissolutionDate: '2021-10-10',
+      foundingDate: '2011-10-10',
+      id: TEST_PUBLISHER_ID,
+      internalType: 'internalType',
+      name: 'name',
+      originId: `${TEST_DATA_SOURCE_ID}:${TEST_PUBLISHER_ID}`,
+      parentOrganization: 'parent',
+      replacedBy: 'replacedBy',
+      subOrganizations: ['subOrganization'],
+    });
+    expect(filteredPayload.adminUsers).toBeUndefined();
+    expect(filteredPayload.registrationAdminUsers).toBeUndefined();
+    expect(filteredPayload.regularUsers).toBeUndefined();
   });
 });

--- a/src/domain/organization/hooks/useOrganizationActions.ts
+++ b/src/domain/organization/hooks/useOrganizationActions.ts
@@ -22,7 +22,10 @@ import {
 } from '../../app/apollo/clearCacheUtils';
 import { ORGANIZATION_ACTIONS } from '../constants';
 import { OrganizationFormFields } from '../types';
-import { getOrganizationPayload } from '../utils';
+import {
+  getOrganizationPayload,
+  omitSensitiveDataFromOrganizationPayload,
+} from '../utils';
 
 export enum ORGANIZATION_MODALS {
   DELETE = 'delete',
@@ -110,7 +113,7 @@ const useOrganizationUpdateActions = ({
         callbacks,
         error,
         message: 'Failed to create organization',
-        payload,
+        payload: omitSensitiveDataFromOrganizationPayload(payload),
         savingFinished,
       });
     }
@@ -154,7 +157,7 @@ const useOrganizationUpdateActions = ({
         callbacks,
         error,
         message: 'Failed to update organization',
-        payload,
+        payload: omitSensitiveDataFromOrganizationPayload(payload),
         savingFinished,
       });
     }

--- a/src/domain/organization/organizationForm/OrganizationForm.tsx
+++ b/src/domain/organization/organizationForm/OrganizationForm.tsx
@@ -1,14 +1,9 @@
 /* eslint-disable max-len */
-import {
-  ApolloClient,
-  NormalizedCacheObject,
-  ServerError,
-  useApolloClient,
-} from '@apollo/client';
+import { ServerError } from '@apollo/client';
 import { Field, Form, Formik } from 'formik';
 import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useLocation, useNavigate } from 'react-router';
+import { useNavigate } from 'react-router';
 import { ValidationError } from 'yup';
 
 import DateInputField from '../../../common/components/formFields/dateInputField/DateInputField';
@@ -19,11 +14,7 @@ import TextInputField from '../../../common/components/formFields/textInputField
 import UserSelectorField from '../../../common/components/formFields/userSelectorField/UserSelectorField';
 import ServerErrorSummary from '../../../common/components/serverErrorSummary/ServerErrorSummary';
 import { ROUTES } from '../../../constants';
-import {
-  CreateOrganizationMutationInput,
-  OrganizationFieldsFragment,
-  useCreateOrganizationMutation,
-} from '../../../generated/graphql';
+import { OrganizationFieldsFragment } from '../../../generated/graphql';
 import useLocale from '../../../hooks/useLocale';
 import getValue from '../../../utils/getValue';
 import {
@@ -32,9 +23,7 @@ import {
 } from '../../../utils/validationUtils';
 import styles from '../../admin/layout/form.module.scss';
 import FormRow from '../../admin/layout/formRow/FormRow';
-import { clearOrganizationsQueries } from '../../app/apollo/clearCacheUtils';
 import { useNotificationsContext } from '../../app/notificationsContext/hooks/useNotificationsContext';
-import { reportError } from '../../app/sentry/utils';
 import useUser from '../../user/hooks/useUser';
 import {
   ORGANIZATION_ACTIONS,
@@ -43,16 +32,12 @@ import {
 } from '../constants';
 import CreateButtonPanel from '../createButtonPanel/CreateButtonPanel';
 import EditButtonPanel from '../editButtonPanel/EditButtonPanel';
+import useOrganizationUpdateActions from '../hooks/useOrganizationActions';
 import useOrganizationInternalTypeOptions from '../hooks/useOrganizationInternalTypeOptions';
 import useOrganizationServerErrors from '../hooks/useOrganizationServerErrors';
-import useOrganizationUpdateActions from '../hooks/useOrganizationUpdateActions';
 import OrganizationAuthenticationNotification from '../organizationAuthenticationNotification/OrganizationAuthenticationNotification';
 import { OrganizationFormFields } from '../types';
-import {
-  checkCanUserDoAction,
-  getOrganizationInitialValues,
-  getOrganizationPayload,
-} from '../utils';
+import { checkCanUserDoAction, getOrganizationInitialValues } from '../utils';
 import { getFocusableFieldId, organizationSchema } from '../validation';
 import SubOrganizationTable from './subOrganizationTable/SubOrganizationTable';
 
@@ -65,12 +50,10 @@ const OrganizationForm: React.FC<OrganizationFormProps> = ({
 }) => {
   const { t } = useTranslation();
   const { addNotification } = useNotificationsContext();
+  const { user } = useUser();
   const navigate = useNavigate();
-  const location = useLocation();
   const locale = useLocale();
   const internalTypeOptions = useOrganizationInternalTypeOptions();
-  const apolloClient = useApolloClient() as ApolloClient<NormalizedCacheObject>;
-  const { user } = useUser();
 
   const action = organization
     ? ORGANIZATION_ACTIONS.UPDATE
@@ -87,7 +70,7 @@ const OrganizationForm: React.FC<OrganizationFormProps> = ({
     navigate(`/${locale}${ROUTES.ORGANIZATIONS}`);
   };
 
-  const { saving, setSaving, updateOrganization } =
+  const { createOrganization, saving, updateOrganization } =
     useOrganizationUpdateActions({
       organization,
     });
@@ -95,8 +78,13 @@ const OrganizationForm: React.FC<OrganizationFormProps> = ({
   const { serverErrorItems, setServerErrorItems, showServerErrors } =
     useOrganizationServerErrors();
 
-  const [createOrganizationMutation] = useCreateOrganizationMutation();
-
+  const onCreate = async (values: OrganizationFormFields) => {
+    await createOrganization(values, {
+      onError: (error: ServerError) => showServerErrors({ error }),
+      onSuccess: goToOrganizationsPage,
+    });
+    // await createOrganization(values, {
+  };
   const onUpdate = async (values: OrganizationFormFields) => {
     await updateOrganization(values, {
       onError: (error: ServerError) => showServerErrors({ error }),
@@ -108,46 +96,6 @@ const OrganizationForm: React.FC<OrganizationFormProps> = ({
         });
       },
     });
-  };
-
-  const createSingleOrganization = async (
-    payload: CreateOrganizationMutationInput
-  ) => {
-    try {
-      const data = await createOrganizationMutation({
-        variables: { input: payload },
-      });
-
-      return getValue(data.data?.createOrganization.id, '');
-    } catch (error) /* istanbul ignore next */ {
-      showServerErrors({ error });
-      // // Report error to Sentry
-      reportError({
-        data: {
-          error: error as Record<string, unknown>,
-          payload,
-          payloadAsString: JSON.stringify(payload),
-        },
-        location,
-        message: 'Failed to create keyword',
-        user,
-      });
-    }
-  };
-
-  const createOrganization = async (values: OrganizationFormFields) => {
-    setSaving(ORGANIZATION_ACTIONS.CREATE);
-    const payload = getOrganizationPayload(values);
-    const createdKeywordId = await createSingleOrganization(payload);
-
-    if (createdKeywordId) {
-      // Clear all keywords queries from apollo cache to show added registrations
-      // in registration list
-      clearOrganizationsQueries(apolloClient);
-      goToOrganizationsPage();
-    }
-
-    setSaving(null);
   };
 
   const inputRowBorderStyle = useMemo(
@@ -217,7 +165,7 @@ const OrganizationForm: React.FC<OrganizationFormProps> = ({
             if (organization) {
               await onUpdate(values);
             } else {
-              await createOrganization(values);
+              await onCreate(values);
             }
           } catch (error) {
             showFormErrors({

--- a/src/domain/organization/organizationForm/OrganizationForm.tsx
+++ b/src/domain/organization/organizationForm/OrganizationForm.tsx
@@ -83,7 +83,6 @@ const OrganizationForm: React.FC<OrganizationFormProps> = ({
       onError: (error: ServerError) => showServerErrors({ error }),
       onSuccess: goToOrganizationsPage,
     });
-    // await createOrganization(values, {
   };
   const onUpdate = async (values: OrganizationFormFields) => {
     await updateOrganization(values, {

--- a/src/domain/organization/utils.ts
+++ b/src/domain/organization/utils.ts
@@ -1,5 +1,6 @@
 import { ApolloClient, NormalizedCacheObject } from '@apollo/client';
 import { TFunction } from 'i18next';
+import omit from 'lodash/omit';
 
 import { MenuItemOptionProps } from '../../common/components/menuDropdown/types';
 import { DATE_FORMAT_API, ROUTES } from '../../constants';
@@ -13,6 +14,7 @@ import {
   OrganizationsDocument,
   OrganizationsQuery,
   OrganizationsQueryVariables,
+  UpdateOrganizationMutationInput,
   UserFieldsFragment,
 } from '../../generated/graphql';
 import { Editability, Language, PathBuilderProps } from '../../types';
@@ -408,3 +410,8 @@ export const getOrganizationPayload = (
     regularUsers,
   };
 };
+
+export const omitSensitiveDataFromOrganizationPayload = (
+  payload: CreateOrganizationMutationInput | UpdateOrganizationMutationInput
+): Partial<CreateOrganizationMutationInput | UpdateOrganizationMutationInput> =>
+  omit(payload, ['adminUsers', 'registrationAdminUsers', 'regularUsers']);

--- a/src/domain/organizations/organizationActionsDropdown/OrganizationActionsDropdown.tsx
+++ b/src/domain/organizations/organizationActionsDropdown/OrganizationActionsDropdown.tsx
@@ -14,7 +14,7 @@ import { useAuth } from '../../auth/hooks/useAuth';
 import { ORGANIZATION_ACTIONS } from '../../organization/constants';
 import useOrganizationUpdateActions, {
   ORGANIZATION_MODALS,
-} from '../../organization/hooks/useOrganizationUpdateActions';
+} from '../../organization/hooks/useOrganizationActions';
 import ConfirmDeleteOrganizationModal from '../../organization/modals/confirmDeleteOrganizationModal/ConfirmDeleteOrganizationModal';
 import {
   getEditButtonProps,

--- a/src/domain/place/EditPlacePage.tsx
+++ b/src/domain/place/EditPlacePage.tsx
@@ -18,9 +18,7 @@ import NotFound from '../notFound/NotFound';
 import useOrganizationAncestors from '../organization/hooks/useOrganizationAncestors';
 import useUser from '../user/hooks/useUser';
 import { PLACE_ACTIONS } from './constants';
-import usePlaceUpdateActions, {
-  PLACE_MODALS,
-} from './hooks/usePlaceUpdateActions';
+import usePlaceUpdateActions, { PLACE_MODALS } from './hooks/usePlaceActions';
 import ConfirmDeletePlaceModal from './modals/confirmDeletePlaceModal/ConfirmDeletePlaceModal';
 import PlaceForm from './placeForm/PlaceForm';
 import { getEditButtonProps, getPlaceFields, placePathBuilder } from './utils';

--- a/src/domain/places/placeActionsDropdown/PlaceActionsDropdown.tsx
+++ b/src/domain/places/placeActionsDropdown/PlaceActionsDropdown.tsx
@@ -14,7 +14,7 @@ import useOrganizationAncestors from '../../organization/hooks/useOrganizationAn
 import { PLACE_ACTIONS } from '../../place/constants';
 import usePlaceUpdateActions, {
   PLACE_MODALS,
-} from '../../place/hooks/usePlaceUpdateActions';
+} from '../../place/hooks/usePlaceActions';
 import ConfirmDeletePlaceModal from '../../place/modals/confirmDeletePlaceModal/ConfirmDeletePlaceModal';
 import { getEditButtonProps, getPlaceFields } from '../../place/utils';
 import useUser from '../../user/hooks/useUser';

--- a/src/domain/registration/__tests__/utils.test.ts
+++ b/src/domain/registration/__tests__/utils.test.ts
@@ -5,7 +5,10 @@ import {
   EMPTY_MULTI_LANGUAGE_OBJECT,
   LE_DATA_LANGUAGES,
 } from '../../../constants';
-import { RegistrationQueryVariables } from '../../../generated/graphql';
+import {
+  CreateRegistrationMutationInput,
+  RegistrationQueryVariables,
+} from '../../../generated/graphql';
 import {
   fakeRegistration,
   fakeUser,
@@ -32,6 +35,7 @@ import {
   isAttendeeCapacityUsed,
   isRegistrationOpen,
   isRegistrationPossible,
+  omitSensitiveDataFromRegistrationPayload,
   registrationPathBuilder,
 } from '../utils';
 
@@ -891,4 +895,90 @@ describe('checkCanUserDoRegistrationAction function', () => {
       ).toBe(isAllowed);
     }
   );
+});
+
+describe('omitSensitiveDataFromRegistrationPayload function', () => {
+  it('should omit sensitive data from payload', () => {
+    const audienceMaxAge = 18,
+      audienceMinAge = 12,
+      confirmationMessageFi = 'Confirmation message fi',
+      confirmationMessageEn = 'Confirmation message en',
+      enrolmentEndTime = '2020-01-01T15:15:00.000Z',
+      enrolmentStartTime = '2020-01-01T09:15:00.000Z',
+      event = 'event:1',
+      instructionsFi = 'Instructions fi',
+      instructionsEn = 'Instructions en',
+      mandatoryFields = ['first_name', 'last_name'],
+      maximumAttendeeCapacity = 10,
+      maximumGroupSize = 2,
+      minimumAttendeeCapacity = 5,
+      registrationUserAccesses = [
+        { email: 'user@email.com', id: null, language: null },
+      ],
+      waitingListCapacity = 3;
+
+    const payload = {
+      audienceMaxAge,
+      audienceMinAge,
+      confirmationMessage: {
+        ar: null,
+        en: confirmationMessageEn,
+        fi: confirmationMessageFi,
+        ru: null,
+        sv: null,
+        zhHans: null,
+      },
+      enrolmentEndTime,
+      enrolmentStartTime,
+      event: { atId: event },
+      instructions: {
+        ar: null,
+        en: instructionsEn,
+        fi: instructionsFi,
+        ru: null,
+        sv: null,
+        zhHans: null,
+      },
+      mandatoryFields,
+      maximumAttendeeCapacity,
+      maximumGroupSize,
+      minimumAttendeeCapacity,
+      registrationUserAccesses,
+      waitingListCapacity,
+    };
+
+    const filteredPayload = omitSensitiveDataFromRegistrationPayload(
+      payload
+    ) as CreateRegistrationMutationInput;
+
+    expect(filteredPayload).toEqual({
+      audienceMaxAge,
+      audienceMinAge,
+      confirmationMessage: {
+        ar: null,
+        en: confirmationMessageEn,
+        fi: confirmationMessageFi,
+        ru: null,
+        sv: null,
+        zhHans: null,
+      },
+      enrolmentEndTime,
+      enrolmentStartTime,
+      event: { atId: event },
+      instructions: {
+        ar: null,
+        en: instructionsEn,
+        fi: instructionsFi,
+        ru: null,
+        sv: null,
+        zhHans: null,
+      },
+      mandatoryFields,
+      maximumAttendeeCapacity,
+      maximumGroupSize,
+      minimumAttendeeCapacity,
+      waitingListCapacity,
+    });
+    expect(filteredPayload.registrationUserAccesses).toBeUndefined();
+  });
 });

--- a/src/domain/registration/hooks/useRegistrationActions.ts
+++ b/src/domain/registration/hooks/useRegistrationActions.ts
@@ -21,7 +21,11 @@ import { clearRegistrationsQueries } from '../../app/apollo/clearCacheUtils';
 import { REGISTRATION_ACTIONS } from '../../registrations/constants';
 import { REGISTRATION_MODALS } from '../constants';
 import { RegistrationFormFields } from '../types';
-import { getRegistrationFields, getRegistrationPayload } from '../utils';
+import {
+  getRegistrationFields,
+  getRegistrationPayload,
+  omitSensitiveDataFromRegistrationPayload,
+} from '../utils';
 
 interface UseRegistrationActionsProps {
   registration?: RegistrationFieldsFragment | null;
@@ -79,7 +83,7 @@ const useRegistrationActions = ({
     await (callbacks?.onSuccess && callbacks.onSuccess(id));
   };
   const { handleError } = useHandleError<
-    CreateRegistrationMutationInput | UpdateRegistrationMutationInput,
+    Partial<CreateRegistrationMutationInput | UpdateRegistrationMutationInput>,
     null
   >();
 
@@ -105,7 +109,7 @@ const useRegistrationActions = ({
         callbacks,
         error,
         message: 'Failed to create registration',
-        payload,
+        payload: omitSensitiveDataFromRegistrationPayload(payload),
         savingFinished,
       });
     }
@@ -162,7 +166,7 @@ const useRegistrationActions = ({
         callbacks,
         error,
         message: 'Failed to update registration',
-        payload,
+        payload: omitSensitiveDataFromRegistrationPayload(payload),
         savingFinished,
       });
     }

--- a/src/domain/registration/utils.ts
+++ b/src/domain/registration/utils.ts
@@ -6,6 +6,7 @@ import { FormikState } from 'formik';
 import { TFunction } from 'i18next';
 import isNil from 'lodash/isNil';
 import isNumber from 'lodash/isNumber';
+import omit from 'lodash/omit';
 
 import { MenuItemOptionProps } from '../../common/components/menuDropdown/types';
 import { NotificationProps } from '../../common/components/notification/Notification';
@@ -15,6 +16,7 @@ import {
   OrganizationFieldsFragment,
   RegistrationFieldsFragment,
   RegistrationQueryVariables,
+  UpdateRegistrationMutationInput,
   UserFieldsFragment,
 } from '../../generated/graphql';
 import { Editability, Language, PathBuilderProps } from '../../types';
@@ -570,3 +572,8 @@ export const copySignupLinkToClipboard = ({
     type: 'success',
   });
 };
+
+export const omitSensitiveDataFromRegistrationPayload = (
+  payload: CreateRegistrationMutationInput | UpdateRegistrationMutationInput
+): Partial<CreateRegistrationMutationInput | UpdateRegistrationMutationInput> =>
+  omit(payload, ['registrationUserAccesses']);

--- a/src/domain/registrationUserAccess/hooks/useRegistrationUserAccessActions.ts
+++ b/src/domain/registrationUserAccess/hooks/useRegistrationUserAccessActions.ts
@@ -1,10 +1,7 @@
-import { useLocation } from 'react-router';
-
 import { useSendRegistrationUserAccessInvitationMutation } from '../../../generated/graphql';
+import useHandleError from '../../../hooks/useHandleError';
 import useMountedState from '../../../hooks/useMountedState';
 import { MutationCallbacks } from '../../../types';
-import { reportError } from '../../app/sentry/utils';
-import useUser from '../../user/hooks/useUser';
 import { REGISTRATION_USER_ACCESS_ACTIONS } from '../constants';
 
 interface UseRegistrationUserAccessActionsProps {
@@ -18,8 +15,6 @@ type UseRegistrationUserAccessActionsState = {
 const useRegistrationUserAccessActions = ({
   id,
 }: UseRegistrationUserAccessActionsProps): UseRegistrationUserAccessActionsState => {
-  const { user } = useUser();
-  const location = useLocation();
   const [saving, setSaving] =
     useMountedState<REGISTRATION_USER_ACCESS_ACTIONS | null>(null);
 
@@ -39,29 +34,7 @@ const useRegistrationUserAccessActions = ({
     await (callbacks?.onSuccess && callbacks.onSuccess(id));
   };
 
-  const handleError = ({
-    callbacks,
-    error,
-    message,
-  }: {
-    callbacks?: MutationCallbacks;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    error: any;
-    message: string;
-  }) => {
-    savingFinished();
-
-    // Report error to Sentry
-    reportError({
-      data: { error, id },
-      location,
-      message,
-      user,
-    });
-
-    // Call callback function if defined
-    callbacks?.onError?.(error);
-  };
+  const { handleError } = useHandleError<null, null>();
 
   const sendInvitation = async (callbacks?: MutationCallbacks) => {
     try {
@@ -74,6 +47,7 @@ const useRegistrationUserAccessActions = ({
         callbacks,
         error,
         message: 'Failed to send invitation to registration user access',
+        savingFinished,
       });
     }
   };

--- a/src/domain/signup/__tests__/utils.test.ts
+++ b/src/domain/signup/__tests__/utils.test.ts
@@ -1,3 +1,4 @@
+import { SignupInput } from '../../../generated/graphql';
 import { fakeSignup } from '../../../utils/mockDataUtils';
 import { registration } from '../../registration/__mocks__/registration';
 import {
@@ -9,6 +10,7 @@ import { TEST_SIGNUP_ID } from '../constants';
 import {
   getSignupGroupInitialValuesFromSignup,
   getUpdateSignupPayload,
+  omitSensitiveDataFromSignupPayload,
 } from '../utils';
 
 describe('getUpdateSignupPayload function', () => {
@@ -221,5 +223,48 @@ describe('getSignupGroupInitialValuesFromSignup function', () => {
     expect(notifications).toEqual(expectedNotifications);
     expect(phoneNumber).toBe(expectedPhoneNumber);
     expect(serviceLanguage).toBe(expectedServiceLanguage);
+  });
+});
+
+describe('omitSensitiveDataFromSignupPayload', () => {
+  it('should omit sensitive data from payload', () => {
+    const payload: SignupInput = {
+      city: 'Helsinki',
+      dateOfBirth: '1999-10-10',
+      email: 'test@email.com',
+      extraInfo: 'Signup entra info',
+      firstName: 'First name',
+      id: '1',
+      lastName: 'Last name',
+      membershipNumber: 'XYZ',
+      nativeLanguage: 'fi',
+      notifications: NOTIFICATION_TYPE.EMAIL,
+      phoneNumber: '0441234567',
+      responsibleForGroup: true,
+      serviceLanguage: 'fi',
+      streetAddress: 'Address',
+      zipcode: '123456',
+    };
+
+    const filteredPayload = omitSensitiveDataFromSignupPayload(
+      payload
+    ) as SignupInput;
+    expect(filteredPayload).toEqual({
+      id: '1',
+      notifications: NOTIFICATION_TYPE.EMAIL,
+      responsibleForGroup: true,
+    });
+    expect(filteredPayload.city).toBeUndefined();
+    expect(filteredPayload.extraInfo).toBeUndefined();
+    expect(filteredPayload.email).toBeUndefined();
+    expect(filteredPayload.extraInfo).toBeUndefined();
+    expect(filteredPayload.firstName).toBeUndefined();
+    expect(filteredPayload.lastName).toBeUndefined();
+    expect(filteredPayload.membershipNumber).toBeUndefined();
+    expect(filteredPayload.nativeLanguage).toBeUndefined();
+    expect(filteredPayload.phoneNumber).toBeUndefined();
+    expect(filteredPayload.serviceLanguage).toBeUndefined();
+    expect(filteredPayload.streetAddress).toBeUndefined();
+    expect(filteredPayload.zipcode).toBeUndefined();
   });
 });

--- a/src/domain/signup/hooks/useSignupActions.ts
+++ b/src/domain/signup/hooks/useSignupActions.ts
@@ -5,10 +5,10 @@ import {
 } from '@apollo/client';
 
 import {
-  CreateSignupGroupMutationInput,
   RegistrationFieldsFragment,
   SendMessageMutationInput,
   SignupFieldsFragment,
+  SignupInput,
   UpdateSignupMutationInput,
   useDeleteSignupMutation,
   useSendMessageMutation,
@@ -27,7 +27,10 @@ import { useSignupGroupFormContext } from '../../signupGroup/signupGroupFormCont
 import { SignupGroupFormFields } from '../../signupGroup/types';
 import { SEND_MESSAGE_FORM_NAME, SIGNUP_ACTIONS } from '../constants';
 import { SendMessageFormFields } from '../types';
-import { getUpdateSignupPayload } from '../utils';
+import {
+  getUpdateSignupPayload,
+  omitSensitiveDataFromSignupPayload,
+} from '../utils';
 
 interface Props {
   registration: RegistrationFieldsFragment;
@@ -67,9 +70,7 @@ const useSignupActions = ({
   };
 
   const { handleError } = useHandleError<
-    | CreateSignupGroupMutationInput
-    | SendMessageMutationInput
-    | UpdateSignupMutationInput,
+    SendMessageMutationInput | Partial<SignupInput | UpdateSignupMutationInput>,
     SignupFieldsFragment
   >();
 
@@ -130,7 +131,7 @@ const useSignupActions = ({
         callbacks,
         error,
         message: 'Failed to update signup',
-        payload,
+        payload: omitSensitiveDataFromSignupPayload(payload),
         savingFinished,
       });
     }

--- a/src/domain/signup/utils.ts
+++ b/src/domain/signup/utils.ts
@@ -1,8 +1,11 @@
+import omit from 'lodash/omit';
+
 import { DATE_FORMAT_API } from '../../constants';
 import {
   AttendeeStatus,
   RegistrationFieldsFragment,
   SignupFieldsFragment,
+  SignupInput,
   UpdateSignupMutationInput,
 } from '../../generated/graphql';
 import formatDate from '../../utils/formatDate';
@@ -88,3 +91,21 @@ export const getSignupGroupInitialValuesFromSignup = (
     signups: [getSignupInitialValues(signup)],
   };
 };
+
+export const omitSensitiveDataFromSignupPayload = (
+  payload: SignupInput | UpdateSignupMutationInput
+): Partial<SignupInput | UpdateSignupMutationInput> =>
+  omit(payload, [
+    'city',
+    'dateOfBirth',
+    'email',
+    'extraInfo',
+    'firstName',
+    'lastName',
+    'membershipNumber',
+    'nativeLanguage',
+    'phoneNumber',
+    'serviceLanguage',
+    'streetAddress',
+    'zipcode',
+  ]);

--- a/src/domain/signupGroup/__tests__/utils.test.ts
+++ b/src/domain/signupGroup/__tests__/utils.test.ts
@@ -1,4 +1,8 @@
 import {
+  CreateSignupGroupMutationInput,
+  SignupInput,
+} from '../../../generated/graphql';
+import {
   fakeRegistration,
   fakeSignup,
   fakeSignupGroup,
@@ -28,6 +32,7 @@ import {
   getUpdateSignupGroupPayload,
   isRestoringSignupGroupFormDataDisabled,
   isSignupFieldRequired,
+  omitSensitiveDataFromSignupGroupPayload,
 } from '../utils';
 
 beforeEach(() => {
@@ -518,5 +523,62 @@ describe('getUpdateSignupGroupPayload function', () => {
         },
       ],
     });
+  });
+});
+
+describe('omitSensitiveDataFromSignupGroupPayload', () => {
+  it('should omit sensitive data from payload', () => {
+    const payload: CreateSignupGroupMutationInput = {
+      extraInfo: 'Extra info',
+      registration: registration.id,
+      reservationCode: 'xxx',
+      signups: [
+        {
+          city: 'Helsinki',
+          dateOfBirth: '1999-10-10',
+          email: 'test@email.com',
+          extraInfo: 'Signup entra info',
+          firstName: 'First name',
+          id: '1',
+          lastName: 'Last name',
+          membershipNumber: 'XYZ',
+          nativeLanguage: 'fi',
+          notifications: NOTIFICATION_TYPE.EMAIL,
+          phoneNumber: '0441234567',
+          responsibleForGroup: true,
+          serviceLanguage: 'fi',
+          streetAddress: 'Address',
+          zipcode: '123456',
+        },
+      ],
+    };
+
+    const filteredPayload = omitSensitiveDataFromSignupGroupPayload(
+      payload
+    ) as CreateSignupGroupMutationInput;
+    expect(filteredPayload).toEqual({
+      registration: registration.id,
+      reservationCode: 'xxx',
+      signups: [
+        {
+          id: '1',
+          notifications: NOTIFICATION_TYPE.EMAIL,
+          responsibleForGroup: true,
+        },
+      ],
+    });
+    const signup = filteredPayload.signups?.[0] as SignupInput;
+    expect(filteredPayload.extraInfo).toBeUndefined();
+    expect(signup.city).toBeUndefined();
+    expect(signup.email).toBeUndefined();
+    expect(signup.extraInfo).toBeUndefined();
+    expect(signup.firstName).toBeUndefined();
+    expect(signup.lastName).toBeUndefined();
+    expect(signup.membershipNumber).toBeUndefined();
+    expect(signup.nativeLanguage).toBeUndefined();
+    expect(signup.phoneNumber).toBeUndefined();
+    expect(signup.serviceLanguage).toBeUndefined();
+    expect(signup.streetAddress).toBeUndefined();
+    expect(signup.zipcode).toBeUndefined();
   });
 });

--- a/src/domain/signupGroup/hooks/useSignupGroupActions.ts
+++ b/src/domain/signupGroup/hooks/useSignupGroupActions.ts
@@ -29,6 +29,7 @@ import { SignupGroupFormFields } from '../../signupGroup/types';
 import {
   getSignupGroupPayload,
   getUpdateSignupGroupPayload,
+  omitSensitiveDataFromSignupGroupPayload,
 } from '../../signupGroup/utils';
 import { SIGNUP_GROUP_ACTIONS } from '../constants';
 import { useSignupGroupFormContext } from '../signupGroupFormContext/hooks/useSignupGroupFormContext';
@@ -122,7 +123,7 @@ const useSignupGroupActions = ({
         callbacks,
         error,
         message: 'Failed to create signup group',
-        payload,
+        payload: omitSensitiveDataFromSignupGroupPayload(payload),
         savingFinished,
       });
     }
@@ -174,7 +175,7 @@ const useSignupGroupActions = ({
         callbacks,
         error,
         message: 'Failed to update signup group',
-        payload,
+        payload: omitSensitiveDataFromSignupGroupPayload(payload),
         savingFinished,
       });
     }

--- a/src/domain/signupGroup/utils.ts
+++ b/src/domain/signupGroup/utils.ts
@@ -1,4 +1,5 @@
 import isEqual from 'lodash/isEqual';
+import omit from 'lodash/omit';
 import snakeCase from 'lodash/snakeCase';
 
 import { DATE_FORMAT_API, FORM_NAMES } from '../../constants';
@@ -18,7 +19,10 @@ import {
   getSeatsReservationData,
   isSeatsReservationExpired,
 } from '../seatsReservation/utils';
-import { getSignupInitialValues } from '../signup/utils';
+import {
+  getSignupInitialValues,
+  omitSensitiveDataFromSignupPayload,
+} from '../signup/utils';
 import {
   NOTIFICATION_TYPE,
   NOTIFICATIONS,
@@ -275,3 +279,14 @@ export const getResponsiblePerson = (
   signupGroup: SignupGroupFieldsFragment
 ): SignupFieldsFragment | undefined =>
   signupGroup?.signups?.find((su) => su?.responsibleForGroup) ?? undefined;
+
+export const omitSensitiveDataFromSignupGroupPayload = (
+  payload: CreateSignupGroupMutationInput | UpdateSignupGroupMutationInput
+): Partial<
+  CreateSignupGroupMutationInput | UpdateSignupGroupMutationInput
+> => ({
+  ...omit(payload, ['extraInfo']),
+  signups: payload.signups
+    ?.filter(skipFalsyType)
+    .map((s) => omitSensitiveDataFromSignupPayload(s)),
+});

--- a/src/domain/user/__mocks__/user.ts
+++ b/src/domain/user/__mocks__/user.ts
@@ -9,7 +9,7 @@ import { TEST_PUBLISHER_ID } from '../../organization/constants';
 const userName = 'Test user';
 
 const getMockedUserResponse = (userSettings: Partial<User>): MockedResponse => {
-  const user = fakeUser(userSettings);
+  const user = fakeUser({ ...userSettings, username: TEST_USER_ID });
   const userVariables = {
     createPath: undefined,
     id: TEST_USER_ID,

--- a/src/domain/user/hooks/useUser.ts
+++ b/src/domain/user/hooks/useUser.ts
@@ -18,7 +18,7 @@ const useUser = (): UserState => {
   const userId = user?.profile.sub;
 
   const { data: userData, loading: loadingUser } = useUserQuery({
-    skip: !apiToken || !user,
+    skip: !apiToken || !userId,
     variables: {
       id: getValue(userId, ''),
       createPath: getPathBuilder(userPathBuilder),


### PR DESCRIPTION
## Description
- Always use `useHandleError` hook when sending error reports to Sentry to keep error handling consistent.
- Send only username instead of full user object to sentry 
- Omit `admin_users`, `registration_admin_users` and `regular_users` from `organization` payload when sending error report to Sentry
- Omit `first_name`, `last_name`, `email`, `date_of_birth`, `phone_number` and `extra_info` from `signup` or `signup group` payload when sending error report to Sentry
- Omit `registration_user_accesses` from `registration` payload when sending error report to Sentry
- Omit `name` and `email` from `feedback` payload when sending error report to Sentry
- Omit `user_email`, `user_name` and `user_phone_number` from `event` payload when sending error report to Sentry

## Closes
[LINK-1622](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1622)

[LINK-1622]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ