### PR TITLE
LINK-1746 a11y footer link list

### DIFF
--- a/src/domain/app/footer/Footer.tsx
+++ b/src/domain/app/footer/Footer.tsx
@@ -21,16 +21,18 @@ import {
   areRegistrationRoutesAllowed,
 } from '../../user/permissions';
 import { useTheme } from '../theme/Theme';
+import {
+  navigationGroupAdmin,
+  navigationGroupEvents,
+  navigationGroupFeatures,
+  navigationGroupHome,
+  navigationGroupInstructions,
+  navigationGroupRegistrations,
+  navigationGroupSupport,
+  navigationGroupTechnology,
+  NO_FOOTER_PATHS,
+} from './constants';
 import styles from './footer.module.scss';
-
-const NO_FOOTER_PATHS: PathPattern[] = [
-  { path: ROUTES.ATTENDANCE_LIST },
-  { path: ROUTES.EDIT_EVENT },
-  { path: ROUTES.EDIT_REGISTRATION },
-  { path: ROUTES.EDIT_SIGNUP },
-  { path: ROUTES.EDIT_SIGNUP_GROUP },
-  { path: ROUTES.REGISTRATION_SIGNUPS },
-];
 
 const Footer: React.FC = () => {
   const { t } = useTranslation();
@@ -41,43 +43,6 @@ const Footer: React.FC = () => {
   const locale = useLocale();
   /* istanbul ignore next */
   const logoLanguage = locale === 'sv' ? 'sv' : 'fi';
-
-  const FOOTER_NAVIGATION_ITEMS = [
-    { labelKey: 'navigation.tabs.events', url: ROUTES.EVENTS },
-    {
-      labelKey: 'navigation.tabs.searchEvents',
-      url: ROUTES.SEARCH,
-    },
-    areRegistrationRoutesAllowed(user) && {
-      labelKey: 'navigation.tabs.registrations',
-      url: ROUTES.REGISTRATIONS,
-    },
-    featureFlagUtils.isFeatureEnabled('SHOW_ADMIN') &&
-      areAdminRoutesAllowed(user) && {
-        labelKey: 'navigation.tabs.admin',
-        url: ROUTES.ADMIN,
-      },
-    { labelKey: 'navigation.tabs.help', url: ROUTES.HELP },
-    {
-      labelKey: 'navigation.tabs.dataProtection',
-      url: DATA_PROTECTION_URL[locale],
-      externalUrl: true,
-    },
-    {
-      labelKey: 'navigation.tabs.accessibilityStatement',
-      url: ROUTES.ACCESSIBILITY_STATEMENT,
-    },
-  ].filter(skipFalsyType);
-
-  const navigationItems = FOOTER_NAVIGATION_ITEMS.map(
-    ({ labelKey, url, externalUrl }) => ({
-      label: t(labelKey),
-      url: !externalUrl ? `/${locale}${url}` : url,
-      externalUrl,
-      target: externalUrl ? '_blank' : '_self',
-    })
-  );
-
   const isHelpPage = pathname.startsWith(`/${locale}${ROUTES.HELP}`);
 
   const logo = useMemo(() => {
@@ -87,6 +52,8 @@ const Footer: React.FC = () => {
 
     return logoLanguage === 'sv' ? logoSvDark : logoFiDark;
   }, [isHelpPage, logoLanguage]);
+
+  const getLocalePath = (path: string) => `/${locale}${path}`;
 
   const goToPage =
     (pathname: string, external?: boolean) =>
@@ -131,22 +98,55 @@ const Footer: React.FC = () => {
           theme={theme.footer}
         >
           <HdsFooter.Navigation>
-            {navigationItems.map((item) => (
-              <HdsFooter.Link
-                key={item.url}
-                href={item.url}
-                label={item.label}
-                target={item.target}
-                onClick={goToPage(item.url, item.externalUrl)}
-              />
-            ))}
+            {[
+              navigationGroupHome,
+              navigationGroupEvents,
+              areRegistrationRoutesAllowed(user) &&
+                navigationGroupRegistrations,
+              featureFlagUtils.isFeatureEnabled('SHOW_ADMIN') &&
+                areAdminRoutesAllowed(user) &&
+                navigationGroupAdmin,
+              navigationGroupInstructions,
+              navigationGroupTechnology,
+              navigationGroupSupport,
+              navigationGroupFeatures,
+            ]
+              .filter(skipFalsyType)
+              .map((group) => (
+                <HdsFooter.NavigationGroup
+                  key={group.headingLink}
+                  headingLink={
+                    <HdsFooter.GroupHeading
+                      label={t(group.heading)}
+                      href={getLocalePath(group.headingLink)}
+                      onClick={goToPage(getLocalePath(group.headingLink))}
+                    />
+                  }
+                >
+                  {group.items?.map((item) => (
+                    <HdsFooter.Link
+                      key={getLocalePath(item.url)}
+                      href={getLocalePath(item.url)}
+                      label={t(item.label)}
+                      onClick={goToPage(getLocalePath(item.url))}
+                    />
+                  ))}
+                </HdsFooter.NavigationGroup>
+              ))}
           </HdsFooter.Navigation>
 
           <HdsFooter.Utilities>
             <HdsFooter.Link
-              href={`/${locale}${ROUTES.SUPPORT_CONTACT}`}
-              onClick={goToPage(`/${locale}${ROUTES.SUPPORT_CONTACT}`)}
-              label={t('common.feedback.text')}
+              href={DATA_PROTECTION_URL[locale]}
+              onClick={goToPage(DATA_PROTECTION_URL[locale], true)}
+              label={t('navigation.tabs.dataProtection')}
+              external
+              target="_blank"
+            />
+            <HdsFooter.Link
+              href={getLocalePath(ROUTES.ACCESSIBILITY_STATEMENT)}
+              onClick={goToPage(getLocalePath(ROUTES.ACCESSIBILITY_STATEMENT))}
+              label={t('navigation.tabs.accessibilityStatement')}
             />
           </HdsFooter.Utilities>
           <HdsFooter.Base

--- a/src/domain/app/footer/constants.ts
+++ b/src/domain/app/footer/constants.ts
@@ -1,0 +1,175 @@
+import { PathPattern } from 'react-router';
+
+import { ROUTES } from '../../../constants';
+
+type NavigationGroup = {
+  heading: string;
+  headingLink: string;
+  items?: NavigationGroupItem[];
+};
+
+type NavigationGroupItem = {
+  label: string;
+  url: string;
+};
+
+const NAVIGATION_GROUP_ITEMS_MAIN: NavigationGroupItem[] = [
+  {
+    label: 'navigation.tabs.searchEvents',
+    url: ROUTES.SEARCH,
+  },
+];
+
+const NAVIGATION_GROUP_ITEMS_EVENTS: NavigationGroupItem[] = [
+  {
+    label: 'createEventPage.title.general',
+    url: ROUTES.CREATE_EVENT,
+  },
+];
+
+const NAVIGATION_GROUP_ITEMS_REGISTRATIONS: NavigationGroupItem[] = [
+  {
+    label: 'createRegistrationPage.title',
+    url: ROUTES.CREATE_REGISTRATION,
+  },
+];
+
+const NAVIGATION_GROUP_ITEMS_ADMIN: NavigationGroupItem[] = [
+  {
+    label: 'keywordsPage.title',
+    url: ROUTES.KEYWORDS,
+  },
+  {
+    label: 'keywordSetsPage.title',
+    url: ROUTES.KEYWORD_SETS,
+  },
+  {
+    label: 'imagesPage.title',
+    url: ROUTES.IMAGES,
+  },
+  {
+    label: 'organizationsPage.title',
+    url: ROUTES.ORGANIZATIONS,
+  },
+  {
+    label: 'placesPage.title',
+    url: ROUTES.PLACES,
+  },
+];
+
+const NAVIGATION_GROUP_ITEMS_SUPPORT: NavigationGroupItem[] = [
+  {
+    label: 'helpPage.sideNavigation.labelTermsOfUse',
+    url: ROUTES.SUPPORT_TERMS_OF_USE,
+  },
+  {
+    label: 'helpPage.sideNavigation.labelContact',
+    url: ROUTES.SUPPORT_CONTACT,
+  },
+  {
+    label: 'helpPage.sideNavigation.labelAskPermission',
+    url: ROUTES.SUPPORT_ASK_PERMISSION,
+  },
+];
+
+const NAVIGATION_GROUP_ITEMS_INSTRUCTIONS: NavigationGroupItem[] = [
+  {
+    label: 'helpPage.sideNavigation.labelGeneral',
+    url: ROUTES.INSTRUCTIONS_GENERAL,
+  },
+  {
+    label: 'helpPage.sideNavigation.labelPlatform',
+    url: ROUTES.INSTRUCTIONS_PLATFORM,
+  },
+  {
+    label: 'helpPage.sideNavigation.labelControlPanel',
+    url: ROUTES.INSTRUCTIONS_CONTROL_PANEL,
+  },
+  {
+    label: 'helpPage.sideNavigation.labelRegistrationInstructions',
+    url: ROUTES.INSTRUCTIONS_REGISTRATION,
+  },
+  {
+    label: 'helpPage.sideNavigation.labelFaq',
+    url: ROUTES.INSTRUCTIONS_FAQ,
+  },
+];
+
+const NAVIGATION_GROUP_ITEMS_TECHNOLOGY: NavigationGroupItem[] = [
+  {
+    label: 'helpPage.sideNavigation.labelGeneral',
+    url: ROUTES.TECHNOLOGY_GENERAL,
+  },
+  {
+    label: 'helpPage.sideNavigation.labelApi',
+    url: ROUTES.TECHNOLOGY_API,
+  },
+  {
+    label: 'helpPage.sideNavigation.labelImageRights',
+    url: ROUTES.TECHNOLOGY_IMAGE_RIGHTS,
+  },
+  {
+    label: 'helpPage.sideNavigation.labelSourceCode',
+    url: ROUTES.TECHNOLOGY_SOURCE_CODE,
+  },
+  {
+    label: 'helpPage.sideNavigation.labelDocumentation',
+    url: ROUTES.TECHNOLOGY_DOCUMENTATION,
+  },
+];
+
+export const NO_FOOTER_PATHS: PathPattern[] = [
+  { path: ROUTES.ATTENDANCE_LIST },
+  { path: ROUTES.EDIT_EVENT },
+  { path: ROUTES.EDIT_REGISTRATION },
+  { path: ROUTES.EDIT_SIGNUP },
+  { path: ROUTES.EDIT_SIGNUP_GROUP },
+  { path: ROUTES.REGISTRATION_SIGNUPS },
+];
+
+export const navigationGroupHome: NavigationGroup = {
+  heading: 'common.home',
+  headingLink: ROUTES.HOME,
+  items: NAVIGATION_GROUP_ITEMS_MAIN,
+};
+
+export const navigationGroupEvents: NavigationGroup = {
+  heading: 'navigation.tabs.events',
+  headingLink: ROUTES.EVENTS,
+  items: NAVIGATION_GROUP_ITEMS_EVENTS,
+};
+
+export const navigationGroupRegistrations: NavigationGroup = {
+  heading: 'navigation.tabs.registrations',
+  headingLink: ROUTES.REGISTRATIONS,
+  items: NAVIGATION_GROUP_ITEMS_REGISTRATIONS,
+};
+
+export const navigationGroupAdmin: NavigationGroup = {
+  heading: 'navigation.tabs.admin',
+  headingLink: ROUTES.ADMIN,
+  items: NAVIGATION_GROUP_ITEMS_ADMIN,
+};
+
+export const navigationGroupInstructions: NavigationGroup = {
+  heading: 'helpPage.sideNavigation.labelInstructions',
+  headingLink: ROUTES.INSTRUCTIONS,
+  items: NAVIGATION_GROUP_ITEMS_INSTRUCTIONS,
+};
+
+export const navigationGroupTechnology: NavigationGroup = {
+  heading: 'helpPage.sideNavigation.labelTechnology',
+  headingLink: ROUTES.TECHNOLOGY,
+  items: NAVIGATION_GROUP_ITEMS_TECHNOLOGY,
+};
+
+export const navigationGroupSupport: NavigationGroup = {
+  heading: 'helpPage.sideNavigation.labelSupport',
+  headingLink: ROUTES.SUPPORT,
+  items: NAVIGATION_GROUP_ITEMS_SUPPORT,
+};
+
+export const navigationGroupFeatures: NavigationGroup = {
+  heading: 'helpPage.sideNavigation.labelFeatures',
+  headingLink: ROUTES.FEATURES,
+};

--- a/src/domain/app/i18n/en.json
+++ b/src/domain/app/i18n/en.json
@@ -1276,7 +1276,7 @@
       "labelControlPanel": "Control panel",
       "labelDocumentation": "Documentation",
       "labelFaq": "FAQ",
-      "labelFeatures": "Searvice features",
+      "labelFeatures": "Service features",
       "labelGeneral": "General",
       "labelImageRights": "Image rights",
       "labelInstructions": "Instructions",


### PR DESCRIPTION
## Description :sparkles:

As of now, Linked events does not have a search functionality for navigating pages. Adding 
sitemap / link list to the footer.

## Issues :bug:

### Closes :no_good_woman:

**[LINK-1746](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1746):**

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

<img width="1505" alt="Screenshot 2024-01-17 at 12 23 06" src="https://github.com/City-of-Helsinki/linkedcomponents-ui/assets/66477579/2cd0afa9-d5ac-465d-af19-e5a6fdf39f90">

## Additional notes :spiral_notepad:


[LINK-1746]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1746?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ