### PR TITLE
fix: events, same translations for navigation and breadcrumbs LINK-1749

### DIFF
--- a/src/domain/app/i18n/en.json
+++ b/src/domain/app/i18n/en.json
@@ -1555,7 +1555,7 @@
     "tabs": {
       "accessibilityStatement": "Accessibility Statement",
       "admin": "Admin",
-      "events": "Events",
+      "events": "My events",
       "help": "Support",
       "registrations": "Registration",
       "dataProtection": "Data Protection",

--- a/src/domain/app/i18n/fi.json
+++ b/src/domain/app/i18n/fi.json
@@ -1556,7 +1556,7 @@
     "tabs": {
       "accessibilityStatement": "Saavutettavuusseloste",
       "admin": "Hallinta",
-      "events": "Tapahtumat",
+      "events": "Omat tapahtumat",
       "help": "Tuki",
       "registrations": "Ilmoittautuminen",
       "dataProtection": "Tietosuoja",

--- a/src/domain/app/i18n/sv.json
+++ b/src/domain/app/i18n/sv.json
@@ -1556,7 +1556,7 @@
     "tabs": {
       "accessibilityStatement": "Tillgänglighets­utlåtande",
       "admin": "Admin",
-      "events": "Evenemang",
+      "events": "Mina evenemangen",
       "help": "Stöd",
       "registrations": "Registrering",
       "dataProtection": "Dataskydd",


### PR DESCRIPTION
## Description :sparkles:

On Events page should use same translation for navigation and breadcrumbs.

## Issues :bug:

### Closes :no_good_woman:

**[LINK-1749](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1749):**

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[LINK-1749]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ