### PR TITLE
LINK-1820 | Display enrolment start time when registration is closed

### DIFF
--- a/src/domain/app/i18n/en.json
+++ b/src/domain/app/i18n/en.json
@@ -1953,7 +1953,8 @@
       "capacityInWaitingList": "Registration for this event is still possible, but there are only {{count}} seat left in the queue.",
       "capacityInWaitingList_other": "Registration for this event is still possible, but there are only {{count}} seats left in the queue.",
       "capacityInWaitingListNoLimit": "Registration for this event is still possible, but there are only seats left in the queue.",
-      "closed": "Registration for this event is currently closed. Please try again later."
+      "closed": "Registration for this event is currently closed. Please try again later.",
+      "closedWithEnrolmentTime": "Registration for this event opens on {{openingDate}} at {{openingTime}}."
     }
   },
   "signupGroup": {

--- a/src/domain/app/i18n/fi.json
+++ b/src/domain/app/i18n/fi.json
@@ -1954,7 +1954,8 @@
       "capacityInWaitingList": "Ilmoittautuminen tähän tapahtumaan on vielä mahdollista, mutta jonopaikkoja on jäljellä vain {{count}} kpl.",
       "capacityInWaitingList_other": "Ilmoittautuminen tähän tapahtumaan on vielä mahdollista, mutta jonopaikkoja on jäljellä vain {{count}} kpl.",
       "capacityInWaitingListNoLimit": "Ilmoittautuminen tähän tapahtumaan on vielä mahdollista, mutta vain jonopaikkoja on jäljellä.",
-      "closed": "Ilmoittautuminen tähän tapahtumaan on tällä hetkellä suljettu. Kokeile myöhemmin uudelleen."
+      "closed": "Ilmoittautuminen tähän tapahtumaan on tällä hetkellä suljettu. Kokeile myöhemmin uudelleen.",
+      "closedWithEnrolmentTime": "Ilmoittautuminen tähän tapahtumaan avautuu {{openingDate}} klo {{openingTime}}."
     }
   },
   "signupGroup": {

--- a/src/domain/app/i18n/sv.json
+++ b/src/domain/app/i18n/sv.json
@@ -1953,7 +1953,8 @@
       "capacityInWaitingList": "Registrering för detta evenemang är fortfarande möjligt, men det är bara {{count}} plats kvar i kön.",
       "capacityInWaitingList_other": "Registrering för detta evenemang är fortfarande möjligt, men det är bara {{count}} platser kvar i kön.",
       "capacityInWaitingListNoLimit": "Registrering till detta evenemang är fortfarande möjlig, men det finns endast platser kvar i kön.",
-      "closed": "Registreringen för detta evenemang är för närvarande stängd. Vänligen försök igen senare."
+      "closed": "Registreringen för detta evenemang är för närvarande stängd. Vänligen försök igen senare.",
+      "closedWithEnrolmentTime": "Anmälan till detta evenemang öppnar den {{openingDate}} kl {{openingTime}}."
     }
   },
   "signupGroup": {

--- a/src/domain/registration/__tests__/utils.test.ts
+++ b/src/domain/registration/__tests__/utils.test.ts
@@ -593,6 +593,17 @@ describe('getRegistrationWarning', () => {
         }),
         i18n.t.bind(i18n)
       )
+    ).toBe('Ilmoittautuminen tähän tapahtumaan avautuu 4.11.2022 klo 00.00.');
+
+    expect(
+      getRegistrationWarning(
+        fakeRegistration({
+          ...singleRegistrationOverrides,
+          enrolmentStartTime: '',
+          enrolmentEndTime: new Date('2022-11-06').toISOString(),
+        }),
+        i18n.t.bind(i18n)
+      )
     ).toBe(
       'Ilmoittautuminen tähän tapahtumaan on tällä hetkellä suljettu. Kokeile myöhemmin uudelleen.'
     );

--- a/src/domain/registration/utils.ts
+++ b/src/domain/registration/utils.ts
@@ -9,7 +9,12 @@ import isNumber from 'lodash/isNumber';
 import omit from 'lodash/omit';
 
 import { NotificationProps } from '../../common/components/notification/Notification';
-import { FORM_NAMES, ROUTES, TIME_FORMAT_DATA } from '../../constants';
+import {
+  FORM_NAMES,
+  ROUTES,
+  TIME_FORMAT,
+  TIME_FORMAT_DATA,
+} from '../../constants';
 import {
   CreateRegistrationMutationInput,
   RegistrationFieldsFragment,
@@ -382,6 +387,13 @@ export const getRegistrationWarning = (
   const freeWaitlistCapacity = getFreeWaitingListCapacity(registration);
 
   if (!registrationOpen) {
+    if (registration.enrolmentStartTime) {
+      const enrolmentStartTime = new Date(registration.enrolmentStartTime);
+      return t('signup.warnings.closedWithEnrolmentTime', {
+        openingDate: formatDate(enrolmentStartTime),
+        openingTime: formatDate(enrolmentStartTime, TIME_FORMAT),
+      });
+    }
     return t('signup.warnings.closed');
   }
 


### PR DESCRIPTION
## Description :sparkles:
Display enrolment start time when registration is closed

## Closes
[LINK-1820](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1820)

## Screenshot
<img width="870" alt="Screenshot 2024-01-16 at 15 56 39" src="https://github.com/City-of-Helsinki/linkedcomponents-ui/assets/24706814/618cf3a2-5bab-4426-a36d-ed2fc8529847">


[LINK-1820]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1820?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ