### PR TITLE
LINK-1673 | Replace client side pagination with server side pagination

### DIFF
--- a/schema.js
+++ b/schema.js
@@ -158,6 +158,8 @@ module.exports = buildSchema(/* GraphQL */ `
     signup(id: ID!): Signup!
     signups(
       attendeeStatus: AttendeeStatus
+      page: Int
+      pageSize: Int
       registration: [ID]
       text: String
     ): SignupsResponse!

--- a/src/domain/signups/__tests__/utils.test.ts
+++ b/src/domain/signups/__tests__/utils.test.ts
@@ -34,6 +34,8 @@ describe('signupsPathBuilder function', () => {
       { attendeeStatus: AttendeeStatus.Attending },
       `/signup/?attendee_status=attending`,
     ],
+    [{ page: 2 }, `/signup/?page=2`],
+    [{ pageSize: 10 }, `/signup/?page_size=10`],
     [
       { registration: [registrationId] },
       `/signup/?registration=${registrationId}`,

--- a/src/domain/signups/query.ts
+++ b/src/domain/signups/query.ts
@@ -4,12 +4,16 @@ import gql from 'graphql-tag';
 export const QUERY_SIGNUPS = gql`
   query Signups(
     $attendeeStatus: AttendeeStatus
+    $page: Int
+    $pageSize: Int
     $registration: [ID]
     $text: String
     $createPath: Any
   ) {
     signups(
       attendeeStatus: $attendeeStatus
+      page: $page
+      pageSize: $pageSize
       registration: $registration
       text: $text
     ) @rest(type: "SignupsResponse", pathBuilder: $createPath) {

--- a/src/domain/signups/signupsTable/SignupsTable.tsx
+++ b/src/domain/signups/signupsTable/SignupsTable.tsx
@@ -16,7 +16,6 @@ import useCommonListProps from '../../../hooks/useCommonListProps';
 import useIdWithPrefix from '../../../hooks/useIdWithPrefix';
 import useLocale from '../../../hooks/useLocale';
 import useQueryStringWithReturnPath from '../../../hooks/useQueryStringWithReturnPath';
-import getPageCount from '../../../utils/getPageCount';
 import getPathBuilder from '../../../utils/getPathBuilder';
 import getValue from '../../../utils/getValue';
 import { scrollToItem } from '../../../utils/scrollToItem';
@@ -116,6 +115,8 @@ const SignupsTable: React.FC<SignupsTableProps> = ({
   const { data: signupsData, loading } = useSignupsQuery({
     variables: {
       ...signupsVariables,
+      page,
+      pageSize: SIGNUPS_PAGE_SIZE,
       registration: [getValue(registration.id, '')],
       text: signupText,
       createPath: getPathBuilder(signupsPathBuilder),
@@ -124,17 +125,10 @@ const SignupsTable: React.FC<SignupsTableProps> = ({
 
   const signups = getValue(signupsData?.signups.data, []).filter(skipFalsyType);
 
-  const signupsCount = signups.length;
-  const pageCount = getPageCount(signupsCount, SIGNUPS_PAGE_SIZE);
-
-  const paginatedSignups = signups.slice(
-    (page - 1) * SIGNUPS_PAGE_SIZE,
-    page * SIGNUPS_PAGE_SIZE
-  );
-  const { onPageChange, pageHref } = useCommonListProps({
+  const { onPageChange, pageCount, pageHref } = useCommonListProps({
     defaultSort: '',
     listId: signupListId,
-    meta: undefined,
+    meta: signupsData?.signups.meta,
     pagePath,
     pageSize: SIGNUPS_PAGE_SIZE,
   });
@@ -155,7 +149,7 @@ const SignupsTable: React.FC<SignupsTableProps> = ({
     const locationState = location.state as SignupsLocationState;
     if (
       locationState?.signupId &&
-      paginatedSignups.find((item) => item?.id === locationState.signupId)
+      signups.find((item) => item?.id === locationState.signupId)
     ) {
       scrollToItem(getSignupItemId(locationState.signupId));
       // Clear registrationId value to keep scroll position correctly
@@ -261,7 +255,7 @@ const SignupsTable: React.FC<SignupsTableProps> = ({
           indexKey="id"
           loading={loading}
           onRowClick={handleRowClick}
-          rows={paginatedSignups}
+          rows={signups}
           variant="light"
         />
 

--- a/src/domain/signups/signupsTable/__tests__/SignupsTable.test.tsx
+++ b/src/domain/signups/signupsTable/__tests__/SignupsTable.test.tsx
@@ -10,7 +10,6 @@ import {
   render,
   screen,
   userEvent,
-  waitFor,
   within,
 } from '../../../../utils/testUtils';
 import { mockedEventResponse } from '../../../event/__mocks__/event';
@@ -23,12 +22,14 @@ import { SignupGroupFormProvider } from '../../../signupGroup/signupGroupFormCon
 import { mockedRegistrationUserResponse } from '../../../user/__mocks__/user';
 import {
   attendeeNames,
+  attendeeNamesPage2,
   attendees,
   attendeesWithGroup,
   getMockedAttendeesResponse,
+  mockedAttendeesPage2Response,
+  mockedAttendeesResponse,
   signupGroupId,
 } from '../../__mocks__/signupsPage';
-import { SIGNUPS_PAGE_SIZE } from '../../constants';
 import SignupsTable, { SignupsTableProps } from '../SignupsTable';
 
 configure({ defaultHidden: true });
@@ -91,31 +92,31 @@ test('should render signups table', async () => {
 test('should navigate between pages', async () => {
   const user = userEvent.setup();
 
-  renderComponent([...defaultMocks, getMockedAttendeesResponse(attendees)]);
+  renderComponent([
+    ...defaultMocks,
+    mockedAttendeesResponse,
+    mockedAttendeesPage2Response,
+  ]);
 
   await loadingSpinnerIsNotInDocument();
+  const attendeePage2Name = [
+    attendeeNamesPage2[0].firstName,
+    attendeeNamesPage2[0].lastName,
+  ].join(' ');
 
   // Page 1 signup should be visible.
   screen.getByRole('button', { name: signupName });
   expect(
-    screen.queryByRole('button', {
-      name: [
-        attendeeNames[SIGNUPS_PAGE_SIZE].firstName,
-        attendeeNames[SIGNUPS_PAGE_SIZE].lastName,
-      ].join(' '),
-    })
+    screen.queryByRole('button', { name: attendeePage2Name })
   ).not.toBeInTheDocument();
 
   const page2Button = getElement('page2');
   await user.click(page2Button);
 
   // Page 2 signup should be visible.
-  await screen.findByRole('button', {
-    name: [
-      attendeeNames[SIGNUPS_PAGE_SIZE].firstName,
-      attendeeNames[SIGNUPS_PAGE_SIZE].lastName,
-    ].join(' '),
-  });
+  expect(
+    await screen.findByRole('button', { name: attendeePage2Name })
+  ).toBeInTheDocument();
   expect(
     screen.queryByRole('button', { name: signupName })
   ).not.toBeInTheDocument();
@@ -124,14 +125,9 @@ test('should navigate between pages', async () => {
   await user.click(page1Button);
 
   // Page 1 signup should be visible.
-  screen.getByRole('button', { name: signupName });
+  expect(screen.getByRole('button', { name: signupName })).toBeInTheDocument();
   expect(
-    screen.queryByRole('button', {
-      name: [
-        attendeeNames[SIGNUPS_PAGE_SIZE].firstName,
-        attendeeNames[SIGNUPS_PAGE_SIZE].lastName,
-      ].join(' '),
-    })
+    screen.queryByRole('button', { name: attendeePage2Name })
   ).not.toBeInTheDocument();
 });
 
@@ -139,7 +135,7 @@ test('should open edit signup page by clicking a signup without group', async ()
   const user = userEvent.setup();
   const { history } = renderComponent([
     ...defaultMocks,
-    getMockedAttendeesResponse(attendees),
+    mockedAttendeesResponse,
   ]);
 
   const signupButton = await screen.findByRole('button', {
@@ -173,7 +169,7 @@ test('should open edit signup page by pressing enter on a signup without group',
   const user = userEvent.setup();
   const { history } = renderComponent([
     ...defaultMocks,
-    getMockedAttendeesResponse(attendees),
+    mockedAttendeesResponse,
   ]);
 
   await loadingSpinnerIsNotInDocument();
@@ -225,9 +221,7 @@ test('should open actions dropdown', async () => {
 
   await user.click(editButton);
 
-  await waitFor(() =>
-    expect(history.location.pathname).toBe(
-      `/fi/registrations/${registrationId}/signup-group/edit/${signupGroupId}`
-    )
+  expect(history.location.pathname).toBe(
+    `/fi/registrations/${registrationId}/signup-group/edit/${signupGroupId}`
   );
 });

--- a/src/domain/signups/utils.ts
+++ b/src/domain/signups/utils.ts
@@ -73,10 +73,12 @@ export const getSignupItemId = (id: string): string => `signup-item-${id}`;
 export const signupsPathBuilder = ({
   args,
 }: PathBuilderProps<SignupsQueryVariables>): string => {
-  const { attendeeStatus, registration, text } = args;
+  const { attendeeStatus, page, pageSize, registration, text } = args;
 
   const variableToKeyItems = [
     { key: 'attendee_status', value: attendeeStatus },
+    { key: 'page', value: page },
+    { key: 'page_size', value: pageSize },
     { key: 'registration', value: registration },
     { key: 'text', value: text },
   ];

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -951,6 +951,8 @@ export type QuerySignupGroupArgs = {
 
 export type QuerySignupsArgs = {
   attendeeStatus?: InputMaybe<AttendeeStatus>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  pageSize?: InputMaybe<Scalars['Int']['input']>;
   registration?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>>>;
   text?: InputMaybe<Scalars['String']['input']>;
 };
@@ -1847,6 +1849,8 @@ export type SignupGroupQuery = { __typename?: 'Query', signupGroup: { __typename
 
 export type SignupsQueryVariables = Exact<{
   attendeeStatus?: InputMaybe<AttendeeStatus>;
+  page?: InputMaybe<Scalars['Int']['input']>;
+  pageSize?: InputMaybe<Scalars['Int']['input']>;
   registration?: InputMaybe<Array<InputMaybe<Scalars['ID']['input']>> | InputMaybe<Scalars['ID']['input']>>;
   text?: InputMaybe<Scalars['String']['input']>;
   createPath?: InputMaybe<Scalars['Any']['input']>;
@@ -4423,9 +4427,11 @@ export type SignupGroupQueryHookResult = ReturnType<typeof useSignupGroupQuery>;
 export type SignupGroupLazyQueryHookResult = ReturnType<typeof useSignupGroupLazyQuery>;
 export type SignupGroupQueryResult = Apollo.QueryResult<SignupGroupQuery, SignupGroupQueryVariables>;
 export const SignupsDocument = gql`
-    query Signups($attendeeStatus: AttendeeStatus, $registration: [ID], $text: String, $createPath: Any) {
+    query Signups($attendeeStatus: AttendeeStatus, $page: Int, $pageSize: Int, $registration: [ID], $text: String, $createPath: Any) {
   signups(
     attendeeStatus: $attendeeStatus
+    page: $page
+    pageSize: $pageSize
     registration: $registration
     text: $text
   ) @rest(type: "SignupsResponse", pathBuilder: $createPath) {
@@ -4453,6 +4459,8 @@ ${SignupFieldsFragmentDoc}`;
  * const { data, loading, error } = useSignupsQuery({
  *   variables: {
  *      attendeeStatus: // value for 'attendeeStatus'
+ *      page: // value for 'page'
+ *      pageSize: // value for 'pageSize'
  *      registration: // value for 'registration'
  *      text: // value for 'text'
  *      createPath: // value for 'createPath'


### PR DESCRIPTION
## Description
At the moment signups table is using client side pagination. However signups endpoint response is already paginated and with current implementation use can see only the first page of the data and some signups are missing

## Closes
[LINK-1673](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1673)

[LINK-1673]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ