### PR TITLE
LINK-1661 | Export signups as Excel file

### DIFF
--- a/src/domain/app/i18n/en.json
+++ b/src/domain/app/i18n/en.json
@@ -1751,6 +1751,7 @@
       "delete": "Delete registration",
       "edit": "Edit",
       "editAttendanceList": "Mark attendees",
+      "exportSignupsAsExcel": "Export particpants (Excel)",
       "showSignups": "Show participants",
       "update": "Save changes"
     },

--- a/src/domain/app/i18n/fi.json
+++ b/src/domain/app/i18n/fi.json
@@ -1752,6 +1752,7 @@
       "delete": "Poista ilmoittautuminen",
       "edit": "Muokkaa",
       "editAttendanceList": "Merkkaa läsnäolijat",
+      "exportSignupsAsExcel": "Lataa osallistujalista (Excel)",
       "showSignups": "Näytä ilmoittautuneet",
       "update": "Tallenna muutokset"
     },

--- a/src/domain/app/i18n/sv.json
+++ b/src/domain/app/i18n/sv.json
@@ -1752,6 +1752,7 @@
       "delete": "Radera registrering",
       "edit": "Redigera",
       "editAttendanceList": "Märk de närvarande",
+      "exportSignupsAsExcel": "Exportera deltagare (Excel)",
       "showSignups": "Visa deltagare",
       "update": "Spara ändringar"
     },

--- a/src/domain/registration/editButtonPanel/EditButtonPanel.tsx
+++ b/src/domain/registration/editButtonPanel/EditButtonPanel.tsx
@@ -24,6 +24,7 @@ import useUser from '../../user/hooks/useUser';
 import {
   copyRegistrationToSessionStorage,
   copySignupLinkToClipboard,
+  exportSignupsAsExcel,
   getRegistrationActionButtonProps,
   getRegistrationFields,
 } from '../utils';
@@ -128,6 +129,15 @@ const EditButtonPanel: React.FC<EditButtonPanelProps> = ({
     getActionItemProps({
       action: REGISTRATION_ACTIONS.EDIT_ATTENDANCE_LIST,
       onClick: goToAttendanceListPage,
+    }),
+    getActionItemProps({
+      action: REGISTRATION_ACTIONS.EXPORT_SIGNUPS_AS_EXCEL,
+      onClick: () =>
+        exportSignupsAsExcel({
+          addNotification,
+          registration,
+          uiLanguage: locale,
+        }),
     }),
     getActionItemProps({
       action: REGISTRATION_ACTIONS.COPY,

--- a/src/domain/registration/editButtonPanel/__tests__/EditButtonPanel.test.tsx
+++ b/src/domain/registration/editButtonPanel/__tests__/EditButtonPanel.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import copyToClipboard from 'copy-to-clipboard';
 import React from 'react';
 
@@ -12,6 +13,7 @@ import {
 } from '../../../../utils/testUtils';
 import { AuthContextProps } from '../../../auth/types';
 import { mockedOrganizationAncestorsResponse } from '../../../organization/__mocks__/organizationAncestors';
+import { shouldExportSignupsAsExcel } from '../../../signups/__tests__/testUtils';
 import { mockedRegistrationUserResponse } from '../../../user/__mocks__/user';
 import {
   publisher,
@@ -67,6 +69,7 @@ const getElement = (
     | 'copy'
     | 'copyLink'
     | 'delete'
+    | 'exportAsExcel'
     | 'markPresent'
     | 'menu'
     | 'showSignups'
@@ -82,6 +85,10 @@ const getElement = (
       return screen.getByRole('button', { name: /kopioi linkk/i });
     case 'delete':
       return screen.getByRole('button', { name: 'Poista ilmoittautuminen' });
+    case 'exportAsExcel':
+      return screen.getByRole('button', {
+        name: 'Lataa osallistujalista (Excel)',
+      });
     case 'markPresent':
       return screen.getByRole('button', { name: 'Merkkaa läsnäolijat' });
     case 'menu':
@@ -177,7 +184,7 @@ test('should route to attendance list page when clicking mark present button', a
 
   await openMenu();
 
-  const markPresentButton = await getElement('markPresent');
+  const markPresentButton = getElement('markPresent');
   await waitFor(() => expect(markPresentButton).toBeEnabled());
   await user.click(markPresentButton);
 
@@ -189,6 +196,13 @@ test('should route to attendance list page when clicking mark present button', a
   expect(decodeURIComponent(history.location.search)).toBe(
     `?returnPath=/registrations/edit/${registration.id}`
   );
+});
+
+test('should export signups as an excel after clicking export as excel button', async () => {
+  renderComponent({ authContextValue });
+  await openMenu();
+  const exportAsExcelButton = getElement('exportAsExcel');
+  await shouldExportSignupsAsExcel({ exportAsExcelButton, registration });
 });
 
 test('should route to create registration page when clicking copy button', async () => {
@@ -233,7 +247,7 @@ test('should route to search page when clicking back button', async () => {
 test('should route to page defined in returnPath when clicking back button', async () => {
   const user = userEvent.setup();
   const { history } = renderComponent({
-    route: `/fi${ROUTES}?returnPath=${ROUTES.SEARCH}&returnPath=${ROUTES.REGISTRATIONS}`,
+    route: `/fi${ROUTES.REGISTRATION_SIGNUPS}?returnPath=${ROUTES.SEARCH}&returnPath=${ROUTES.REGISTRATIONS}`,
   });
 
   const backButton = getElement('back');

--- a/src/domain/registrations/constants.tsx
+++ b/src/domain/registrations/constants.tsx
@@ -6,6 +6,7 @@ import {
   IconEye,
   IconLink,
   IconPen,
+  IconSaveDiskette,
 } from 'hds-react';
 
 export enum REGISTRATION_ACTIONS {
@@ -15,6 +16,7 @@ export enum REGISTRATION_ACTIONS {
   DELETE = 'delete',
   EDIT = 'edit',
   EDIT_ATTENDANCE_LIST = 'editAttendanceList',
+  EXPORT_SIGNUPS_AS_EXCEL = 'exportSignupsAsExcel',
   SHOW_SIGNUPS = 'showSignups',
   UPDATE = 'update',
 }
@@ -42,6 +44,9 @@ export const REGISTRATION_ICONS = {
   [REGISTRATION_ACTIONS.DELETE]: <IconCross aria-hidden={true} />,
   [REGISTRATION_ACTIONS.EDIT]: <IconCogwheel aria-hidden={true} />,
   [REGISTRATION_ACTIONS.EDIT_ATTENDANCE_LIST]: <IconCheck aria-hidden={true} />,
+  [REGISTRATION_ACTIONS.EXPORT_SIGNUPS_AS_EXCEL]: (
+    <IconSaveDiskette aria-hidden={true} />
+  ),
   [REGISTRATION_ACTIONS.SHOW_SIGNUPS]: <IconEye aria-hidden={true} />,
   [REGISTRATION_ACTIONS.UPDATE]: <IconPen aria-hidden={true} />,
 };
@@ -54,6 +59,8 @@ export const REGISTRATION_LABEL_KEYS = {
   [REGISTRATION_ACTIONS.EDIT]: 'registrationsPage.actionButtons.edit',
   [REGISTRATION_ACTIONS.EDIT_ATTENDANCE_LIST]:
     'registrationsPage.actionButtons.editAttendanceList',
+  [REGISTRATION_ACTIONS.EXPORT_SIGNUPS_AS_EXCEL]:
+    'registrationsPage.actionButtons.exportSignupsAsExcel',
   [REGISTRATION_ACTIONS.SHOW_SIGNUPS]:
     'registrationsPage.actionButtons.showSignups',
   [REGISTRATION_ACTIONS.UPDATE]: 'registrationsPage.actionButtons.update',

--- a/src/domain/registrations/registrationActionsDropdown/RegistrationActionsDropdown.tsx
+++ b/src/domain/registrations/registrationActionsDropdown/RegistrationActionsDropdown.tsx
@@ -20,6 +20,7 @@ import ConfirmDeleteRegistrationModal from '../../registration/modals/confirmDel
 import {
   copyRegistrationToSessionStorage,
   copySignupLinkToClipboard,
+  exportSignupsAsExcel,
   getRegistrationActionButtonProps,
   getRegistrationFields,
 } from '../../registration/utils';
@@ -108,6 +109,15 @@ const RegistrationActionsDropdown: React.FC<
     getActionItemProps({
       action: REGISTRATION_ACTIONS.EDIT_ATTENDANCE_LIST,
       onClick: goToAttendenceListPage,
+    }),
+    getActionItemProps({
+      action: REGISTRATION_ACTIONS.EXPORT_SIGNUPS_AS_EXCEL,
+      onClick: () =>
+        exportSignupsAsExcel({
+          addNotification,
+          registration,
+          uiLanguage: locale,
+        }),
     }),
     getActionItemProps({
       action: REGISTRATION_ACTIONS.COPY,

--- a/src/domain/registrations/registrationActionsDropdown/__tests__/RegistrationActionsDropdown.test.tsx
+++ b/src/domain/registrations/registrationActionsDropdown/__tests__/RegistrationActionsDropdown.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import copyToClipboard from 'copy-to-clipboard';
 import React from 'react';
 
@@ -20,6 +21,7 @@ import {
   mockedDeleteRegistrationResponse,
   registration,
 } from '../../../registration/__mocks__/editRegistrationPage';
+import { shouldExportSignupsAsExcel } from '../../../signups/__tests__/testUtils';
 import { mockedRegistrationUserResponse } from '../../../user/__mocks__/user';
 import RegistrationActionsDropdown, {
   RegistrationActionsDropdownProps,
@@ -27,6 +29,12 @@ import RegistrationActionsDropdown, {
 
 configure({ defaultHidden: true });
 vi.mock('copy-to-clipboard');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+  sessionStorage.clear();
+});
 
 const defaultProps: RegistrationActionsDropdownProps = {
   registration,
@@ -69,6 +77,7 @@ const getElement = (
     | 'copyLink'
     | 'delete'
     | 'edit'
+    | 'exportAsExcel'
     | 'markPresent'
     | 'menu'
     | 'showSignups'
@@ -83,6 +92,10 @@ const getElement = (
       return screen.getByRole('button', { name: 'Poista ilmoittautuminen' });
     case 'edit':
       return screen.getByRole('button', { name: 'Muokkaa' });
+    case 'exportAsExcel':
+      return screen.getByRole('button', {
+        name: 'Lataa osallistujalista (Excel)',
+      });
     case 'markPresent':
       return screen.getByRole('button', { name: 'Merkkaa läsnäolijat' });
     case 'menu':
@@ -196,6 +209,14 @@ test('should route to attendance list page when clicking mark present button', a
     )
   );
   expect(history.location.search).toBe('?returnPath=%2Fregistrations');
+});
+
+test('should export signups as an excel after clicking export as excel button', async () => {
+  renderComponent({ authContextValue });
+  await openMenu();
+  const exportAsExcelButton = getElement('exportAsExcel');
+
+  await shouldExportSignupsAsExcel({ exportAsExcelButton, registration });
 });
 
 test('should route to create registration page when clicking copy button', async () => {

--- a/src/domain/signups/SignupsPage.tsx
+++ b/src/domain/signups/SignupsPage.tsx
@@ -19,10 +19,12 @@ import Container from '../app/layout/container/Container';
 import MainContent from '../app/layout/mainContent/MainContent';
 import PageWrapper from '../app/layout/pageWrapper/PageWrapper';
 import TitleRow from '../app/layout/titleRow/TitleRow';
+import { useNotificationsContext } from '../app/notificationsContext/hooks/useNotificationsContext';
 import { useAuth } from '../auth/hooks/useAuth';
 import NotFound from '../notFound/NotFound';
 import useOrganizationAncestors from '../organization/hooks/useOrganizationAncestors';
 import {
+  exportSignupsAsExcel,
   getRegistrationActionButtonProps,
   getRegistrationFields,
 } from '../registration/utils';
@@ -56,6 +58,7 @@ const SignupsPage: React.FC<SignupsPageProps> = ({ registration }) => {
 
   const { isAuthenticated: authenticated } = useAuth();
   const publisher = getValue(registration.publisher, '');
+  const { addNotification } = useNotificationsContext();
 
   const { organizationAncestors } = useOrganizationAncestors(publisher);
   const { user } = useUser();
@@ -112,6 +115,20 @@ const SignupsPage: React.FC<SignupsPageProps> = ({ registration }) => {
       action: REGISTRATION_ACTIONS.EDIT_ATTENDANCE_LIST,
       authenticated,
       onClick: goToAttendanceListPage,
+      organizationAncestors,
+      registration,
+      t,
+      user,
+    }),
+    getRegistrationActionButtonProps({
+      action: REGISTRATION_ACTIONS.EXPORT_SIGNUPS_AS_EXCEL,
+      authenticated,
+      onClick: () =>
+        exportSignupsAsExcel({
+          addNotification,
+          registration,
+          uiLanguage: locale,
+        }),
       organizationAncestors,
       registration,
       t,

--- a/src/domain/signups/__tests__/SignupsPage.test.tsx
+++ b/src/domain/signups/__tests__/SignupsPage.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable max-len */
 import { MockedResponse } from '@apollo/client/testing';
 import { createMemoryHistory } from 'history';
@@ -23,6 +24,7 @@ import { mockedOrganizationAncestorsResponse } from '../../organization/__mocks_
 import { mockedNotFoundRegistrationResponse } from '../../registration/__mocks__/editRegistrationPage';
 import {
   mockedRegistrationResponse,
+  registration,
   registrationId,
 } from '../../registration/__mocks__/registration';
 import { mockedRegistrationUserResponse } from '../../user/__mocks__/user';
@@ -33,6 +35,7 @@ import {
   sendMessageValues,
 } from '../__mocks__/signupsPage';
 import SignupsPage from '../SignupsPage';
+import { shouldExportSignupsAsExcel } from './testUtils';
 
 configure({ defaultHidden: true });
 
@@ -56,6 +59,8 @@ const defaultMocks = [
 
 beforeEach(() => {
   vi.clearAllMocks();
+  localStorage.clear();
+  sessionStorage.clear();
 });
 
 const findCreateSignupButton = () =>
@@ -65,6 +70,7 @@ const getElement = (
   key:
     | 'attendeeTable'
     | 'createSignupButton'
+    | 'exportAsExcel'
     | 'menu'
     | 'toggle'
     | 'waitingListTable'
@@ -74,6 +80,10 @@ const getElement = (
       return screen.getByRole('table', { name: /osallistujat/i });
     case 'createSignupButton':
       return screen.getByRole('button', { name: /lisää osallistuja/i });
+    case 'exportAsExcel':
+      return screen.getByRole('button', {
+        name: 'Lataa osallistujalista (Excel)',
+      });
     case 'menu':
       return screen.getByRole('region', { name: /valinnat/i });
     case 'toggle':
@@ -227,4 +237,13 @@ test('should route to attendance list page when clicking mark present button', a
       `/fi/registrations/${registrationId}/attendance-list`
     )
   );
+});
+
+test('should export signups as an excel after clicking export as excel button', async () => {
+  const user = userEvent.setup();
+  renderComponent();
+  await loadingSpinnerIsNotInDocument(10000);
+  await openMenu();
+  const exportAsExcelButton = getElement('exportAsExcel');
+  await shouldExportSignupsAsExcel({ exportAsExcelButton, registration });
 });

--- a/src/domain/signups/__tests__/testUtils.ts
+++ b/src/domain/signups/__tests__/testUtils.ts
@@ -1,0 +1,35 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { RegistrationFieldsFragment } from '../../../generated/graphql';
+import { userEvent, waitFor } from '../../../utils/testUtils';
+import { setApiTokenToStorage } from '../../auth/utils';
+
+export const shouldExportSignupsAsExcel = async ({
+  exportAsExcelButton,
+  registration,
+}: {
+  exportAsExcelButton: HTMLElement;
+  registration: RegistrationFieldsFragment;
+}) => {
+  const user = userEvent.setup();
+
+  setApiTokenToStorage('api-token');
+  global.fetch = vi.fn(() =>
+    Promise.resolve({ blob: () => Promise.resolve({}), status: 200 })
+  ) as any;
+  const link: any = { click: vi.fn(), remove: vi.fn() };
+  global.URL.createObjectURL = vi.fn(() => 'https://test.com');
+  global.URL.revokeObjectURL = vi.fn();
+
+  const createElement = document.createElement;
+  document.createElement = vi.fn().mockImplementation(() => link);
+
+  await user.click(exportAsExcelButton);
+
+  await waitFor(() =>
+    expect(link.download).toBe(`registered_persons_${registration.id}`)
+  );
+  expect(link.href).toBe('https://test.com');
+  expect(link.click).toHaveBeenCalledTimes(1);
+  // Restore original createElement to avoid unexpected side effects
+  document.createElement = createElement;
+};

--- a/src/utils/__tests__/stripTrailingSlash.ts
+++ b/src/utils/__tests__/stripTrailingSlash.ts
@@ -1,0 +1,6 @@
+import stripTrailingSlash from '../stripTrailingSlash';
+
+test('should string trailing dash if needed', () => {
+  expect(stripTrailingSlash('https://test.com')).toBe('https://test.com');
+  expect(stripTrailingSlash('https://test.com/')).toBe('https://test.com');
+});

--- a/src/utils/stripTrailingSlash.ts
+++ b/src/utils/stripTrailingSlash.ts
@@ -1,0 +1,4 @@
+const stripTrailingSlash = (url: string) =>
+  url.endsWith('/') ? url.slice(0, -1) : url;
+
+export default stripTrailingSlash;


### PR DESCRIPTION
## Description :sparkles:
Support exporting registration signups as an Excel file
Allow users to export signups in registration list page, registration edit page and signups page

## Closes
[LINK-1661](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1661)

## Screenshots
<img width="1437" alt="Screenshot 2023-11-17 at 20 59 35" src="https://github.com/City-of-Helsinki/linkedcomponents-ui/assets/24706814/45134161-0c6e-4a59-96b3-cd8cfd5b2b04">

<img width="1416" alt="Screenshot 2023-11-17 at 20 56 56" src="https://github.com/City-of-Helsinki/linkedcomponents-ui/assets/24706814/7dc437ad-ab65-45f8-90cd-127c17f2d8b7">

<img width="1445" alt="Screenshot 2023-11-17 at 21 00 42" src="https://github.com/City-of-Helsinki/linkedcomponents-ui/assets/24706814/c4cd7ea9-018b-444b-b34c-e10a162fdf46">


[LINK-1661]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ