### PR TITLE
Hide contact information from admins if the event is not external

### DIFF
--- a/src/domain/event/__mocks__/editEventPage.ts
+++ b/src/domain/event/__mocks__/editEventPage.ts
@@ -42,7 +42,10 @@ import {
   topicAtIds,
   topics,
 } from '../../keywordSet/__mocks__/keywordSets';
-import { TEST_PUBLISHER_ID } from '../../organization/constants';
+import {
+  EXTERNAL_PUBLISHER_ID,
+  TEST_PUBLISHER_ID,
+} from '../../organization/constants';
 import { locationText, place, placeAtId } from '../../place/__mocks__/place';
 import { EventFormFields } from '../types';
 
@@ -363,6 +366,16 @@ const mockedPostponedEventResponse: MockedResponse = {
   result: postponedEventResponse,
 };
 
+const externalEvent = {
+  ...event,
+  publisher: EXTERNAL_PUBLISHER_ID,
+};
+const externalEventResponse = { data: { event: externalEvent } };
+const mockedExternalEventResponse: MockedResponse = {
+  request: { query: EventDocument, variables: eventVariables },
+  result: externalEventResponse,
+};
+
 const deleteEventVariables = { id: eventId };
 const deleteEventResponse = { data: { deleteEvent: null } };
 const mockedDeleteEventResponse: MockedResponse = {
@@ -572,6 +585,7 @@ export {
   mockedEventResponse,
   mockedEventTimeResponse,
   mockedEventWithSubEventResponse,
+  mockedExternalEventResponse,
   mockedInvalidEventResponse,
   mockedInvalidUpdateEventResponse,
   mockedPostponedEventResponse,

--- a/src/domain/event/eventForm/EventForm.tsx
+++ b/src/domain/event/eventForm/EventForm.tsx
@@ -28,6 +28,7 @@ import PageWrapper from '../../app/layout/pageWrapper/PageWrapper';
 import Section from '../../app/layout/section/Section';
 import { useNotificationsContext } from '../../app/notificationsContext/hooks/useNotificationsContext';
 import { replaceParamsToEventQueryString } from '../../events/utils';
+import { EXTERNAL_PUBLISHER_ID } from '../../organization/constants';
 import useOrganizationAncestors from '../../organization/hooks/useOrganizationAncestors';
 import { isAdminUserInOrganization } from '../../organization/utils';
 import useUser from '../../user/hooks/useUser';
@@ -350,7 +351,6 @@ const EventForm: React.FC<EventFormProps> = ({
   }, [mainCategories]);
 
   const { name } = event ? getEventFields(event, locale) : { name: '' };
-
   return (
     <>
       {event && (
@@ -492,7 +492,9 @@ const EventForm: React.FC<EventFormProps> = ({
                   isExternalUser={isExternalUser}
                 />
               </Section>
-              {(isExternalUser || isAdminUser) && (
+              {(isExternalUser ||
+                (isAdminUser &&
+                  event?.publisher === EXTERNAL_PUBLISHER_ID)) && (
                 <Section title={t('event.form.sections.contact')}>
                   <ExternalUserContact
                     isEditingAllowed={isEditingAllowed && !isAdminUser}

--- a/src/domain/events/eventsTable/eventsTableRow/EventsTableRow.tsx
+++ b/src/domain/events/eventsTable/eventsTableRow/EventsTableRow.tsx
@@ -12,6 +12,7 @@ import { usePageSettings } from '../../../app/hooks/usePageSettings';
 import StatusTag from '../../../event/tags/statusTag/StatusTag';
 import SuperEventTypeTag from '../../../event/tags/superEventTypeTag/SuperEventTypeTag';
 import { getEventFields } from '../../../event/utils';
+import { EXTERNAL_PUBLISHER_ID } from '../../../organization/constants';
 import OrganizationName from '../../../organization/organizationName/OrganizationName';
 import EventActionsDropdown from '../../eventActionsDropdown/EventActionsDropdown';
 import { getEventItemId } from '../../utils';
@@ -134,7 +135,7 @@ const EventTableRow: React.FC<Props> = ({
           </div>
         </td>
         <td className={styles.publisherColumn}>
-          {publisher !== 'others' ? (
+          {publisher !== EXTERNAL_PUBLISHER_ID ? (
             <OrganizationName id={publisher} />
           ) : (
             <span className={styles.externalPublisher}>

--- a/src/domain/events/eventsTable/eventsTableRow/__tests__/EventsTableRow.test.tsx
+++ b/src/domain/events/eventsTable/eventsTableRow/__tests__/EventsTableRow.test.tsx
@@ -27,6 +27,7 @@ import {
   mockedExternalOrganizationAncestorsResponse,
   mockedOrganizationAncestorsResponse,
 } from '../../../../organization/__mocks__/organizationAncestors';
+import { EXTERNAL_PUBLISHER_ID } from '../../../../organization/constants';
 import EventsTableRow from '../EventsTableRow';
 
 configure({ defaultHidden: true });
@@ -164,7 +165,7 @@ test('should have an icon highlighting that the event was created by external us
   const commonEventInfo = {
     id: eventValues.id,
     publicationStatus: eventValues.publicationStatus,
-    publisher: 'others',
+    publisher: EXTERNAL_PUBLISHER_ID,
   };
   const event = fakeEvent({
     ...commonEventInfo,

--- a/src/domain/organization/__mocks__/organization.ts
+++ b/src/domain/organization/__mocks__/organization.ts
@@ -31,7 +31,10 @@ const externalOrganization = fakeOrganization({
   id: EXTERNAL_PUBLISHER_ID,
   name: 'Muu',
 });
-const externalOrganizationVariables = { createPath: undefined, id: 'others' };
+const externalOrganizationVariables = {
+  createPath: undefined,
+  id: EXTERNAL_PUBLISHER_ID,
+};
 const externalOrganizationResponse = { data: { externalOrganization } };
 const mockedExternalOrganizationResponse: MockedResponse = {
   request: {

--- a/src/domain/user/__mocks__/user.ts
+++ b/src/domain/user/__mocks__/user.ts
@@ -4,7 +4,10 @@ import range from 'lodash/range';
 import { MAX_PAGE_SIZE, TEST_USER_ID } from '../../../constants';
 import { User, UserDocument, UsersDocument } from '../../../generated/graphql';
 import { fakeUser, fakeUsers } from '../../../utils/mockDataUtils';
-import { TEST_PUBLISHER_ID } from '../../organization/constants';
+import {
+  EXTERNAL_PUBLISHER_ID,
+  TEST_PUBLISHER_ID,
+} from '../../organization/constants';
 
 const userName = 'Test user';
 
@@ -24,6 +27,14 @@ const getMockedUserResponse = (userSettings: Partial<User>): MockedResponse => {
 
 const mockedUserResponse = getMockedUserResponse({
   adminOrganizations: [TEST_PUBLISHER_ID],
+  displayName: userName,
+  organization: TEST_PUBLISHER_ID,
+  organizationMemberships: [],
+  registrationAdminOrganizations: [],
+});
+
+const mockedExternalAdminUserResponse = getMockedUserResponse({
+  adminOrganizations: [TEST_PUBLISHER_ID, EXTERNAL_PUBLISHER_ID],
   displayName: userName,
   organization: TEST_PUBLISHER_ID,
   organizationMemberships: [],
@@ -72,6 +83,7 @@ const mockedUsersResponse = {
 
 export {
   getMockedUserResponse,
+  mockedExternalAdminUserResponse,
   mockedRegistrationUserResponse,
   mockedRegularUserResponse,
   mockedUserResponse,


### PR DESCRIPTION
See LINK-1697 - contact information needs to be shown admins only when the event is external.