### PR TITLE
LINK-1756 | Add text-shadow to landing page hero heading

### DIFF
--- a/src/domain/landingPage/hero/hero.module.scss
+++ b/src/domain/landingPage/hero/hero.module.scss
@@ -35,6 +35,7 @@
       color: var(--hero-heading-color);
       margin: 0 0 var(--spacing-m);
       line-height: var(--lineheight-m);
+      text-shadow: 0 0 2px var(--color-black);
 
       @include max-width-column(8);
 


### PR DESCRIPTION
## Description
Add text-shadow to the heading of the landing page hero to improve the contrast and to solve accessibility issue caused by low contrast

## Closes
[LINK-1756](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1756)

## Screenshot
<img width="1109" alt="Screenshot 2023-11-30 at 14 28 39" src="https://github.com/City-of-Helsinki/linkedcomponents-ui/assets/24706814/d4ed139e-324d-4657-8097-e3a11bb0ba44">
