### PR TITLE
LINK-1709: Rename develop branch to main

### DIFF
--- a/azure-pipelines-acceptance-tests.yml
+++ b/azure-pipelines-acceptance-tests.yml
@@ -14,8 +14,7 @@ trigger: none
 pr:
   branches:
     include:
-    - develop
-    - production
+    - main
 
 # By default, use self-hosted agents
 pool: Default

--- a/azure-pipelines-build-devtest.yml
+++ b/azure-pipelines-build-devtest.yml
@@ -13,7 +13,7 @@ trigger:
   batch: true
   branches:
     include:
-      - develop
+      - main
   paths:
     exclude:
       - README.md

--- a/azure-pipelines-build-staging.yml
+++ b/azure-pipelines-build-staging.yml
@@ -4,7 +4,7 @@ trigger:
   batch: true
   branches:
     include:
-      - production
+      - main
   paths:
     exclude:
       - README.md

--- a/azure-pipelines-e2e-dev.yml
+++ b/azure-pipelines-e2e-dev.yml
@@ -7,7 +7,7 @@ schedules:
 - cron: '0 5-22 * * *'
   branches: 
     include: 
-    - develop 
+    - main 
   always: true
 
 # Pull request (PR) triggers cause a pipeline to run whenever a pull request is

--- a/azure-pipelines-e2e-prod.yml
+++ b/azure-pipelines-e2e-prod.yml
@@ -7,7 +7,7 @@ schedules:
 - cron: '0 5-22 * * *'
   branches: 
     include: 
-    - develop 
+    - main 
   always: true
 
 # Pull request (PR) triggers cause a pipeline to run whenever a pull request is


### PR DESCRIPTION
## Description :sparkles:

`develop` branch was renamed to `main`. Need to change pipelines to use `main` instead of `develop` as well.

### Closes :no_good_woman:

**[LINK-1709](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1709)**


[LINK-1709]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1709?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ