### PR TITLE
fix: search events and support pages, add breadcrumbs LINK-1747

### DIFF
--- a/src/domain/app/layout/titleRow/TitleRow.tsx
+++ b/src/domain/app/layout/titleRow/TitleRow.tsx
@@ -14,6 +14,7 @@ type TitleRowProps = {
   buttonWrapperClassName?: string;
   editingInfo?: React.ReactElement;
   title: string;
+  titleClassName?: string;
 };
 
 const TitleRow = ({
@@ -24,6 +25,7 @@ const TitleRow = ({
   buttonWrapperClassName,
   editingInfo,
   title,
+  titleClassName,
 }: TitleRowProps): React.ReactElement => {
   const { t } = useTranslation();
   return (
@@ -34,7 +36,7 @@ const TitleRow = ({
         </div>
       )}
       <div className={styles.titleRow}>
-        <div className={styles.title}>
+        <div className={classNames(styles.title, titleClassName)}>
           <h1>{title}</h1>
           {editingInfo}
         </div>

--- a/src/domain/app/routes/helpPageRoutes/__tests__/HelpPageRoutes.test.tsx
+++ b/src/domain/app/routes/helpPageRoutes/__tests__/HelpPageRoutes.test.tsx
@@ -153,16 +153,17 @@ const generalInstructionCases: [Language, PageValues][] = [
       title: 'Tuki - Linked Events',
     },
   ],
-  [
-    'sv',
-    {
-      description: '',
-      expectedRoute: '/sv/help/instructions/general',
-      keywords: '',
-      pageTitle: 'Allmänt',
-      title: '',
-    },
-  ],
+  // TODO: Add this when Swedish is added to supported languages
+  // [
+  //   'sv',
+  //   {
+  //     description: '',
+  //     expectedRoute: '/sv/help/instructions/general',
+  //     keywords: '',
+  //     pageTitle: 'Allmänt',
+  //     title: '',
+  //   },
+  // ],
 ];
 
 it.each(generalInstructionCases)(
@@ -240,16 +241,17 @@ const controlPanelCases: [Language, PageValues][] = [
       title: 'Hallintapaneeli - Linked Events',
     },
   ],
-  [
-    'sv',
-    {
-      description: '',
-      expectedRoute: '/sv/help/instructions/control-panel',
-      keywords: '',
-      pageTitle: 'Kontrollpanel',
-      title: '',
-    },
-  ],
+  // TODO: Add this when Swedish is added to supported languages
+  // [
+  //   'sv',
+  //   {
+  //     description: '',
+  //     expectedRoute: '/sv/help/instructions/control-panel',
+  //     keywords: '',
+  //     pageTitle: 'Kontrollpanel',
+  //     title: '',
+  //   },
+  // ],
 ];
 
 it.each(controlPanelCases)(
@@ -288,16 +290,17 @@ const registrationInstructionsCases: [Language, PageValues][] = [
       title: 'Linked Registration -ohje - Linked Events',
     },
   ],
-  [
-    'sv',
-    {
-      description: '',
-      expectedRoute: '/sv/help/instructions/registration',
-      keywords: '',
-      pageTitle: 'Linked Registration instruktioner',
-      title: '',
-    },
-  ],
+  // TODO: Add this when Swedish is added to supported languages
+  // [
+  //   'sv',
+  //   {
+  //     description: '',
+  //     expectedRoute: '/sv/help/instructions/registration',
+  //     keywords: '',
+  //     pageTitle: 'Linked Registration instruktioner',
+  //     title: '',
+  //   },
+  // ],
 ];
 
 it.each(registrationInstructionsCases)(
@@ -379,16 +382,17 @@ const generalTechnologyCases: [Language, PageValues][] = [
       title: 'Teknologia - Linked Events',
     },
   ],
-  [
-    'sv',
-    {
-      description: '',
-      expectedRoute: '/sv/help/technology/general',
-      keywords: '',
-      pageTitle: 'Allmänt',
-      title: '',
-    },
-  ],
+  // TODO: Add this when Swedish is added to supported languages
+  // [
+  //   'sv',
+  //   {
+  //     description: '',
+  //     expectedRoute: '/sv/help/technology/general',
+  //     keywords: '',
+  //     pageTitle: 'Allmänt',
+  //     title: '',
+  //   },
+  // ],
 ];
 
 it.each(generalTechnologyCases)(
@@ -423,16 +427,17 @@ const apiCases: [Language, PageValues][] = [
       title: 'Rajapinta - Linked Events',
     },
   ],
-  [
-    'sv',
-    {
-      description: '',
-      expectedRoute: '/sv/help/technology/api',
-      keywords: '',
-      pageTitle: 'API',
-      title: '',
-    },
-  ],
+  // TODO: Add this when Swedish is added to supported languages
+  // [
+  //   'sv',
+  //   {
+  //     description: '',
+  //     expectedRoute: '/sv/help/technology/api',
+  //     keywords: '',
+  //     pageTitle: 'API',
+  //     title: '',
+  //   },
+  // ],
 ];
 
 it.each(apiCases)(
@@ -451,7 +456,7 @@ const imageRightsCases: [Language, PageValues][] = [
       expectedRoute: '/en/help/technology/image-rights',
       keywords:
         'image, rights, license, linked, events, event, management, api, admin, Helsinki, Finland',
-      pageTitle: 'Image rights',
+      pageTitle: 'Image Rights',
       title: 'Image Rights - Linked Events',
     },
   ],
@@ -467,16 +472,17 @@ const imageRightsCases: [Language, PageValues][] = [
       title: 'Kuvaoikeudet - Linked Events',
     },
   ],
-  [
-    'sv',
-    {
-      description: '',
-      expectedRoute: '/sv/help/technology/image-rights',
-      keywords: '',
-      pageTitle: 'Bildrättigheter',
-      title: '',
-    },
-  ],
+  // TODO: Add this when Swedish is added to supported languages
+  // [
+  //   'sv',
+  //   {
+  //     description: '',
+  //     expectedRoute: '/sv/help/technology/image-rights',
+  //     keywords: '',
+  //     pageTitle: 'Bildrättigheter',
+  //     title: '',
+  //   },
+  // ],
 ];
 
 it.each(imageRightsCases)(
@@ -513,16 +519,17 @@ const sourceCodeCases: [Language, PageValues][] = [
       title: 'Lähdekoodi - Linked Events',
     },
   ],
-  [
-    'sv',
-    {
-      description: '',
-      expectedRoute: '/sv/help/technology/source-code',
-      keywords: '',
-      pageTitle: 'Källkod',
-      title: '',
-    },
-  ],
+  // TODO: Add this when Swedish is added to supported languages
+  // [
+  //   'sv',
+  //   {
+  //     description: '',
+  //     expectedRoute: '/sv/help/technology/source-code',
+  //     keywords: '',
+  //     pageTitle: 'Källkod',
+  //     title: '',
+  //   },
+  // ],
 ];
 
 it.each(sourceCodeCases)(
@@ -558,16 +565,17 @@ const documentationCases: [Language, PageValues][] = [
       title: 'Dokumentaatio - Linked Events',
     },
   ],
-  [
-    'sv',
-    {
-      description: '',
-      expectedRoute: '/sv/help/technology/documentation',
-      keywords: '',
-      pageTitle: 'Dokumentation',
-      title: '',
-    },
-  ],
+  // TODO: Add this when Swedish is added to supported languages
+  // [
+  //   'sv',
+  //   {
+  //     description: '',
+  //     expectedRoute: '/sv/help/technology/documentation',
+  //     keywords: '',
+  //     pageTitle: 'Dokumentation',
+  //     title: '',
+  //   },
+  // ],
 ];
 
 it.each(documentationCases)(
@@ -604,16 +612,17 @@ const termsOfUseCases: [Language, PageValues][] = [
       title: 'Tietosuoja ja käyttöehdot - Linked Events',
     },
   ],
-  [
-    'sv',
-    {
-      description: 'Dataskydd och användarvillkor för Linked Events.',
-      expectedRoute: '/sv/help/support/terms-of-use',
-      keywords: '',
-      pageTitle: 'Dataskydd och användarvillkor',
-      title: '',
-    },
-  ],
+  // TODO: Add this when Swedish is added to supported languages
+  // [
+  //   'sv',
+  //   {
+  //     description: 'Dataskydd och användarvillkor för Linked Events.',
+  //     expectedRoute: '/sv/help/support/terms-of-use',
+  //     keywords: '',
+  //     pageTitle: 'Dataskydd och användarvillkor',
+  //     title: '',
+  //   },
+  // ],
 ];
 
 it.each(termsOfUseCases)(
@@ -736,16 +745,17 @@ const featuresCases: [Language, PageValues][] = [
       title: 'Palvelun ominaisuudet - Linked Events',
     },
   ],
-  [
-    'sv',
-    {
-      description: '',
-      expectedRoute: '/sv/help/features',
-      keywords: '',
-      pageTitle: 'Tjänstens egenskaper',
-      title: '',
-    },
-  ],
+  // TODO: Add this when Swedish is added to supported languages
+  // [
+  //   'sv',
+  //   {
+  //     description: '',
+  //     expectedRoute: '/sv/help/features',
+  //     keywords: '',
+  //     pageTitle: 'Tjänstens egenskaper',
+  //     title: '',
+  //   },
+  // ],
 ];
 
 it.each(featuresCases)(

--- a/src/domain/app/routes/helpPageRoutes/__tests__/HelpPageRoutes.test.tsx
+++ b/src/domain/app/routes/helpPageRoutes/__tests__/HelpPageRoutes.test.tsx
@@ -154,16 +154,6 @@ const generalInstructionCases: [Language, PageValues][] = [
     },
   ],
   // TODO: Add this when Swedish is added to supported languages
-  // [
-  //   'sv',
-  //   {
-  //     description: '',
-  //     expectedRoute: '/sv/help/instructions/general',
-  //     keywords: '',
-  //     pageTitle: 'Allmänt',
-  //     title: '',
-  //   },
-  // ],
 ];
 
 it.each(generalInstructionCases)(
@@ -198,16 +188,6 @@ const platformCases: [Language, PageValues][] = [
     },
   ],
   // TODO: Add this when Swedish is supported
-  // [
-  //   'sv',
-  //   {
-  //     description: '',
-  //     expectedRoute: '/sv/help/instructions/platform',
-  //     keywords: '',
-  //     pageTitle: 'Plattform',
-  //     title: '',
-  //   },
-  // ],
 ];
 
 it.each(platformCases)(
@@ -242,16 +222,6 @@ const controlPanelCases: [Language, PageValues][] = [
     },
   ],
   // TODO: Add this when Swedish is added to supported languages
-  // [
-  //   'sv',
-  //   {
-  //     description: '',
-  //     expectedRoute: '/sv/help/instructions/control-panel',
-  //     keywords: '',
-  //     pageTitle: 'Kontrollpanel',
-  //     title: '',
-  //   },
-  // ],
 ];
 
 it.each(controlPanelCases)(
@@ -291,16 +261,6 @@ const registrationInstructionsCases: [Language, PageValues][] = [
     },
   ],
   // TODO: Add this when Swedish is added to supported languages
-  // [
-  //   'sv',
-  //   {
-  //     description: '',
-  //     expectedRoute: '/sv/help/instructions/registration',
-  //     keywords: '',
-  //     pageTitle: 'Linked Registration instruktioner',
-  //     title: '',
-  //   },
-  // ],
 ];
 
 it.each(registrationInstructionsCases)(
@@ -338,16 +298,6 @@ const faqCases: [Language, PageValues][] = [
     },
   ],
   // TODO: Add this when Swedish is supported
-  // [
-  //   'sv',
-  //   {
-  //     description: '',
-  //     expectedRoute: '/sv/help/instructions/faq',
-  //     keywords: '',
-  //     pageTitle: 'Vanliga frågor',
-  //     title: '',
-  //   },
-  // ],
 ];
 
 it.each(faqCases)(
@@ -383,16 +333,6 @@ const generalTechnologyCases: [Language, PageValues][] = [
     },
   ],
   // TODO: Add this when Swedish is added to supported languages
-  // [
-  //   'sv',
-  //   {
-  //     description: '',
-  //     expectedRoute: '/sv/help/technology/general',
-  //     keywords: '',
-  //     pageTitle: 'Allmänt',
-  //     title: '',
-  //   },
-  // ],
 ];
 
 it.each(generalTechnologyCases)(
@@ -428,16 +368,6 @@ const apiCases: [Language, PageValues][] = [
     },
   ],
   // TODO: Add this when Swedish is added to supported languages
-  // [
-  //   'sv',
-  //   {
-  //     description: '',
-  //     expectedRoute: '/sv/help/technology/api',
-  //     keywords: '',
-  //     pageTitle: 'API',
-  //     title: '',
-  //   },
-  // ],
 ];
 
 it.each(apiCases)(
@@ -473,16 +403,6 @@ const imageRightsCases: [Language, PageValues][] = [
     },
   ],
   // TODO: Add this when Swedish is added to supported languages
-  // [
-  //   'sv',
-  //   {
-  //     description: '',
-  //     expectedRoute: '/sv/help/technology/image-rights',
-  //     keywords: '',
-  //     pageTitle: 'Bildrättigheter',
-  //     title: '',
-  //   },
-  // ],
 ];
 
 it.each(imageRightsCases)(
@@ -520,16 +440,6 @@ const sourceCodeCases: [Language, PageValues][] = [
     },
   ],
   // TODO: Add this when Swedish is added to supported languages
-  // [
-  //   'sv',
-  //   {
-  //     description: '',
-  //     expectedRoute: '/sv/help/technology/source-code',
-  //     keywords: '',
-  //     pageTitle: 'Källkod',
-  //     title: '',
-  //   },
-  // ],
 ];
 
 it.each(sourceCodeCases)(
@@ -566,16 +476,6 @@ const documentationCases: [Language, PageValues][] = [
     },
   ],
   // TODO: Add this when Swedish is added to supported languages
-  // [
-  //   'sv',
-  //   {
-  //     description: '',
-  //     expectedRoute: '/sv/help/technology/documentation',
-  //     keywords: '',
-  //     pageTitle: 'Dokumentation',
-  //     title: '',
-  //   },
-  // ],
 ];
 
 it.each(documentationCases)(
@@ -613,16 +513,6 @@ const termsOfUseCases: [Language, PageValues][] = [
     },
   ],
   // TODO: Add this when Swedish is added to supported languages
-  // [
-  //   'sv',
-  //   {
-  //     description: 'Dataskydd och användarvillkor för Linked Events.',
-  //     expectedRoute: '/sv/help/support/terms-of-use',
-  //     keywords: '',
-  //     pageTitle: 'Dataskydd och användarvillkor',
-  //     title: '',
-  //   },
-  // ],
 ];
 
 it.each(termsOfUseCases)(
@@ -658,16 +548,6 @@ const contactCases: [Language, PageValues][] = [
     },
   ],
   // TODO: Add this when Swedish is supported
-  // [
-  //   'sv',
-  //   {
-  //     description: '',
-  //     expectedRoute: '/sv/help/support/contact',
-  //     keywords: '',
-  //     pageTitle: 'Ta kontakt',
-  //     title: '',
-  //   },
-  // ],
 ];
 
 it.each(contactCases)(
@@ -701,16 +581,6 @@ const askPermissionCases: [Language, PageValues][] = [
     },
   ],
   // TODO: Add this when Swedish is added to supported languages
-  // [
-  //   'sv',
-  //   {
-  //     description: '',
-  //     expectedRoute: '/sv/help/support/ask-permission',
-  //     keywords: '',
-  //     pageTitle: 'Begära tillgång',
-  //     title: '',
-  //   },
-  // ],
 ];
 
 it.each(askPermissionCases)(
@@ -746,16 +616,6 @@ const featuresCases: [Language, PageValues][] = [
     },
   ],
   // TODO: Add this when Swedish is added to supported languages
-  // [
-  //   'sv',
-  //   {
-  //     description: '',
-  //     expectedRoute: '/sv/help/features',
-  //     keywords: '',
-  //     pageTitle: 'Tjänstens egenskaper',
-  //     title: '',
-  //   },
-  // ],
 ];
 
 it.each(featuresCases)(

--- a/src/domain/eventSearch/searchPanel/SearchPanel.tsx
+++ b/src/domain/eventSearch/searchPanel/SearchPanel.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router';
 
+import Breadcrumb from '../../../common/components/breadcrumb/Breadcrumb';
 import Button from '../../../common/components/button/Button';
 import DateSelectorDropdown, {
   DATE_FIELDS,
@@ -17,6 +18,7 @@ import { OptionType } from '../../../types';
 import getValue from '../../../utils/getValue';
 import skipFalsyType from '../../../utils/skipFalsyType';
 import Container from '../../app/layout/container/Container';
+import TitleRow from '../../app/layout/titleRow/TitleRow';
 import { useTheme } from '../../app/theme/Theme';
 import { EVENT_TYPE } from '../../event/constants';
 import useEventTypeOptions from '../../event/hooks/useEventTypeOptions';
@@ -101,6 +103,19 @@ const SearchPanel: React.FC = () => {
         >
           <section className={styles.searchPanelWrapper}>
             <Container withOffset={true}>
+              <TitleRow
+                breadcrumbClassName={styles.titleRow}
+                breadcrumb={
+                  <Breadcrumb
+                    list={[
+                      { title: t('common.home'), path: ROUTES.HOME },
+                      { title: t(`eventSearchPage.pageTitle`), path: null },
+                    ]}
+                  />
+                }
+                title={t('eventSearchPage.pageTitle')}
+                titleClassName={styles.titleRow}
+              />
               <div className={styles.searchRow}>
                 <div className={styles.inputWrapper}>
                   <SearchInput

--- a/src/domain/eventSearch/searchPanel/searchPanel.module.scss
+++ b/src/domain/eventSearch/searchPanel/searchPanel.module.scss
@@ -14,7 +14,7 @@
     position: relative;
     z-index: 2;
     background-color: var(--search-panel-background-color);
-    padding: var(--spacing-4-xl) 0;
+    padding: 0 0 var(--spacing-4-xl);
   }
 
   .button {
@@ -35,9 +35,14 @@
     --focus-outline-color: var(--search-panel-button-color);
   }
 
+  .titleRow {
+    color: var(--color-white);
+  }
+
   .searchRow {
     display: grid;
     grid-gap: var(--spacing-m);
+    margin-top: var(--spacing-s);
 
     @include medium-up {
       display: flex;

--- a/src/domain/help/pages/apiPage/ApiPage.tsx
+++ b/src/domain/help/pages/apiPage/ApiPage.tsx
@@ -1,13 +1,17 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 
+import Breadcrumb from '../../../../common/components/breadcrumb/Breadcrumb';
 import ExternalLink from '../../../../common/components/externalLink/ExternalLink';
 import { ROUTES } from '../../../../constants';
 import useLocale from '../../../../hooks/useLocale';
 import { Language } from '../../../../types';
 import PageWrapper from '../../../app/layout/pageWrapper/PageWrapper';
+import TitleRow from '../../../app/layout/titleRow/TitleRow';
 
 const ApiPage: React.FC = () => {
+  const { t } = useTranslation();
   const locale = useLocale();
 
   const getContent = (locale: Language) => {
@@ -15,7 +19,6 @@ const ApiPage: React.FC = () => {
       case 'en':
         return (
           <>
-            <h1>API</h1>
             <p>
               The Linked Events API contains event information about the City of
               Helsinki's events, courses and volunteer assignments. Some of the
@@ -52,7 +55,6 @@ const ApiPage: React.FC = () => {
       case 'fi':
         return (
           <>
-            <h1>Rajapinta</h1>
             <p>
               Linked Events -rajapinta pitää sisällään tapahtumatietoja
               Helsingin kaupungin tapahtumista, kursseista ja
@@ -92,7 +94,6 @@ const ApiPage: React.FC = () => {
       case 'sv':
         return (
           <>
-            <h1>API</h1>
             <p>
               Linked Events API innehåller evenemangsinformation om Helsingfors
               stads evenemang, kurser och volontäruppdrag. En del av API's
@@ -136,6 +137,25 @@ const ApiPage: React.FC = () => {
       keywords={['keywords.help', 'keywords.documentation']}
       title="helpPage.pageTitleApi"
     >
+      <TitleRow
+        breadcrumb={
+          <Breadcrumb
+            list={[
+              { title: t('common.home'), path: ROUTES.HOME },
+              { title: t('helpPage.pageTitle'), path: ROUTES.HELP },
+              {
+                title: t('helpPage.pageTitleTechnology'),
+                path: ROUTES.TECHNOLOGY,
+              },
+              {
+                title: t('helpPage.pageTitleApi'),
+                path: null,
+              },
+            ]}
+          />
+        }
+        title={t('helpPage.pageTitleApi')}
+      />
       {getContent(locale)}
     </PageWrapper>
   );

--- a/src/domain/help/pages/askPermissionPage/AskPermissionPage.tsx
+++ b/src/domain/help/pages/askPermissionPage/AskPermissionPage.tsx
@@ -4,12 +4,14 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { ValidationError } from 'yup';
 
+import Breadcrumb from '../../../../common/components/breadcrumb/Breadcrumb';
 import Button from '../../../../common/components/button/Button';
 import SingleOrganizationSelectorField from '../../../../common/components/formFields/singleOrganizationSelectorField/SingleOrganizationSelectorField';
 import TextAreaField from '../../../../common/components/formFields/textAreaField/TextAreaField';
 import TextInputField from '../../../../common/components/formFields/textInputField/TextInputField';
 import FormGroup from '../../../../common/components/formGroup/FormGroup';
 import ServerErrorSummary from '../../../../common/components/serverErrorSummary/ServerErrorSummary';
+import { ROUTES } from '../../../../constants';
 import { FeedbackInput } from '../../../../generated/graphql';
 import useIdWithPrefix from '../../../../hooks/useIdWithPrefix';
 import useLocale from '../../../../hooks/useLocale';
@@ -19,6 +21,7 @@ import {
 } from '../../../../utils/validationUtils';
 import AuthenticationNotification from '../../../app/authenticationNotification/AuthenticationNotification';
 import PageWrapper from '../../../app/layout/pageWrapper/PageWrapper';
+import TitleRow from '../../../app/layout/titleRow/TitleRow';
 import useAuth from '../../../auth/hooks/useAuth';
 import useFeedbackActions from '../../../feedback/hooks/useFeedbackActions';
 import useFeedbackServerErrors from '../../../feedback/hooks/useFeedbackServerErrors';
@@ -110,7 +113,25 @@ const AskPermissionPage: React.FC = () => {
       keywords={['keywords.ask', 'keywords.permission']}
       title="helpPage.askPermissionPage.pageTitle"
     >
-      <h1>{t('helpPage.askPermissionPage.pageTitle')}</h1>
+      <TitleRow
+        breadcrumb={
+          <Breadcrumb
+            list={[
+              { title: t('common.home'), path: ROUTES.HOME },
+              { title: t('helpPage.pageTitle'), path: ROUTES.HELP },
+              {
+                title: t('helpPage.pageTitle'),
+                path: ROUTES.SUPPORT,
+              },
+              {
+                title: t('helpPage.askPermissionPage.pageTitle'),
+                path: null,
+              },
+            ]}
+          />
+        }
+        title={t('helpPage.askPermissionPage.pageTitle')}
+      />
       <AuthenticationNotification
         className={styles.authenticationNotification}
         showOnlyNotAuthenticatedError

--- a/src/domain/help/pages/contactPage/ContactPage.tsx
+++ b/src/domain/help/pages/contactPage/ContactPage.tsx
@@ -4,12 +4,14 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { ValidationError } from 'yup';
 
+import Breadcrumb from '../../../../common/components/breadcrumb/Breadcrumb';
 import Button from '../../../../common/components/button/Button';
 import SingleSelectField from '../../../../common/components/formFields/singleSelectField/SingleSelectField';
 import TextAreaField from '../../../../common/components/formFields/textAreaField/TextAreaField';
 import TextInputField from '../../../../common/components/formFields/textInputField/TextInputField';
 import FormGroup from '../../../../common/components/formGroup/FormGroup';
 import ServerErrorSummary from '../../../../common/components/serverErrorSummary/ServerErrorSummary';
+import { ROUTES } from '../../../../constants';
 import { FeedbackInput } from '../../../../generated/graphql';
 import useIdWithPrefix from '../../../../hooks/useIdWithPrefix';
 import {
@@ -17,6 +19,7 @@ import {
   showFormErrors,
 } from '../../../../utils/validationUtils';
 import PageWrapper from '../../../app/layout/pageWrapper/PageWrapper';
+import TitleRow from '../../../app/layout/titleRow/TitleRow';
 import useAuth from '../../../auth/hooks/useAuth';
 import useFeedbackActions from '../../../feedback/hooks/useFeedbackActions';
 import useFeedbackServerErrors from '../../../feedback/hooks/useFeedbackServerErrors';
@@ -129,7 +132,25 @@ const ContactPage: React.FC = () => {
       ]}
       title="helpPage.contactPage.pageTitle"
     >
-      <h1>{t('helpPage.contactPage.pageTitle')}</h1>
+      <TitleRow
+        breadcrumb={
+          <Breadcrumb
+            list={[
+              { title: t('common.home'), path: ROUTES.HOME },
+              { title: t('helpPage.pageTitle'), path: ROUTES.HELP },
+              {
+                title: t('helpPage.pageTitle'),
+                path: ROUTES.SUPPORT,
+              },
+              {
+                title: t('helpPage.contactPage.pageTitle'),
+                path: null,
+              },
+            ]}
+          />
+        }
+        title={t('helpPage.contactPage.pageTitle')}
+      />
 
       <Formik
         initialValues={initialValues}

--- a/src/domain/help/pages/controlPanelPage/ControlPanelPage.tsx
+++ b/src/domain/help/pages/controlPanelPage/ControlPanelPage.tsx
@@ -1,12 +1,16 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 
+import Breadcrumb from '../../../../common/components/breadcrumb/Breadcrumb';
 import ExternalLink from '../../../../common/components/externalLink/ExternalLink';
-import { SUPPORT_EMAIL } from '../../../../constants';
+import { ROUTES, SUPPORT_EMAIL } from '../../../../constants';
 import useLocale from '../../../../hooks/useLocale';
 import { Language } from '../../../../types';
 import PageWrapper from '../../../app/layout/pageWrapper/PageWrapper';
+import TitleRow from '../../../app/layout/titleRow/TitleRow';
 
 const ControlPanelPage: React.FC = () => {
+  const { t } = useTranslation();
   const locale = useLocale();
 
   const getContent = (locale: Language) => {
@@ -14,7 +18,6 @@ const ControlPanelPage: React.FC = () => {
       case 'en':
         return (
           <>
-            <h1>Control panel</h1>
             <h2>General</h2>
             <p>
               Linked Events is an event interface for the City of Helsinki. The
@@ -176,7 +179,6 @@ const ControlPanelPage: React.FC = () => {
       case 'fi':
         return (
           <>
-            <h1>Hallintapaneeli</h1>
             <h2>Yleistä</h2>
             <p>
               Linked Events on Helsingin kaupungin tapahtumarajapinta.
@@ -334,7 +336,6 @@ const ControlPanelPage: React.FC = () => {
       case 'sv':
         return (
           <>
-            <h1>Kontrollpanel</h1>
             <h2>Allmänt</h2>
             <p>
               Linked Events är evenemangsgränssnittet för Helsingfors stad. De
@@ -500,6 +501,25 @@ const ControlPanelPage: React.FC = () => {
       keywords={['keywords.controlPanel', 'keywords.help']}
       title="helpPage.pageTitleControlPanel"
     >
+      <TitleRow
+        breadcrumb={
+          <Breadcrumb
+            list={[
+              { title: t('common.home'), path: ROUTES.HOME },
+              { title: t('helpPage.pageTitle'), path: ROUTES.HELP },
+              {
+                title: t('helpPage.sideNavigation.labelInstructions'),
+                path: ROUTES.INSTRUCTIONS,
+              },
+              {
+                title: t('helpPage.sideNavigation.labelControlPanel'),
+                path: null,
+              },
+            ]}
+          />
+        }
+        title={t('helpPage.sideNavigation.labelControlPanel')}
+      />
       {getContent(locale)}
     </PageWrapper>
   );

--- a/src/domain/help/pages/documentationPage/DocumentationPage.tsx
+++ b/src/domain/help/pages/documentationPage/DocumentationPage.tsx
@@ -3,15 +3,20 @@
 import 'swagger-ui-react/swagger-ui.css';
 
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import SwaggerUI from 'swagger-ui-react';
 
+import Breadcrumb from '../../../../common/components/breadcrumb/Breadcrumb';
+import { ROUTES } from '../../../../constants';
 import { SWAGGER_SCHEMA_URL } from '../../../../envVariables';
 import useLocale from '../../../../hooks/useLocale';
 import { Language } from '../../../../types';
 import PageWrapper from '../../../app/layout/pageWrapper/PageWrapper';
+import TitleRow from '../../../app/layout/titleRow/TitleRow';
 import SwaggerLink from '../swaggerLink/SwaggerLink';
 
 const DocumentationPage: React.FC = () => {
+  const { t } = useTranslation();
   const locale = useLocale();
 
   const getContent = (locale: Language) => {
@@ -19,7 +24,6 @@ const DocumentationPage: React.FC = () => {
       case 'en':
         return (
           <>
-            <h1>Documentation</h1>
             <p>
               The latest documentation for the API in the Open API 2.0 markup
               language can be found at:
@@ -34,7 +38,6 @@ const DocumentationPage: React.FC = () => {
       case 'fi':
         return (
           <>
-            <h1>Dokumentaatio</h1>
             <p>
               Rajapinnan tuorein dokumentaatio Open API 2.0-kuvauskielellä
               löytyy osoitteesta:
@@ -48,7 +51,6 @@ const DocumentationPage: React.FC = () => {
       case 'sv':
         return (
           <>
-            <h1>Dokumentation</h1>
             <p>
               Den senaste dokumentationen för gränssnittet i Open API
               2.0-märkningsspråket finns på:
@@ -69,6 +71,25 @@ const DocumentationPage: React.FC = () => {
       keywords={['keywords.documentation', 'keywords.help']}
       title="helpPage.pageTitleDocumentation"
     >
+      <TitleRow
+        breadcrumb={
+          <Breadcrumb
+            list={[
+              { title: t('common.home'), path: ROUTES.HOME },
+              { title: t('helpPage.pageTitle'), path: ROUTES.HELP },
+              {
+                title: t('helpPage.pageTitleTechnology'),
+                path: ROUTES.TECHNOLOGY,
+              },
+              {
+                title: t('helpPage.pageTitleDocumentation'),
+                path: null,
+              },
+            ]}
+          />
+        }
+        title={t('helpPage.pageTitleDocumentation')}
+      />
       {getContent(locale)}
       {/* @ts-ignore */}
       <SwaggerUI url={SWAGGER_SCHEMA_URL} />

--- a/src/domain/help/pages/faqPage/FaqPage.tsx
+++ b/src/domain/help/pages/faqPage/FaqPage.tsx
@@ -2,7 +2,10 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
+import Breadcrumb from '../../../../common/components/breadcrumb/Breadcrumb';
+import { ROUTES } from '../../../../constants';
 import PageWrapper from '../../../app/layout/pageWrapper/PageWrapper';
+import TitleRow from '../../../app/layout/titleRow/TitleRow';
 import AddingEventsFaq from '../../faq/addingEventsFaq/AddingEventsFaq';
 import AddingToOwnProjectsFaq from '../../faq/addingToOwnProjectsFaq/AddingToOwnProjectsFaq';
 import EventFormNotWorkingFaq from '../../faq/eventFormNotWorkingFaq/EventFormNotWorkingFaq';
@@ -22,7 +25,25 @@ const FaqPage: React.FC = () => {
       keywords={['keywords.faq', 'keywords.asked', 'keywords.questions']}
       title="helpPage.pageTitleFaq"
     >
-      <h1>{t('helpPage.pageTitleFaq')}</h1>
+      <TitleRow
+        breadcrumb={
+          <Breadcrumb
+            list={[
+              { title: t('common.home'), path: ROUTES.HOME },
+              { title: t('helpPage.pageTitle'), path: ROUTES.HELP },
+              {
+                title: t('helpPage.sideNavigation.labelInstructions'),
+                path: ROUTES.INSTRUCTIONS,
+              },
+              {
+                title: t('helpPage.pageTitleFaq'),
+                path: null,
+              },
+            ]}
+          />
+        }
+        title={t('helpPage.pageTitleFaq')}
+      />
       <div className={styles.accordions}>
         <AddingEventsFaq />
         <ImageRightsFaq />

--- a/src/domain/help/pages/featuresPage/FeaturesPage.tsx
+++ b/src/domain/help/pages/featuresPage/FeaturesPage.tsx
@@ -1,12 +1,16 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 
+import Breadcrumb from '../../../../common/components/breadcrumb/Breadcrumb';
 import { ROUTES } from '../../../../constants';
 import useLocale from '../../../../hooks/useLocale';
 import { Language } from '../../../../types';
 import PageWrapper from '../../../app/layout/pageWrapper/PageWrapper';
+import TitleRow from '../../../app/layout/titleRow/TitleRow';
 
 const FeaturesPage: React.FC = () => {
+  const { t } = useTranslation();
   const locale = useLocale();
 
   const getContent = (locale: Language) => {
@@ -14,7 +18,6 @@ const FeaturesPage: React.FC = () => {
       case 'en':
         return (
           <>
-            <h1>Service features</h1>
             <h2>Event management</h2>
             <p>
               The Linked Events dashboard lets you enter new events, courses,
@@ -42,7 +45,6 @@ const FeaturesPage: React.FC = () => {
       case 'fi':
         return (
           <>
-            <h1>Palvelun ominaisuudet</h1>
             <h2>Tapahtumien hallinta</h2>
             <p>
               Linked Eventsin hallintapaneelin avulla voit syöttää uusia
@@ -70,7 +72,6 @@ const FeaturesPage: React.FC = () => {
       case 'sv':
         return (
           <>
-            <h1>Tjänstens egenskaper</h1>
             <h2>Evenemanghantering</h2>
             <p>
               Med instrumentpanelen för Linked Events kan du ange nya evenemang,
@@ -104,6 +105,21 @@ const FeaturesPage: React.FC = () => {
       keywords={['keywords.features']}
       title="helpPage.pageTitleFeatures"
     >
+      <TitleRow
+        breadcrumb={
+          <Breadcrumb
+            list={[
+              { title: t('common.home'), path: ROUTES.HOME },
+              { title: t('helpPage.pageTitle'), path: ROUTES.HELP },
+              {
+                title: t('helpPage.pageTitleFeatures'),
+                path: null,
+              },
+            ]}
+          />
+        }
+        title={t('helpPage.pageTitleFeatures')}
+      />
       {getContent(locale)}
     </PageWrapper>
   );

--- a/src/domain/help/pages/generalInstructionsPage/GeneralInstructionsPage.tsx
+++ b/src/domain/help/pages/generalInstructionsPage/GeneralInstructionsPage.tsx
@@ -1,51 +1,47 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 
+import Breadcrumb from '../../../../common/components/breadcrumb/Breadcrumb';
+import { ROUTES } from '../../../../constants';
 import useLocale from '../../../../hooks/useLocale';
 import { Language } from '../../../../types';
 import PageWrapper from '../../../app/layout/pageWrapper/PageWrapper';
+import TitleRow from '../../../app/layout/titleRow/TitleRow';
 import SourceCodeLinks from '../../sourceCodeLinks/SourceCodeLinks';
 import SwaggerLink from '../swaggerLink/SwaggerLink';
 
 const GeneralInstructionsPage: React.FC = () => {
+  const { t } = useTranslation();
   const locale = useLocale();
 
   const getContent = (locale: Language) => {
     switch (locale) {
       case 'en':
         return (
-          <>
-            <h1>General</h1>
-            <p>
-              These Linked Events instructions provide answers to the most
-              common questions, as well as instructions for using the control
-              panel and interface. More detailed information about the Linked
-              Events interface, software and documentation can be found at:
-            </p>
-          </>
+          <p>
+            These Linked Events instructions provide answers to the most common
+            questions, as well as instructions for using the control panel and
+            interface. More detailed information about the Linked Events
+            interface, software and documentation can be found at:
+          </p>
         );
       case 'fi':
         return (
-          <>
-            <h1>Yleistä</h1>
-            <p>
-              Näistä Linked Events ohjeista löydät vastaukset yleisimpiin
-              kysymyksiin sekä ohjeet hallintapaneelin ja rajapinnan käyttöön.
-              Tarkemmat tiedot Linked Events-rajapinnasta, -ohjelmistosta ja
-              -dokumentaatiosta löytyy osoitteista:
-            </p>
-          </>
+          <p>
+            Näistä Linked Events ohjeista löydät vastaukset yleisimpiin
+            kysymyksiin sekä ohjeet hallintapaneelin ja rajapinnan käyttöön.
+            Tarkemmat tiedot Linked Events-rajapinnasta, -ohjelmistosta ja
+            -dokumentaatiosta löytyy osoitteista:
+          </p>
         );
       case 'sv':
         return (
-          <>
-            <h1>Allmänt</h1>
-            <p>
-              Dessa instruktioner för Linked Events ger svar på de vanligaste
-              frågorna samt instruktioner för hur du använder kontrollpanelen
-              och gränssnittet. Mer detaljerad information om Linked Events
-              gränssnitt, programvara och dokumentation finns på:
-            </p>
-          </>
+          <p>
+            Dessa instruktioner för Linked Events ger svar på de vanligaste
+            frågorna samt instruktioner för hur du använder kontrollpanelen och
+            gränssnittet. Mer detaljerad information om Linked Events
+            gränssnitt, programvara och dokumentation finns på:
+          </p>
         );
     }
   };
@@ -55,6 +51,22 @@ const GeneralInstructionsPage: React.FC = () => {
       keywords={['keywords.support', 'keywords.help', 'keywords.instructions']}
       title="helpPage.pageTitleInstructions"
     >
+      <TitleRow
+        breadcrumb={
+          <Breadcrumb
+            list={[
+              { title: t('common.home'), path: ROUTES.HOME },
+              { title: t('helpPage.pageTitle'), path: ROUTES.HELP },
+              {
+                title: t('helpPage.sideNavigation.labelInstructions'),
+                path: ROUTES.INSTRUCTIONS,
+              },
+              { title: t('helpPage.sideNavigation.labelGeneral'), path: null },
+            ]}
+          />
+        }
+        title={t('helpPage.sideNavigation.labelGeneral')}
+      />
       {getContent(locale)}
       <SourceCodeLinks showExplanations />
       <SwaggerLink showExplanations />

--- a/src/domain/help/pages/generalTechologyPage/GeneralTechnologyPage.tsx
+++ b/src/domain/help/pages/generalTechologyPage/GeneralTechnologyPage.tsx
@@ -1,54 +1,49 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 
+import Breadcrumb from '../../../../common/components/breadcrumb/Breadcrumb';
+import { ROUTES } from '../../../../constants';
 import useLocale from '../../../../hooks/useLocale';
 import { Language } from '../../../../types';
 import PageWrapper from '../../../app/layout/pageWrapper/PageWrapper';
+import TitleRow from '../../../app/layout/titleRow/TitleRow';
 import SourceCodeLinks from '../../sourceCodeLinks/SourceCodeLinks';
 
 const GeneralTechnologyPage: React.FC = () => {
+  const { t } = useTranslation();
   const locale = useLocale();
 
   const getContent = (locale: Language) => {
     switch (locale) {
       case 'en':
         return (
-          <>
-            <h1>General</h1>
-            <p>
-              Linked Events is developed for a Django platform in Python and
-              Javascript programming languages and utilizes a PostgreSQL
-              database to capture data. Linked Events Admin is a React-based
-              application for event management and its and the platform's source
-              code can be found in Github version control at:
-            </p>
-          </>
+          <p>
+            Linked Events is developed for a Django platform in Python and
+            Javascript programming languages and utilizes a PostgreSQL database
+            to capture data. Linked Events Admin is a React-based application
+            for event management and its and the platform's source code can be
+            found in Github version control at:
+          </p>
         );
       case 'fi':
         return (
-          <>
-            <h1>Yleistä</h1>
-            <p>
-              Linked Events on kehitetty Django-alustalle Python- ja
-              Javascript-ohjelmointikielillä ja se hyödyntää
-              PostgreSQL-tietokantaa tietojen taltioimiseen. Linked Events Admin
-              on React-pohjainen sovellus tapahtumien hallintaan ja sen sekä
-              alustan lähdekoodit löytyvät Github-versionhallinnasta
-              osoitteista:
-            </p>
-          </>
+          <p>
+            Linked Events on kehitetty Django-alustalle Python- ja
+            Javascript-ohjelmointikielillä ja se hyödyntää
+            PostgreSQL-tietokantaa tietojen taltioimiseen. Linked Events Admin
+            on React-pohjainen sovellus tapahtumien hallintaan ja sen sekä
+            alustan lähdekoodit löytyvät Github-versionhallinnasta osoitteista:
+          </p>
         );
       case 'sv':
         return (
-          <>
-            <h1>Allmänt</h1>
-            <p>
-              Linked Events är utvecklat för Django-plattformen i
-              programmeringsspråk Python och Javascript och använder en
-              PostgreSQL-databas för att fånga data. Linked Events Admin är en
-              React-baserad applikation för evenemangshantering och dess och
-              plattformens källkod finns i Github-versionskontrollen på:
-            </p>
-          </>
+          <p>
+            Linked Events är utvecklat för Django-plattformen i
+            programmeringsspråk Python och Javascript och använder en
+            PostgreSQL-databas för att fånga data. Linked Events Admin är en
+            React-baserad applikation för evenemangshantering och dess och
+            plattformens källkod finns i Github-versionskontrollen på:
+          </p>
         );
     }
   };
@@ -58,6 +53,25 @@ const GeneralTechnologyPage: React.FC = () => {
       keywords={['keywords.technology', 'keywords.help', 'keywords.support']}
       title="helpPage.pageTitleTechnology"
     >
+      <TitleRow
+        breadcrumb={
+          <Breadcrumb
+            list={[
+              { title: t('common.home'), path: ROUTES.HOME },
+              { title: t('helpPage.pageTitle'), path: ROUTES.HELP },
+              {
+                title: t('helpPage.pageTitleTechnology'),
+                path: ROUTES.TECHNOLOGY,
+              },
+              {
+                title: t('helpPage.sideNavigation.labelGeneral'),
+                path: null,
+              },
+            ]}
+          />
+        }
+        title={t('helpPage.sideNavigation.labelGeneral')}
+      />
       {getContent(locale)}
       <SourceCodeLinks />
     </PageWrapper>

--- a/src/domain/help/pages/imageRightsPage/ImageRightsPage.tsx
+++ b/src/domain/help/pages/imageRightsPage/ImageRightsPage.tsx
@@ -1,58 +1,54 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 
+import Breadcrumb from '../../../../common/components/breadcrumb/Breadcrumb';
+import { ROUTES } from '../../../../constants';
 import useLocale from '../../../../hooks/useLocale';
 import { Language } from '../../../../types';
 import PageWrapper from '../../../app/layout/pageWrapper/PageWrapper';
+import TitleRow from '../../../app/layout/titleRow/TitleRow';
 
 const ImageRightsPage: React.FC = () => {
+  const { t } = useTranslation();
   const locale = useLocale();
 
   const getContent = (locale: Language) => {
     switch (locale) {
       case 'en':
         return (
-          <>
-            <h1>Image rights</h1>
-            <p>
-              The City of Helsinki has all the rights to the images. If the
-              license of the image to be shared in the interface is marked
-              event_only, the image may only be used for information and
-              communication about the event. Using images for this purpose is
-              free for the user. The use or transfer of the image for other
-              purposes is prohibited. When using images, it is essential to
-              mention the source and author of the images.
-            </p>
-          </>
+          <p>
+            The City of Helsinki has all the rights to the images. If the
+            license of the image to be shared in the interface is marked
+            event_only, the image may only be used for information and
+            communication about the event. Using images for this purpose is free
+            for the user. The use or transfer of the image for other purposes is
+            prohibited. When using images, it is essential to mention the source
+            and author of the images.
+          </p>
         );
       case 'fi':
         return (
-          <>
-            <h1>Kuvaoikeudet</h1>
-            <p>
-              Helsingin kaupungilla on kuviin kaikki oikeudet. Mikäli
-              rajapinnassa jaettavan kuvan tietojen kohdassa license on merkintä
-              event_only, saa kuvaa käyttää ainoastaan kuvan tapahtumaa
-              käsittelevään tiedotukseen ja viestintään. Kuvien käyttäminen
-              tähän tarkoitukseen on käyttäjälle ilmaista. Kuvan käyttö tai
-              siirto muihin tarkoituksiin on kielletty. Kuvia käytettäessä on
-              ehdottomasti mainittava kuvien lähde ja kuvaaja.
-            </p>
-          </>
+          <p>
+            Helsingin kaupungilla on kuviin kaikki oikeudet. Mikäli rajapinnassa
+            jaettavan kuvan tietojen kohdassa license on merkintä event_only,
+            saa kuvaa käyttää ainoastaan kuvan tapahtumaa käsittelevään
+            tiedotukseen ja viestintään. Kuvien käyttäminen tähän tarkoitukseen
+            on käyttäjälle ilmaista. Kuvan käyttö tai siirto muihin
+            tarkoituksiin on kielletty. Kuvia käytettäessä on ehdottomasti
+            mainittava kuvien lähde ja kuvaaja.
+          </p>
         );
       case 'sv':
         return (
-          <>
-            <h1>Bildrättigheter</h1>
-            <p>
-              Helsingfors stad har alla rättigheter till bilderna. Om licensen
-              för bilden som ska delas i gränssnittet är markerad endast
-              evenemang, får bilden endast användas för information och
-              kommunikation om bildens evenemang. Att använda bilder för detta
-              ändamål är gratis för användaren. Användning eller överföring av
-              bilden för andra ändamål är förbjuden. När du använder bilder är
-              det viktigt att nämna bildens källa och författare.
-            </p>
-          </>
+          <p>
+            Helsingfors stad har alla rättigheter till bilderna. Om licensen för
+            bilden som ska delas i gränssnittet är markerad endast evenemang,
+            får bilden endast användas för information och kommunikation om
+            bildens evenemang. Att använda bilder för detta ändamål är gratis
+            för användaren. Användning eller överföring av bilden för andra
+            ändamål är förbjuden. När du använder bilder är det viktigt att
+            nämna bildens källa och författare.
+          </p>
         );
     }
   };
@@ -63,6 +59,25 @@ const ImageRightsPage: React.FC = () => {
       keywords={['keywords.image', 'keywords.rights', 'keywords.license']}
       title="helpPage.pageTitleImageRights"
     >
+      <TitleRow
+        breadcrumb={
+          <Breadcrumb
+            list={[
+              { title: t('common.home'), path: ROUTES.HOME },
+              { title: t('helpPage.pageTitle'), path: ROUTES.HELP },
+              {
+                title: t('helpPage.pageTitleTechnology'),
+                path: ROUTES.TECHNOLOGY,
+              },
+              {
+                title: t('helpPage.pageTitleImageRights'),
+                path: null,
+              },
+            ]}
+          />
+        }
+        title={t('helpPage.pageTitleImageRights')}
+      />
       {getContent(locale)}
     </PageWrapper>
   );

--- a/src/domain/help/pages/platformPage/PlatformPage.tsx
+++ b/src/domain/help/pages/platformPage/PlatformPage.tsx
@@ -3,9 +3,12 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 
 import imageUrl from '../../../../assets/images/png/platform-page.png';
+import Breadcrumb from '../../../../common/components/breadcrumb/Breadcrumb';
 import Highlight from '../../../../common/components/highlight/Highlight';
+import { ROUTES } from '../../../../constants';
 import IconCloud from '../../../../icons/IconCloud';
 import PageWrapper from '../../../app/layout/pageWrapper/PageWrapper';
+import TitleRow from '../../../app/layout/titleRow/TitleRow';
 import styles from './platformPage.module.scss';
 
 const PlatformPage: React.FC = () => {
@@ -18,7 +21,22 @@ const PlatformPage: React.FC = () => {
       keywords={['keywords.platform', 'keywords.help', 'keywords.instructions']}
       title="helpPage.platformPage.pageTitle"
     >
-      <h1>{t('helpPage.platformPage.titlePlatform')}</h1>
+      <TitleRow
+        breadcrumb={
+          <Breadcrumb
+            list={[
+              { title: t('common.home'), path: ROUTES.HOME },
+              { title: t('helpPage.pageTitle'), path: ROUTES.HELP },
+              {
+                title: t('helpPage.sideNavigation.labelInstructions'),
+                path: ROUTES.INSTRUCTIONS,
+              },
+              { title: t('helpPage.platformPage.titlePlatform'), path: null },
+            ]}
+          />
+        }
+        title={t('helpPage.platformPage.titlePlatform')}
+      />
       <div className={styles.mainContent}>
         <img src={imageUrl} alt={t('helpPage.platformPage.imageAlt')} />
         <div>

--- a/src/domain/help/pages/registrationInstructions/RegistrationInstructions.tsx
+++ b/src/domain/help/pages/registrationInstructions/RegistrationInstructions.tsx
@@ -13,9 +13,12 @@ import imageEn5 from '../../../../assets/images/png/registration_instructions_5_
 import imageFi5 from '../../../../assets/images/png/registration_instructions_5_FI.png';
 import imageEn6 from '../../../../assets/images/png/registration_instructions_6_EN.png';
 import imageFi6 from '../../../../assets/images/png/registration_instructions_6_FI.png';
+import Breadcrumb from '../../../../common/components/breadcrumb/Breadcrumb';
+import { ROUTES } from '../../../../constants';
 import useLocale from '../../../../hooks/useLocale';
 import { Language } from '../../../../types';
 import PageWrapper from '../../../app/layout/pageWrapper/PageWrapper';
+import TitleRow from '../../../app/layout/titleRow/TitleRow';
 import styles from './registrationInstructions.module.scss';
 
 const DocumentationPage: React.FC = () => {
@@ -61,7 +64,6 @@ const DocumentationPage: React.FC = () => {
       case 'en':
         return (
           <>
-            <h1>Linked Registration instructions</h1>
             <h2>Creating a registration</h2>
             <p>
               After publishing an event: go to the Registration section in
@@ -182,7 +184,6 @@ const DocumentationPage: React.FC = () => {
       case 'fi':
         return (
           <>
-            <h1>Linked Registration -ohje</h1>
             <h2>Creating a registration</h2>
             <p>
               Julkaistuasi tapahtuman: Siirry Linked Eventsissä
@@ -295,7 +296,7 @@ const DocumentationPage: React.FC = () => {
           </>
         );
       case 'sv':
-        return <h1>Linked Registration instruktioner</h1>;
+        return <></>;
     }
   };
 
@@ -304,6 +305,27 @@ const DocumentationPage: React.FC = () => {
       className={styles.registrationInstructions}
       title="helpPage.registrationInstructionsPage.pageTitle"
     >
+      <TitleRow
+        breadcrumb={
+          <Breadcrumb
+            list={[
+              { title: t('common.home'), path: ROUTES.HOME },
+              { title: t('helpPage.pageTitle'), path: ROUTES.HELP },
+              {
+                title: t('helpPage.sideNavigation.labelInstructions'),
+                path: ROUTES.INSTRUCTIONS,
+              },
+              {
+                title: t(
+                  'helpPage.sideNavigation.labelRegistrationInstructions'
+                ),
+                path: null,
+              },
+            ]}
+          />
+        }
+        title={t('helpPage.sideNavigation.labelRegistrationInstructions')}
+      />
       {getContent(locale)}
     </PageWrapper>
   );

--- a/src/domain/help/pages/sourceCodePage/SourceCodePage.tsx
+++ b/src/domain/help/pages/sourceCodePage/SourceCodePage.tsx
@@ -1,11 +1,16 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 
+import Breadcrumb from '../../../../common/components/breadcrumb/Breadcrumb';
+import { ROUTES } from '../../../../constants';
 import useLocale from '../../../../hooks/useLocale';
 import { Language } from '../../../../types';
 import PageWrapper from '../../../app/layout/pageWrapper/PageWrapper';
+import TitleRow from '../../../app/layout/titleRow/TitleRow';
 import SourceCodeLinks from '../../sourceCodeLinks/SourceCodeLinks';
 
 const SourceCodePage: React.FC = () => {
+  const { t } = useTranslation();
   const locale = useLocale();
 
   const getContent = (locale: Language) => {
@@ -13,7 +18,6 @@ const SourceCodePage: React.FC = () => {
       case 'en':
         return (
           <>
-            <h1>Source code</h1>
             <p>
               The complete code base of Linked Events can be found in the City
               of Helsinki's Github:
@@ -28,7 +32,6 @@ const SourceCodePage: React.FC = () => {
       case 'fi':
         return (
           <>
-            <h1>Lähdekoodi</h1>
             <p>
               Linked Eventsin koodikanta löytyy kokonaisuudessaan Helsingin
               kaupungin Githubista:
@@ -43,7 +46,6 @@ const SourceCodePage: React.FC = () => {
       case 'sv':
         return (
           <>
-            <h1>Källkod</h1>
             <p>
               Den kompletta kodbasen för Linked Events finns i Helsingfors stads
               Github:
@@ -63,6 +65,25 @@ const SourceCodePage: React.FC = () => {
       keywords={['keywords.sourceCode', 'keywords.help']}
       title="helpPage.pageTitleSourceCode"
     >
+      <TitleRow
+        breadcrumb={
+          <Breadcrumb
+            list={[
+              { title: t('common.home'), path: ROUTES.HOME },
+              { title: t('helpPage.pageTitle'), path: ROUTES.HELP },
+              {
+                title: t('helpPage.pageTitleTechnology'),
+                path: ROUTES.TECHNOLOGY,
+              },
+              {
+                title: t('helpPage.pageTitleSourceCode'),
+                path: null,
+              },
+            ]}
+          />
+        }
+        title={t('helpPage.pageTitleSourceCode')}
+      />
       {getContent(locale)}
     </PageWrapper>
   );

--- a/src/domain/help/pages/termsOfUsePage/TermsOfUsePage.tsx
+++ b/src/domain/help/pages/termsOfUsePage/TermsOfUsePage.tsx
@@ -1,12 +1,17 @@
 /* eslint-disable max-len */
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 
+import Breadcrumb from '../../../../common/components/breadcrumb/Breadcrumb';
 import ExternalLink from '../../../../common/components/externalLink/ExternalLink';
+import { ROUTES } from '../../../../constants';
 import useLocale from '../../../../hooks/useLocale';
 import { Language } from '../../../../types';
 import PageWrapper from '../../../app/layout/pageWrapper/PageWrapper';
+import TitleRow from '../../../app/layout/titleRow/TitleRow';
 
 const TermsOfUsePage: React.FC = () => {
+  const { t } = useTranslation();
   const locale = useLocale();
 
   const getContent = (locale: Language) => {
@@ -14,7 +19,6 @@ const TermsOfUsePage: React.FC = () => {
       case 'en':
         return (
           <>
-            <h1>Data Privacy and Terms of Use</h1>
             <p>
               Linked Events, the event data management service, is logged in
               with the Helsinki profile of the City of Helsinki, either as an
@@ -248,7 +252,6 @@ const TermsOfUsePage: React.FC = () => {
       case 'fi':
         return (
           <>
-            <h1>Tietosuoja ja käyttöehdot</h1>
             <p>
               Linked Events, tapahtumatietojen hallintapalveluun, kirjaudutaan
               Helsingin kaupungin Helsinki profiililla joko kaupungin
@@ -486,7 +489,6 @@ const TermsOfUsePage: React.FC = () => {
       case 'sv':
         return (
           <>
-            <h1>Dataskydd och användarvillkor</h1>
             <p>
               Linked Events, tjänsten för hantering av evenemangsdata, är
               inloggad med Helsingfors stads profil, antingen som anställd vid
@@ -733,6 +735,25 @@ const TermsOfUsePage: React.FC = () => {
       keywords={['keywords.termsOfUse']}
       title="helpPage.pageTitleTermsOfUse"
     >
+      <TitleRow
+        breadcrumb={
+          <Breadcrumb
+            list={[
+              { title: t('common.home'), path: ROUTES.HOME },
+              { title: t('helpPage.pageTitle'), path: ROUTES.HELP },
+              {
+                title: t('helpPage.pageTitle'),
+                path: ROUTES.SUPPORT,
+              },
+              {
+                title: t('helpPage.pageTitleTermsOfUse'),
+                path: null,
+              },
+            ]}
+          />
+        }
+        title={t('helpPage.pageTitleTermsOfUse')}
+      />
       {getContent(locale)}
     </PageWrapper>
   );


### PR DESCRIPTION
## Description :sparkles:

Adding breadcrumbs on search and support pages.

## Issues :bug:

### Closes :no_good_woman:

**[LINK-1747](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1747):**

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:
<img width="1235" alt="Screenshot 2024-01-19 at 12 59 01" src="https://github.com/City-of-Helsinki/linkedcomponents-ui/assets/66477579/f870cc24-6a83-4c9a-af11-55dab845a1d5">

<img width="1240" alt="Screenshot 2024-01-19 at 12 59 12" src="https://github.com/City-of-Helsinki/linkedcomponents-ui/assets/66477579/da03b8f1-2835-41c7-a5c6-8f0d6896acfa">

## Additional notes :spiral_notepad:


[LINK-1747]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1747?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ