### PR TITLE
LINK-1848 | prioritise most used language options

### DIFF
--- a/src/domain/language/hooks/__tests__/useLanguageOptions.test.tsx
+++ b/src/domain/language/hooks/__tests__/useLanguageOptions.test.tsx
@@ -1,0 +1,59 @@
+import { MockedProvider } from '@apollo/client/testing';
+import { renderHook, waitFor } from '@testing-library/react';
+import { PropsWithChildren } from 'react';
+
+import { createCache } from '../../../app/apollo/apolloClient';
+import {
+  mockedLanguagesResponse,
+  mockedServiceLanguagesResponse,
+} from '../../__mocks__/language';
+import useLanguageOptions, {
+  UseLanguageOptionsProps,
+} from '../useLanguageOptions';
+
+const mocks = [mockedLanguagesResponse, mockedServiceLanguagesResponse];
+
+const getHookWrapper = (props?: UseLanguageOptionsProps) => {
+  const wrapper = ({ children }: PropsWithChildren) => (
+    <MockedProvider cache={createCache()} mocks={mocks}>
+      {children}
+    </MockedProvider>
+  );
+  const { result } = renderHook(() => useLanguageOptions(props), {
+    wrapper,
+  });
+  return { result };
+};
+
+test('should return language options', async () => {
+  const { result } = getHookWrapper();
+
+  await waitFor(() => expect(result.current.length).toBeTruthy());
+
+  expect(result.current).toEqual([
+    { label: 'Suomi', value: 'fi' },
+    { label: 'Ruotsi', value: 'sv' },
+    { label: 'Englanti', value: 'en' },
+    { label: 'Arabia', value: 'ar' },
+    { label: 'Espanja', value: 'es' },
+    { label: 'Kiina', value: 'zh_hans' },
+    { label: 'Persia', value: 'fa' },
+    { label: 'Ranska', value: 'fr' },
+    { label: 'Somali', value: 'so' },
+    { label: 'Turkki', value: 'tr' },
+    { label: 'Venäjä', value: 'ru' },
+    { label: 'Viro', value: 'et' },
+  ]);
+});
+
+test('should return service language options', async () => {
+  const { result } = getHookWrapper({ variables: { serviceLanguage: true } });
+
+  await waitFor(() => expect(result.current.length).toBeTruthy());
+
+  expect(result.current).toEqual([
+    { label: 'Suomi', value: 'fi' },
+    { label: 'Ruotsi', value: 'sv' },
+    { label: 'Englanti', value: 'en' },
+  ]);
+});

--- a/src/domain/language/hooks/useLanguageOptions.ts
+++ b/src/domain/language/hooks/useLanguageOptions.ts
@@ -15,13 +15,15 @@ import {
   sortLanguageOptions,
 } from '../utils';
 
+export type UseLanguageOptionsProps = {
+  variables?: LanguagesQueryVariables;
+  idKey?: 'atId' | 'id';
+};
+
 const useLanguageOptions = ({
   variables,
   idKey,
-}: {
-  variables?: LanguagesQueryVariables;
-  idKey?: 'atId' | 'id';
-} = {}): OptionType[] => {
+}: UseLanguageOptionsProps = {}): OptionType[] => {
   const locale = useLocale();
 
   const { data } = useLanguagesQuery({

--- a/src/domain/language/utils.ts
+++ b/src/domain/language/utils.ts
@@ -1,4 +1,5 @@
 import capitalize from 'lodash/capitalize';
+import get from 'lodash/get';
 
 import {
   LanguageFieldsFragment,
@@ -18,8 +19,20 @@ export const getLanguageOption = (
   value: getValue(language[idKey], ''),
 });
 
-export const sortLanguageOptions = (a: OptionType, b: OptionType): number =>
-  a.label > b.label ? 1 : -1;
+export const sortLanguageOptions = (a: OptionType, b: OptionType): number => {
+  const languagePriorities = {
+    fi: 3,
+    sv: 2,
+    en: 1,
+  };
+  const aPriority = get(languagePriorities, a.value, 0);
+  const bPriority = get(languagePriorities, b.value, 0);
+
+  if (aPriority !== bPriority) {
+    return bPriority - aPriority;
+  }
+  return a.label > b.label ? 1 : -1;
+};
 
 export const languagesPathBuilder = ({
   args,


### PR DESCRIPTION
## Description
Prioritise most used languages in the Native language and Service language dropdown in the signup form

## Closes
[LINK-1848](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1848)

## Screenshot
<img width="783" alt="Screenshot 2024-02-02 at 11 39 01" src="https://github.com/City-of-Helsinki/linkedcomponents-ui/assets/24706814/6533e1ab-e6cc-4607-b630-bc154da91bdf">


[LINK-1848]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1848?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ