### PR TITLE
LINK-1688 | Display signup and registration name as a link

### DIFF
--- a/src/domain/registrations/registrationsTable/RegistrationsTable.tsx
+++ b/src/domain/registrations/registrationsTable/RegistrationsTable.tsx
@@ -2,6 +2,7 @@ import isNumber from 'lodash/isNumber';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router';
+import { Link } from 'react-router-dom';
 
 import Table from '../../../common/components/table/Table';
 import {
@@ -28,13 +29,21 @@ export interface RegistrationsTableProps {
 
 const NameColumn = (registration: RegistrationFieldsFragment) => {
   const locale = useLocale();
-  const { event } = getRegistrationFields(registration, locale);
+  const queryStringWithReturnPath = useQueryStringWithReturnPath();
+  const { event, registrationUrl } = getRegistrationFields(
+    registration,
+    locale
+  );
 
   return (
     <div className={styles.nameWrapper}>
-      <span className={styles.registrationName} title={event?.name}>
+      <Link
+        className={styles.registrationName}
+        title={event?.name}
+        to={{ pathname: registrationUrl, search: queryStringWithReturnPath }}
+      >
         {event?.name}
-      </span>
+      </Link>
     </div>
   );
 };
@@ -115,6 +124,10 @@ const RegistrationsTable: React.FC<RegistrationsTableProps> = ({
           className: styles.nameColumn,
           key: 'name',
           headerName: t('registrationsPage.registrationsTableColumns.name'),
+          onClick: (ev) => {
+            ev.stopPropagation();
+            ev.preventDefault();
+          },
           transform: NameColumn,
         },
         {

--- a/src/domain/registrations/registrationsTable/__tests__/RegistrationsTable.test.tsx
+++ b/src/domain/registrations/registrationsTable/__tests__/RegistrationsTable.test.tsx
@@ -28,6 +28,7 @@ import RegistrationsTable, {
 configure({ defaultHidden: true });
 
 const registrationId = getValue(registrations.data[0]?.id, '');
+const eventName = getValue(registrations.data[0]?.event?.name?.fi, '');
 const registration = registrations.data[0] as Registration;
 
 const mocks = [
@@ -42,6 +43,8 @@ const defaultProps: RegistrationsTableProps = {
 };
 
 const authContextValue = fakeAuthenticatedAuthContextValue();
+
+const FIND_LINK_TIMEOUT = 5000;
 
 const renderComponent = (props?: Partial<RegistrationsTableProps>) =>
   render(<RegistrationsTable {...defaultProps} {...props} />, {
@@ -142,9 +145,25 @@ test('should open registration page by clicking event name', async () => {
   const button = await screen.findByRole(
     'button',
     { name: registrationId },
-    { timeout: 20000 }
+    { timeout: FIND_LINK_TIMEOUT }
   );
   await user.click(button);
+  expect(history.location.pathname).toBe(
+    `/fi/registrations/edit/${registrationId}`
+  );
+});
+
+test('event name should work as a link to edit registration page', async () => {
+  const user = userEvent.setup();
+  const { history } = renderComponent({ registrations: [registration] });
+
+  const registrationLink = await screen.findByRole(
+    'link',
+    { name: eventName },
+    { timeout: FIND_LINK_TIMEOUT }
+  );
+  await user.click(registrationLink);
+
   expect(history.location.pathname).toBe(
     `/fi/registrations/edit/${registrationId}`
   );
@@ -158,7 +177,7 @@ test('should open registration page by pressing enter on row', async () => {
   const button = await screen.findByRole(
     'button',
     { name: registrationId },
-    { timeout: 20000 }
+    { timeout: FIND_LINK_TIMEOUT }
   );
   await user.click(button);
   await user.type(button, '{enter}');

--- a/src/domain/signups/signupsTable/SignupsTable.tsx
+++ b/src/domain/signups/signupsTable/SignupsTable.tsx
@@ -2,6 +2,7 @@ import omit from 'lodash/omit';
 import React, { FC } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router';
+import { Link } from 'react-router-dom';
 
 import Pagination from '../../../common/components/pagination/Pagination';
 import Table from '../../../common/components/table/Table';
@@ -38,7 +39,8 @@ type ColumnProps = {
 
 const NameColumn: FC<ColumnProps> = ({ registration, signup }) => {
   const language = useLocale();
-  const { fullName } = getSignupFields({
+  const queryStringWithReturnPath = useQueryStringWithReturnPath();
+  const { fullName, signupGroupUrl, signupUrl } = getSignupFields({
     language,
     registration,
     signup,
@@ -46,9 +48,16 @@ const NameColumn: FC<ColumnProps> = ({ registration, signup }) => {
 
   return (
     <div className={styles.nameWrapper}>
-      <span className={styles.sgnupName} title={fullName}>
+      <Link
+        className={styles.signupName}
+        title={fullName}
+        to={{
+          pathname: signupGroupUrl ?? signupUrl,
+          search: queryStringWithReturnPath,
+        }}
+      >
         {fullName}
-      </span>
+      </Link>
     </div>
   );
 };
@@ -208,6 +217,10 @@ const SignupsTable: React.FC<SignupsTableProps> = ({
               className: styles.nameColumn,
               key: 'name',
               headerName: t('signupsPage.signupsTableColumns.name'),
+              onClick: (ev) => {
+                ev.stopPropagation();
+                ev.preventDefault();
+              },
               transform: MemoizedNameColumn,
             },
             {

--- a/src/domain/signups/signupsTable/__tests__/SignupsTable.test.tsx
+++ b/src/domain/signups/signupsTable/__tests__/SignupsTable.test.tsx
@@ -131,6 +131,21 @@ test('should navigate between pages', async () => {
   ).not.toBeInTheDocument();
 });
 
+test('signup name should work as a link to edit signup page', async () => {
+  const user = userEvent.setup();
+  const { history } = renderComponent([
+    ...defaultMocks,
+    mockedAttendeesResponse,
+  ]);
+
+  const signupLink = await screen.findByRole('link', { name: signupName });
+  await user.click(signupLink);
+
+  expect(history.location.pathname).toBe(
+    `/fi/registrations/${registrationId}/signup/edit/${attendees.data[0].id}`
+  );
+});
+
 test('should open edit signup page by clicking a signup without group', async () => {
   const user = userEvent.setup();
   const { history } = renderComponent([
@@ -138,13 +153,26 @@ test('should open edit signup page by clicking a signup without group', async ()
     mockedAttendeesResponse,
   ]);
 
-  const signupButton = await screen.findByRole('button', {
-    name: signupName,
-  });
+  const signupButton = await screen.findByRole('button', { name: signupName });
   await user.click(signupButton);
 
   expect(history.location.pathname).toBe(
     `/fi/registrations/${registrationId}/signup/edit/${attendees.data[0].id}`
+  );
+});
+
+test('signup group name should work as a link to edit signup group page', async () => {
+  const user = userEvent.setup();
+  const { history } = renderComponent([
+    ...defaultMocks,
+    getMockedAttendeesResponse(attendeesWithGroup),
+  ]);
+
+  const signupLink = await screen.findByRole('link', { name: signupName });
+  await user.click(signupLink);
+
+  expect(history.location.pathname).toBe(
+    `/fi/registrations/${registrationId}/signup-group/edit/${signupGroupId}`
   );
 });
 

--- a/src/domain/signups/signupsTable/signupsTable.module.scss
+++ b/src/domain/signups/signupsTable/signupsTable.module.scss
@@ -20,7 +20,7 @@
   display: flex;
   align-items: center;
 
-  .sgnupName {
+  .signupName {
     overflow: hidden;
     text-overflow: ellipsis;
   }


### PR DESCRIPTION
## Description
Display signup name as a link in signups table
Display event name as a link in registrations table

## Closes
[LINK-1688](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1688)

## Screenshot
<img width="1427" alt="Screenshot 2023-11-08 at 11 52 59" src="https://github.com/City-of-Helsinki/linkedcomponents-ui/assets/24706814/2083b22a-f481-494f-9c2c-d4e614f6c7de">
<img width="1428" alt="Screenshot 2023-11-08 at 12 10 52" src="https://github.com/City-of-Helsinki/linkedcomponents-ui/assets/24706814/8af1ee78-ea82-425c-ac07-f74aebee9af4">


[LINK-1688]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1688?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ