### PR TITLE
LINK-1715 | Info texts to signup form

### DIFF
--- a/src/domain/app/i18n/en.json
+++ b/src/domain/app/i18n/en.json
@@ -1847,6 +1847,7 @@
         "labelNativeLanguage": "Native language",
         "labelPhoneNumber": "Telephone number",
         "labelServiceLanguage": "Language of communication",
+        "notificationTextContactPersonInfo": "Enter your guardian's contact information here if you are a minor.",
         "placeholderEmail": "Enter your email address",
         "placeholderFirstName": "Enter the contact person's first name",
         "placeholderLastName": "Enter the contact person's last name",
@@ -1874,6 +1875,7 @@
       "placeholderExtraInfo": "Enter any additional information or request",
       "signup": {
         "buttonDeleteSignup": "Delete participant",
+        "helperExtraInfo": "Enter here the information about possible allergies, special diets, accessibility or other special needs, if they are information necessary for participating in the event. We forward the information to the event organizer so that the safety and accessibility of the event can be ensured. By entering the data, you give your consent to the processing of the data. You can withdraw your consent by deleting the data.",
         "labelCity": "City",
         "labelDateOfBirth": "Date of birth",
         "labelExtraInfo": "Additional information (optional)",

--- a/src/domain/app/i18n/fi.json
+++ b/src/domain/app/i18n/fi.json
@@ -1848,6 +1848,7 @@
         "labelNativeLanguage": "Äidinkieli",
         "labelPhoneNumber": "Puhelinnumero",
         "labelServiceLanguage": "Asiointikieli",
+        "notificationTextContactPersonInfo": "Jos olet alaikäinen, syötä tähän huoltajasi yhteystiedot.",
         "placeholderEmail": "Syötä sähköpostiosoite",
         "placeholderFirstName": "Syötä yhteyshenkilön etunimi",
         "placeholderLastName": "Syötä yhteyshenkilön sukunimi",
@@ -1875,6 +1876,7 @@
       "placeholderExtraInfo": "Syötä mahdollinen lisätieto tai toive",
       "signup": {
         "buttonDeleteSignup": "Poista osallistuja",
+        "helperExtraInfo": "Syötä tähän tiedot mahdollisista allergioista, erityisruokavalioista, esteettömyys- tai muista erityistarpeista, mikäli ne on tapahtumaan osallistumisen kannalta tarpeellisia tietoja. Välitämme tiedot tapahtumajärjestäjälle, jotta tapahtuman turvallisuus ja esteettömyys voidaan varmistaa. Syöttämällä tiedot annat suostumuksesi tietojen käsittelyyn. Antamasi suostumuksen voit peruuttaa poistamalla tiedot.",
         "labelCity": "Kaupunki",
         "labelDateOfBirth": "Syntymäaika",
         "labelExtraInfo": "Lisätietoa (valinnainen)",

--- a/src/domain/app/i18n/sv.json
+++ b/src/domain/app/i18n/sv.json
@@ -1848,6 +1848,7 @@
         "labelNativeLanguage": "Modersmål",
         "labelPhoneNumber": "Telefonnummer",
         "labelServiceLanguage": "Transaktionsspråk",
+        "notificationTextContactPersonInfo": "Ange din vårdnadshavares kontaktuppgifter här om du är minderårig.",
         "placeholderEmail": "Skriv in din mailadress",
         "placeholderFirstName": "Ange kontaktens förnamn",
         "placeholderLastName": "Ange kontaktens efternamn",
@@ -1858,7 +1859,7 @@
         "titleAdditionalInfo": "Ytterligare information",
         "titleCannotEditContactPerson": "Deltagargruppens kontaktpersonsuppgifter kan inte redigeras från denna sida.",
         "titleContactInfo": "Kontaktinformation",
-        "titleContacPersonInfo": "Information om kontaktperson",
+        "titleContactPersonInfo": "Information om kontaktperson",
         "titleNotifications": "Evenemangmeddelanden"
       },
       "freeAttendeeCapacity": "Tillgängliga platser",
@@ -1875,6 +1876,7 @@
       "placeholderExtraInfo": "Ange ytterligare information eller begäran",
       "signup": {
         "buttonDeleteSignup": "Ta bort deltagare",
+        "helperExtraInfo": "Ange här information om eventuella allergier, specialkost, tillgänglighet eller andra särskilda behov, om det är information som behövs för att delta i evenemanget. Vi vidarebefordrar informationen till arrangören för att evenemangets säkerhet och tillgänglighet kan säkerställas. Genom att ange uppgifterna ger du ditt samtycke till behandlingen av uppgifterna. Du kan återkalla ditt samtycke genom att radera uppgifterna.",
         "labelCity": "Staden",
         "labelDateOfBirth": "Födelsedatum",
         "labelExtraInfo": "Ytterligare information (valfritt)",

--- a/src/domain/signupGroup/signupGroupFormFields/SignupGroupFormFields.tsx
+++ b/src/domain/signupGroup/signupGroupFormFields/SignupGroupFormFields.tsx
@@ -117,7 +117,14 @@ const SignupGroupFormFields: React.FC<Props> = ({
         registration={registration}
         signupGroup={signupGroup}
       />
-      <h2>{getContactPersonTranslation('titleContactPersonInfo')}</h2>
+      <FormGroup>
+        <h2>{getContactPersonTranslation('titleContactPersonInfo')}</h2>
+      </FormGroup>
+      <Notification type="info">
+        <p style={{ margin: 0 }}>
+          {getContactPersonTranslation('notificationTextContactPersonInfo')}
+        </p>
+      </Notification>
       <Divider />
       {contactPersonFieldsDisabled && signup && (
         <CannotEditContactPersonNotification

--- a/src/domain/signupGroup/signupGroupFormFields/signups/signup/Signup.tsx
+++ b/src/domain/signupGroup/signupGroupFormFields/signups/signup/Signup.tsx
@@ -148,6 +148,7 @@ const Signup: React.FC<Props> = ({
           className={styles.extraInfoField}
           component={TextAreaField}
           disabled={disabled}
+          helperText={translateSignupText('helperExtraInfo')}
           label={translateSignupText('labelExtraInfo')}
           placeholder={translateSignupText('placeholderExtraInfo')}
           required={isSignupFieldRequired(


### PR DESCRIPTION
## Description :sparkles:
Add helper text for signup extra info field and notification for contact person section
Update user consent text

## Closes
[LINK-1715](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1715)

## Screenshots
<img width="739" alt="Screenshot 2023-11-23 at 14 11 23" src="https://github.com/City-of-Helsinki/linkedcomponents-ui/assets/24706814/6ee1f1cd-ef9b-4b4b-b99e-0ed49a85ee35">



[LINK-1715]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1715?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ