### PR TITLE
LINK-1563 moderator sees external user contact info

### DIFF
--- a/src/domain/event/__tests__/EditEventPage.test.tsx
+++ b/src/domain/event/__tests__/EditEventPage.test.tsx
@@ -431,22 +431,30 @@ test('should show server errors', async () => {
   screen.getByText(/lopetusaika ei voi olla menneisyydessä./i);
 });
 
-test('should render fields for external user', async () => {
-  const mocks = [
-    mockedEventResponse,
-    mockedEventTimeResponse,
-    mockedImageResponse,
-    mockedKeywordSelectorKeywordsResponse,
-    mockedAudienceKeywordSetResponse,
-    mockedTopicsKeywordSetResponse,
-    mockedLanguagesResponse,
-    mockedPlaceResponse,
-    mockedPlacesResponse,
-    mockedFilteredPlacesResponse,
-    mockedUserWithoutOrganizationsResponse,
-    mockedOrganizationResponse,
-    mockedOrganizationAncestorsResponse,
+test('should render external user contact fields for admin', async () => {
+  renderComponent();
+
+  await loadingSpinnerIsNotInDocument();
+
+  const externalUserContactFields = [
+    /nimi/i,
+    /sähköpostiosoite/i,
+    /puhelinnumero/i,
+    /organisaatio/i,
+    /olen lukenut tietosuojaselosteen ja annan luvan tietojeni käyttöön/i,
   ];
+
+  const fieldset = await screen.findByTestId('fields-external-user-contact');
+
+  externalUserContactFields.forEach(async (label) =>
+    expect(await within(fieldset).findByLabelText(label)).toBeInTheDocument()
+  );
+
+  await actWait(100);
+});
+
+test('should render fields for external user', async () => {
+  const mocks = [...baseMocks, mockedUserWithoutOrganizationsResponse];
 
   renderComponent(mocks);
 

--- a/src/domain/event/__tests__/EditEventPage.test.tsx
+++ b/src/domain/event/__tests__/EditEventPage.test.tsx
@@ -444,13 +444,11 @@ test('should render external user contact fields for admin', async () => {
     /olen lukenut tietosuojaselosteen ja annan luvan tietojeni käyttöön/i,
   ];
 
-  const fieldset = await screen.findByTestId('fields-external-user-contact');
+  const fieldset = await screen.findByRole('group', { name: /yhteystiedot/i });
 
-  externalUserContactFields.forEach(async (label) =>
-    expect(await within(fieldset).findByLabelText(label)).toBeInTheDocument()
-  );
-
-  await actWait(100);
+  for (const label of externalUserContactFields) {
+    expect(await within(fieldset).findByLabelText(label)).toBeInTheDocument();
+  }
 });
 
 test('should render fields for external user', async () => {

--- a/src/domain/event/__tests__/EditEventPage.test.tsx
+++ b/src/domain/event/__tests__/EditEventPage.test.tsx
@@ -452,7 +452,21 @@ test('should render external user contact fields for admin', async () => {
 });
 
 test('should render fields for external user', async () => {
-  const mocks = [...baseMocks, mockedUserWithoutOrganizationsResponse];
+  const mocks = [
+    mockedEventResponse,
+    mockedEventTimeResponse,
+    mockedImageResponse,
+    mockedKeywordSelectorKeywordsResponse,
+    mockedAudienceKeywordSetResponse,
+    mockedTopicsKeywordSetResponse,
+    mockedLanguagesResponse,
+    mockedPlaceResponse,
+    mockedPlacesResponse,
+    mockedFilteredPlacesResponse,
+    mockedUserWithoutOrganizationsResponse,
+    mockedOrganizationResponse,
+    mockedOrganizationAncestorsResponse,
+  ];
 
   renderComponent(mocks);
 

--- a/src/domain/event/eventForm/EventForm.tsx
+++ b/src/domain/event/eventForm/EventForm.tsx
@@ -14,7 +14,6 @@ import {
   EventFieldsFragment,
   EventQuery,
   EventQueryVariables,
-  OrganizationFieldsFragment,
   PublicationStatus,
   SuperEventType,
 } from '../../../generated/graphql';
@@ -108,8 +107,6 @@ type EventFormProps = EventFormWrapperProps & {
   ) => void;
   values: EventFormFields;
   isExternalUser: boolean;
-  isAdminUser: boolean;
-  organizationAncestors: OrganizationFieldsFragment[];
 };
 
 const EventForm: React.FC<EventFormProps> = ({
@@ -120,8 +117,6 @@ const EventForm: React.FC<EventFormProps> = ({
   setTouched,
   values,
   isExternalUser,
-  isAdminUser,
-  organizationAncestors,
 }) => {
   const { t } = useTranslation();
   const { addNotification } = useNotificationsContext();
@@ -130,6 +125,15 @@ const EventForm: React.FC<EventFormProps> = ({
   const navigate = useNavigate();
 
   const { user } = useUser();
+  const { organizationAncestors } = useOrganizationAncestors(
+    getValue(event?.publisher, '')
+  );
+
+  const isAdminUser = isAdminUserInOrganization({
+    id: getValue(event?.publisher, ''),
+    organizationAncestors,
+    user,
+  });
 
   const mainCategories = useMainCategories(values.type as EVENT_TYPE);
 
@@ -543,16 +547,6 @@ const EventFormWrapper: React.FC<EventFormWrapperProps> = (props) => {
   const { event } = props;
   const { user, externalUser } = useUser();
 
-  const { organizationAncestors } = useOrganizationAncestors(
-    getValue(event?.publisher, '')
-  );
-
-  const isAdminUser = isAdminUserInOrganization({
-    id: getValue(event?.publisher, ''),
-    organizationAncestors,
-    user,
-  });
-
   const eventInitialValues = externalUser
     ? EVENT_EXTERNAL_USER_INITIAL_VALUES
     : EVENT_INITIAL_VALUES;
@@ -603,8 +597,6 @@ const EventFormWrapper: React.FC<EventFormWrapperProps> = (props) => {
               setTouched={setTouched}
               values={values}
               isExternalUser={externalUser}
-              isAdminUser={isAdminUser}
-              organizationAncestors={organizationAncestors}
             />
           </FormikPersist>
         );

--- a/src/domain/event/formSections/externalUserContact/ExternalUserContact.tsx
+++ b/src/domain/event/formSections/externalUserContact/ExternalUserContact.tsx
@@ -21,11 +21,7 @@ const ExternalUserContact: FC<ExternalUserContactProps> = ({
   const { t } = useTranslation();
 
   return (
-    <Fieldset
-      heading={t('event.form.sections.contact')}
-      hideLegend
-      data-testid="fields-external-user-contact"
-    >
+    <Fieldset heading={t('event.form.sections.contact')} hideLegend>
       <FieldRow>
         <FieldColumn>
           <FormGroup>

--- a/src/domain/event/formSections/externalUserContact/ExternalUserContact.tsx
+++ b/src/domain/event/formSections/externalUserContact/ExternalUserContact.tsx
@@ -21,7 +21,11 @@ const ExternalUserContact: FC<ExternalUserContactProps> = ({
   const { t } = useTranslation();
 
   return (
-    <Fieldset heading={t('event.form.sections.contact')} hideLegend>
+    <Fieldset
+      heading={t('event.form.sections.contact')}
+      hideLegend
+      data-testid="fields-external-user-contact"
+    >
       <FieldRow>
         <FieldColumn>
           <FormGroup>

--- a/src/domain/organization/utils.ts
+++ b/src/domain/organization/utils.ts
@@ -123,7 +123,9 @@ export const hasAdminOrganization = (user?: UserFieldsFragment): boolean =>
 
 export const hasRegistrationAdminOrganization = (
   user?: UserFieldsFragment
-): boolean => !!user?.registrationAdminOrganizations.length;
+): boolean =>
+  !!user?.registrationAdminOrganizations &&
+  !!user?.registrationAdminOrganizations.length;
 
 const _isAdminUserInOrganization = ({
   adminOrganizations,

--- a/src/domain/organization/utils.ts
+++ b/src/domain/organization/utils.ts
@@ -123,9 +123,7 @@ export const hasAdminOrganization = (user?: UserFieldsFragment): boolean =>
 
 export const hasRegistrationAdminOrganization = (
   user?: UserFieldsFragment
-): boolean =>
-  !!user?.registrationAdminOrganizations &&
-  !!user?.registrationAdminOrganizations.length;
+): boolean => !!user?.registrationAdminOrganizations?.length;
 
 const _isAdminUserInOrganization = ({
   adminOrganizations,


### PR DESCRIPTION
## Description :sparkles:

Moderator should be able to see external users contact information when previewing on edit page. However this information should not be edited, so keeping the fields disabled.

## Issues :bug:

### Closes :no_good_woman:

**[LINK-1563](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1563):**

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

<img width="1217" alt="Screenshot 2023-10-19 at 12 55 00" src="https://github.com/City-of-Helsinki/linkedcomponents-ui/assets/66477579/a710fedd-5751-4717-8c07-aeb7871f3072">


## Additional notes :spiral_notepad:


[LINK-1563]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1563?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ