### PR TITLE
Separate file for table clickableRow to avoid import issues

### DIFF
--- a/src/common/components/table/clickableRow.module.scss
+++ b/src/common/components/table/clickableRow.module.scss
@@ -1,0 +1,12 @@
+.clickableRow {
+  cursor: pointer;
+
+  &:focus {
+    outline: var(--focus-outline-width) solid var(--focus-outline-color);
+    outline-offset: calc(0px - var(--focus-outline-width));
+
+    &:not(:global(.focus-visible)) {
+      outline: none;
+    }
+  }
+}

--- a/src/common/components/table/table.module.scss
+++ b/src/common/components/table/table.module.scss
@@ -148,14 +148,5 @@
 }
 
 .clickableRow {
-  cursor: pointer;
-
-  &:focus {
-    outline: var(--focus-outline-width) solid var(--focus-outline-color);
-    outline-offset: calc(0px - var(--focus-outline-width));
-
-    &:not(:global(.focus-visible)) {
-      outline: none;
-    }
-  }
+  composes: clickableRow from '../../../common/components/table/clickableRow.module.scss';
 }

--- a/src/domain/events/eventsTable/eventsTable.module.scss
+++ b/src/domain/events/eventsTable/eventsTable.module.scss
@@ -70,5 +70,5 @@
 }
 
 .clickableRow {
-  composes: clickableRow from '../../../common/components/table/table.module.scss';
+  composes: clickableRow from '../../../common/components/table/clickableRow.module.scss';
 }

--- a/src/domain/organizations/organizationsTable/organizationsTable.module.scss
+++ b/src/domain/organizations/organizationsTable/organizationsTable.module.scss
@@ -33,5 +33,5 @@
 }
 
 .clickableRow {
-  composes: clickableRow from '../../../common/components/table/table.module.scss';
+  composes: clickableRow from '../../../common/components/table/clickableRow.module.scss';
 }


### PR DESCRIPTION
## Description
Separate file for table clickableRow to avoid import issues

This PR should fix issues when parsing stylesheets at https://linkedevents.dev.hel.ninja/fi/events.
<img width="1726" alt="Screenshot 2023-10-23 at 15 52 59" src="https://github.com/City-of-Helsinki/linkedcomponents-ui/assets/24706814/fcaa5213-d070-4e0d-a862-bd308d36a158">

Original issue can be produced:
1. Build project with `yarn build`
2. Preview builded project with `yarn serve`
3. Open http://localhost:3000/en/events by using Safari or Firefox
-> Blank screen with `Did not parse stylesheet at...` errors
