### PR TITLE
LINK-1772, LINK-1773 | Focus to notification heading after contact form submit

### DIFF
--- a/src/domain/feedback/successNotification/SuccessNotification.tsx
+++ b/src/domain/feedback/successNotification/SuccessNotification.tsx
@@ -1,0 +1,32 @@
+import { FC, useEffect, useRef } from 'react';
+
+import Notification from '../../../common/components/notification/Notification';
+import styles from './successNotification.module.scss';
+
+type Props = {
+  label: string;
+  text: string;
+};
+const SuccessNotification: FC<Props> = ({ label, text }) => {
+  const labelRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    labelRef.current?.focus();
+  }, []);
+
+  return (
+    <Notification
+      className={styles.successNotification}
+      label={
+        <div tabIndex={-1} ref={labelRef}>
+          {label}
+        </div>
+      }
+      type="success"
+    >
+      {text}
+    </Notification>
+  );
+};
+
+export default SuccessNotification;

--- a/src/domain/feedback/successNotification/successNotification.module.scss
+++ b/src/domain/feedback/successNotification/successNotification.module.scss
@@ -1,0 +1,3 @@
+.successNotification {
+  margin: var(--spacing-m) 0;
+}

--- a/src/domain/help/pages/askPermissionPage/AskPermissionPage.tsx
+++ b/src/domain/help/pages/askPermissionPage/AskPermissionPage.tsx
@@ -9,7 +9,6 @@ import SingleOrganizationSelectorField from '../../../../common/components/formF
 import TextAreaField from '../../../../common/components/formFields/textAreaField/TextAreaField';
 import TextInputField from '../../../../common/components/formFields/textInputField/TextInputField';
 import FormGroup from '../../../../common/components/formGroup/FormGroup';
-import Notification from '../../../../common/components/notification/Notification';
 import ServerErrorSummary from '../../../../common/components/serverErrorSummary/ServerErrorSummary';
 import { FeedbackInput } from '../../../../generated/graphql';
 import useIdWithPrefix from '../../../../hooks/useIdWithPrefix';
@@ -23,6 +22,7 @@ import PageWrapper from '../../../app/layout/pageWrapper/PageWrapper';
 import { useAuth } from '../../../auth/hooks/useAuth';
 import useFeedbackActions from '../../../feedback/hooks/useFeedbackActions';
 import useFeedbackServerErrors from '../../../feedback/hooks/useFeedbackServerErrors';
+import SuccessNotification from '../../../feedback/successNotification/SuccessNotification';
 import useAllOrganizations from '../../../organization/hooks/useAllOrganizations';
 import { getOrganizationFields } from '../../../organization/utils';
 import {
@@ -100,14 +100,6 @@ const AskPermissionPage: React.FC = () => {
 
         resetForm();
         await validateForm();
-
-        document
-          .getElementById(
-            getAskPermissionFormFocusableFieldId(
-              ASK_PERMISSION_FORM_FIELD.ORGANIZATION
-            )
-          )
-          ?.focus();
       },
     });
   };
@@ -167,12 +159,10 @@ const AskPermissionPage: React.FC = () => {
             <Form className={styles.contactForm} noValidate>
               <div id={successId}>
                 {success && (
-                  <Notification
+                  <SuccessNotification
                     label={t('helpPage.askPermissionPage.titleSuccess')}
-                    type="success"
-                  >
-                    {t('helpPage.askPermissionPage.textSuccess')}
-                  </Notification>
+                    text={t('helpPage.askPermissionPage.textSuccess')}
+                  />
                 )}
               </div>
               <ServerErrorSummary errors={serverErrorItems} />

--- a/src/domain/help/pages/askPermissionPage/__tests__/AskPermissionPage.test.tsx
+++ b/src/domain/help/pages/askPermissionPage/__tests__/AskPermissionPage.test.tsx
@@ -24,6 +24,7 @@ import {
   organizations,
 } from '../../../../organizations/__mocks__/organizationsPage';
 import { mockedUserResponse } from '../../../../user/__mocks__/user';
+import { isContactInfoSentSuccessfully } from '../../testUtils';
 import AskPermissionPage from '../AskPermissionPage';
 
 configure({ defaultHidden: true });
@@ -72,13 +73,6 @@ type GetElementKey =
   | 'organizationOption'
   | 'organizationToggleButton'
   | 'sendButton';
-
-const findElement = (key: 'success') => {
-  switch (key) {
-    case 'success':
-      return screen.findByRole('heading', { name: /kiitos yhteydenotostasi/i });
-  }
-};
 
 const getElement = (key: GetElementKey) => {
   switch (key) {
@@ -194,13 +188,12 @@ test('should succesfully send access request when user is signed in', async () =
 
   renderComponent({ mocks: [mockedPostFeedbackResponse], authContextValue });
 
-  const { organizationToggleButton } = await enterCommonValues();
+  await enterCommonValues();
 
   const sendButton = getElement('sendButton');
   await user.click(sendButton);
 
-  await waitFor(() => expect(organizationToggleButton).toHaveFocus());
-  await findElement('success');
+  await isContactInfoSentSuccessfully();
 });
 
 test('should show server errors', async () => {

--- a/src/domain/help/pages/contactPage/ContactPage.tsx
+++ b/src/domain/help/pages/contactPage/ContactPage.tsx
@@ -9,7 +9,6 @@ import SingleSelectField from '../../../../common/components/formFields/singleSe
 import TextAreaField from '../../../../common/components/formFields/textAreaField/TextAreaField';
 import TextInputField from '../../../../common/components/formFields/textInputField/TextInputField';
 import FormGroup from '../../../../common/components/formGroup/FormGroup';
-import Notification from '../../../../common/components/notification/Notification';
 import ServerErrorSummary from '../../../../common/components/serverErrorSummary/ServerErrorSummary';
 import { FeedbackInput } from '../../../../generated/graphql';
 import useIdWithPrefix from '../../../../hooks/useIdWithPrefix';
@@ -21,6 +20,7 @@ import PageWrapper from '../../../app/layout/pageWrapper/PageWrapper';
 import { useAuth } from '../../../auth/hooks/useAuth';
 import useFeedbackActions from '../../../feedback/hooks/useFeedbackActions';
 import useFeedbackServerErrors from '../../../feedback/hooks/useFeedbackServerErrors';
+import SuccessNotification from '../../../feedback/successNotification/SuccessNotification';
 import {
   CONTACT_FORM_BODY_MAX_LENGTH,
   CONTACT_FORM_FIELD,
@@ -84,6 +84,7 @@ const ContactPage: React.FC = () => {
       body: `${getPayloadStart(values)}${values.body}`,
     };
 
+    setSuccess(true);
     submitFeedback(payload, {
       onError: (error) => showServerErrors({ error }),
       onSuccess: async () => {
@@ -91,14 +92,6 @@ const ContactPage: React.FC = () => {
 
         resetForm();
         await validateForm();
-
-        document
-          .getElementById(
-            getContactFormFocusableFieldId(
-              authenticated ? CONTACT_FORM_FIELD.TOPIC : CONTACT_FORM_FIELD.NAME
-            )
-          )
-          ?.focus();
       },
     });
   };
@@ -181,12 +174,10 @@ const ContactPage: React.FC = () => {
             <Form className={styles.contactForm} noValidate>
               <div id={successId}>
                 {success && (
-                  <Notification
+                  <SuccessNotification
                     label={t('helpPage.contactPage.titleSuccess')}
-                    type="success"
-                  >
-                    {t('helpPage.contactPage.textSuccess')}
-                  </Notification>
+                    text={t('helpPage.contactPage.textSuccess')}
+                  />
                 )}
               </div>
               <ServerErrorSummary errors={serverErrorItems} />

--- a/src/domain/help/pages/contactPage/__tests__/ContactPage.test.tsx
+++ b/src/domain/help/pages/contactPage/__tests__/ContactPage.test.tsx
@@ -20,6 +20,8 @@ import {
   userEvent,
   waitFor,
 } from '../../../../../utils/testUtils';
+import { mockedUserResponse } from '../../../../user/__mocks__/user';
+import { isContactInfoSentSuccessfully } from '../../testUtils';
 import ContactPage from '../ContactPage';
 
 configure({ defaultHidden: true });
@@ -59,13 +61,6 @@ const mockedPostGuestFeedbackResponse: MockedResponse = {
     variables: postFeedbackVariables,
   },
   result: postGuestFeedbackResponse,
-};
-
-const findElement = (key: 'success') => {
-  switch (key) {
-    case 'success':
-      return screen.findByRole('heading', { name: /kiitos yhteydenotostasi/i });
-  }
 };
 
 type GetElementKey =
@@ -280,29 +275,30 @@ test('should succesfully send feedback when user is not signed in', async () => 
   await enterCommonValues();
   await user.click(sendButton);
 
-  await waitFor(() => expect(nameInput).toHaveFocus());
-  await findElement('success');
+  await isContactInfoSentSuccessfully();
 });
 
 test('should succesfully send feedback when user is signed in', async () => {
   const user = userEvent.setup();
 
-  renderComponent({ mocks: [mockedPostFeedbackResponse], authContextValue });
+  renderComponent({
+    mocks: [mockedUserResponse, mockedPostFeedbackResponse],
+    authContextValue,
+  });
 
   const sendButton = getElement('sendButton');
 
-  const { topicToggleButton } = await enterCommonValues();
+  await enterCommonValues();
   await user.click(sendButton);
 
-  await waitFor(() => expect(topicToggleButton).toHaveFocus());
-  await findElement('success');
+  await isContactInfoSentSuccessfully();
 });
 
 test('should show server errors', async () => {
   const user = userEvent.setup();
 
   renderComponent({
-    mocks: [mockedInvalidPostFeedbackResponse],
+    mocks: [mockedUserResponse, mockedInvalidPostFeedbackResponse],
     authContextValue,
   });
 

--- a/src/domain/help/pages/testUtils.ts
+++ b/src/domain/help/pages/testUtils.ts
@@ -1,0 +1,13 @@
+import { screen, waitFor, within } from '../../../utils/testUtils';
+
+const successHeadingText = 'Kiitos yhteydenotostasi.';
+
+export const findSuccessHeading = () =>
+  screen.findByRole('heading', { name: successHeadingText });
+
+export const isContactInfoSentSuccessfully = async () => {
+  const successHeading = await findSuccessHeading();
+  await waitFor(() =>
+    expect(within(successHeading).getByText(successHeadingText)).toHaveFocus()
+  );
+};


### PR DESCRIPTION
## Description
Focus to notification heading after successful ask permission or contact form submit to give screen readers feedback that the submit succeeded.

## Close
[LINK-1772](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1772)
[LINK-1773](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1773)

## Screenshot
<img width="1587" alt="Screenshot 2023-11-28 at 13 04 32" src="https://github.com/City-of-Helsinki/linkedcomponents-ui/assets/24706814/8fc78781-3212-450b-810a-b312ba908236">


[LINK-1772]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LINK-1773]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1773?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ