### PR TITLE
feat: add signup phone number to table

### DIFF
--- a/src/domain/app/i18n/en.json
+++ b/src/domain/app/i18n/en.json
@@ -1999,9 +1999,10 @@
       "placeholderSearch": "Filter participants"
     },
     "signupsTableColumns": {
-      "email": "Email",
+      "contactPersonEmail": "Contact person's email",
+      "contactPersonPhoneNumber": "Contact person's phone number",
       "name": "Name",
-      "phone": "Phone number",
+      "phoneNumber": "Phone number",
       "status": "Status"
     },
     "title": "Signups",

--- a/src/domain/app/i18n/fi.json
+++ b/src/domain/app/i18n/fi.json
@@ -1999,9 +1999,10 @@
       "placeholderSearch": "Hae osallistujia"
     },
     "signupsTableColumns": {
-      "email": "Sähköposti",
+      "contactPersonEmail": "Yhteyshenkilön sähköposti",
+      "contactPersonPhoneNumber": "Yhteyshenkilön puhelinnumero",
       "name": "Nimi",
-      "phone": "Puhelinnumero",
+      "phoneNumber": "Puhelinnumero",
       "status": "Status"
     },
     "title": "Ilmoittautuneet",

--- a/src/domain/app/i18n/sv.json
+++ b/src/domain/app/i18n/sv.json
@@ -1998,9 +1998,10 @@
       "placeholderSearch": "Filtrera registreringar"
     },
     "signupsTableColumns": {
-      "email": "E-post",
+      "contactPersonEmail": "Kontaktpersons e-post",
+      "contactPersonPhoneNumber": "Kontaktpersons telefonnummer",
       "name": "Name",
-      "phone": "Telefonnummer",
+      "phoneNumber": "Telefonnummer",
       "status": "Status"
     },
     "title": "Anmälningar",

--- a/src/domain/signups/__tests__/utils.test.ts
+++ b/src/domain/signups/__tests__/utils.test.ts
@@ -4,11 +4,21 @@ import {
 } from '../../../generated/graphql';
 import { fakeRegistration, fakeSignup } from '../../../utils/mockDataUtils';
 import { registrationId } from '../../registration/__mocks__/registration';
+import { TEST_REGISTRATION_ID } from '../../registration/constants';
+import { TEST_SIGNUP_ID } from '../../signup/constants';
+import { TEST_SIGNUP_GROUP_ID } from '../../signupGroup/constants';
 import { getSignupFields, signupsPathBuilder } from '../utils';
 
 describe('getSignupFields function', () => {
   it('should return default values if value is not set', () => {
-    const { email, firstName, id, lastName, phoneNumber } = getSignupFields({
+    const {
+      contactPersonEmail,
+      contactPersonPhoneNumber,
+      firstName,
+      id,
+      lastName,
+      phoneNumber,
+    } = getSignupFields({
       language: 'fi',
       registration: fakeRegistration(),
       signup: fakeSignup({
@@ -22,14 +32,52 @@ describe('getSignupFields function', () => {
         firstName: null,
         id: '',
         lastName: null,
+        phoneNumber: null,
       }),
     });
 
-    expect(email).toBe('');
+    expect(contactPersonEmail).toBe('');
+    expect(contactPersonPhoneNumber).toBe('');
     expect(firstName).toBe('');
     expect(id).toBe('');
     expect(lastName).toBe('');
     expect(phoneNumber).toBe('');
+  });
+
+  it('should return correct signupfields', () => {
+    expect(
+      getSignupFields({
+        language: 'fi',
+        registration: fakeRegistration({ id: TEST_REGISTRATION_ID }),
+        signup: fakeSignup({
+          contactPerson: {
+            email: 'contact@email.com',
+            firstName: 'Contact person first name',
+            lastName: 'Contact person last name',
+            id: '',
+            phoneNumber: '0401234567',
+          },
+          firstName: 'First name',
+          id: TEST_SIGNUP_ID,
+          lastName: 'Last name',
+          phoneNumber: '0407654321',
+          signupGroup: TEST_SIGNUP_GROUP_ID,
+        }),
+      })
+    ).toEqual({
+      attendeeStatus: 'attending',
+      contactPersonEmail: 'contact@email.com',
+      contactPersonPhoneNumber: '0401234567',
+      firstName: 'First name',
+      fullName: 'First name Last name',
+      id: 'signup:0',
+      lastName: 'Last name',
+      phoneNumber: '0407654321',
+      signupGroup: 'signupgroup:1',
+      signupGroupUrl:
+        '/fi/registrations/registration:0/signup-group/edit/signupgroup:1',
+      signupUrl: '/fi/registrations/registration:0/signup/edit/signup:0',
+    });
   });
 });
 

--- a/src/domain/signups/signupsTable/SignupsTable.tsx
+++ b/src/domain/signups/signupsTable/SignupsTable.tsx
@@ -64,9 +64,23 @@ const NameColumn: FC<ColumnProps> = ({ registration, signup }) => {
   );
 };
 
-const EmailColumn: FC<ColumnProps> = ({ registration, signup }) => {
+const PhoneColumn: FC<ColumnProps> = ({ registration, signup }) => {
   const language = useLocale();
-  const { email, signupGroup } = getSignupFields({
+  const { phoneNumber } = getSignupFields({
+    language,
+    registration,
+    signup,
+  });
+
+  return getValue(phoneNumber, '-');
+};
+
+const ContactPersonEmailColumn: FC<ColumnProps> = ({
+  registration,
+  signup,
+}) => {
+  const language = useLocale();
+  const { contactPersonEmail, signupGroup } = getSignupFields({
     language,
     registration,
     signup,
@@ -84,16 +98,19 @@ const EmailColumn: FC<ColumnProps> = ({ registration, signup }) => {
       small
     >
       {getValue(
-        signupGroupData?.signupGroup.contactPerson?.email ?? email,
+        signupGroupData?.signupGroup.contactPerson?.email ?? contactPersonEmail,
         '-'
       )}
     </LoadingSpinner>
   );
 };
 
-const PhoneColumn: FC<ColumnProps> = ({ registration, signup }) => {
+const ContactPersonPhoneColumn: FC<ColumnProps> = ({
+  registration,
+  signup,
+}) => {
   const language = useLocale();
-  const { phoneNumber, signupGroup } = getSignupFields({
+  const { contactPersonPhoneNumber, signupGroup } = getSignupFields({
     language,
     registration,
     signup,
@@ -110,7 +127,8 @@ const PhoneColumn: FC<ColumnProps> = ({ registration, signup }) => {
       small
     >
       {getValue(
-        signupGroupData?.signupGroup.contactPerson?.phoneNumber ?? phoneNumber,
+        signupGroupData?.signupGroup.contactPerson?.phoneNumber ??
+          contactPersonPhoneNumber,
         '-'
       )}
     </LoadingSpinner>
@@ -213,16 +231,23 @@ const SignupsTable: React.FC<SignupsTableProps> = ({
     [registration]
   );
 
-  const MemoizedEmailColumn = React.useCallback(
+  const MemoizedPhoneColumn = React.useCallback(
     (signup: SignupFieldsFragment) => (
-      <EmailColumn signup={signup} registration={registration} />
+      <PhoneColumn signup={signup} registration={registration} />
     ),
     [registration]
   );
 
-  const MemoizedPhoneColumn = React.useCallback(
+  const MemoizedContactPersonEmailColumn = React.useCallback(
     (signup: SignupFieldsFragment) => (
-      <PhoneColumn signup={signup} registration={registration} />
+      <ContactPersonEmailColumn signup={signup} registration={registration} />
+    ),
+    [registration]
+  );
+
+  const MemoizedContactPersonPhoneColumn = React.useCallback(
+    (signup: SignupFieldsFragment) => (
+      <ContactPersonPhoneColumn signup={signup} registration={registration} />
     ),
     [registration]
   );
@@ -261,16 +286,26 @@ const SignupsTable: React.FC<SignupsTableProps> = ({
               transform: MemoizedNameColumn,
             },
             {
+              className: styles.phoneColumn,
+              key: 'phone',
+              headerName: t('signupsPage.signupsTableColumns.phoneNumber'),
+              transform: MemoizedPhoneColumn,
+            },
+            {
               className: styles.emailColumn,
-              key: 'email',
-              headerName: t('signupsPage.signupsTableColumns.email'),
-              transform: MemoizedEmailColumn,
+              key: 'contactPersonEmail',
+              headerName: t(
+                'signupsPage.signupsTableColumns.contactPersonEmail'
+              ),
+              transform: MemoizedContactPersonEmailColumn,
             },
             {
               className: styles.phoneColumn,
-              key: 'phone',
-              headerName: t('signupsPage.signupsTableColumns.phone'),
-              transform: MemoizedPhoneColumn,
+              key: 'contactPersonPhone',
+              headerName: t(
+                'signupsPage.signupsTableColumns.contactPersonPhoneNumber'
+              ),
+              transform: MemoizedContactPersonPhoneColumn,
             },
             {
               className: styles.statusColumn,

--- a/src/domain/signups/signupsTable/__tests__/SignupsTable.test.tsx
+++ b/src/domain/signups/signupsTable/__tests__/SignupsTable.test.tsx
@@ -90,7 +90,13 @@ test('should render signups table', async () => {
 
   screen.getByRole('heading', { name: 'Signups table' });
 
-  const columnHeaders = ['Nimi', 'Sähköposti', 'Puhelinnumero', 'Status'];
+  const columnHeaders = [
+    'Nimi',
+    'Puhelinnumero',
+    'Yhteyshenkilön sähköposti',
+    'Yhteyshenkilön puhelinnumero',
+    'Status',
+  ];
 
   for (const name of columnHeaders) {
     screen.getByRole('columnheader', { name });
@@ -240,7 +246,7 @@ test('should open edit signup group page by pressing enter on a signup with grou
   );
 });
 
-test('should display email and phone number for a signup', async () => {
+test("should display contact person's email and phone number for a signup", async () => {
   renderComponent([...defaultMocks, getMockedAttendeesResponse(attendees)]);
 
   await loadingSpinnerIsNotInDocument();
@@ -257,7 +263,7 @@ test('should display email and phone number for a signup', async () => {
   ).toBeInTheDocument();
 });
 
-test('should display email and phone number for a signup group', async () => {
+test("should display contact person's email and phone number for a signup group", async () => {
   renderComponent([
     ...defaultMocks,
     getMockedAttendeesResponse(attendeesWithGroup),

--- a/src/domain/signups/types.ts
+++ b/src/domain/signups/types.ts
@@ -9,7 +9,8 @@ export type SignupSearchInitialValues = {
 
 export type SignupFields = {
   attendeeStatus: AttendeeStatus;
-  email: string;
+  contactPersonEmail: string;
+  contactPersonPhoneNumber: string;
   firstName: string;
   fullName: string;
   lastName: string;

--- a/src/domain/signups/utils.ts
+++ b/src/domain/signups/utils.ts
@@ -49,11 +49,12 @@ export const getSignupFields = ({
   return {
     id,
     attendeeStatus: signup.attendeeStatus as AttendeeStatus,
-    email: getValue(signup.contactPerson?.email, ''),
+    contactPersonEmail: getValue(signup.contactPerson?.email, ''),
+    contactPersonPhoneNumber: getValue(signup.contactPerson?.phoneNumber, ''),
     firstName,
     fullName,
     lastName,
-    phoneNumber: getValue(signup.contactPerson?.phoneNumber, ''),
+    phoneNumber: getValue(signup.phoneNumber, ''),
     signupGroup,
     signupGroupUrl: signupGroup
       ? `/${language}${ROUTES.EDIT_SIGNUP_GROUP.replace(


### PR DESCRIPTION
## Description
At the moment signups table displays only contact person's email and phone number. Add also signup's phone number to the table and rename columns of contact person's email and phone number

## Closes
[LINK-1862](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1862)

## Screenshot
<img width="1073" alt="Screenshot 2024-01-31 at 12 54 01" src="https://github.com/City-of-Helsinki/linkedcomponents-ui/assets/24706814/5233efbc-a7cf-4a07-a45b-776f49e0fe60">


[LINK-1862]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1862?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ