### PR TITLE
fix: fixing e2e errors caused by footer changes LINK-1746

### DIFF
--- a/browser-tests/footer/footer.components.ts
+++ b/browser-tests/footer/footer.components.ts
@@ -25,10 +25,10 @@ export const findFooter = async (t: TestController) => {
         return withinFooter().findByRole('link', { name: /hallinta/i });
       },
       contactLink() {
-        return withinFooter().findByRole('link', { name: /anna palautetta/i });
+        return withinFooter().findByRole('link', { name: /ota yhteyttä/i });
       },
       eventsLink() {
-        return withinFooter().findByRole('link', { name: /tapahtumat/i });
+        return withinFooter().findByRole('link', { name: /omat tapahtumat/i });
       },
       eventSearchLink() {
         return withinFooter().findByRole('link', { name: /etsi tapahtumia/i });
@@ -36,8 +36,8 @@ export const findFooter = async (t: TestController) => {
       registrationsLink() {
         return withinFooter().findByRole('link', { name: /ilmoittautuminen/i });
       },
-      supportLink() {
-        return withinFooter().findByRole('link', { name: /tuki/i });
+      instructionsLink() {
+        return withinFooter().findByRole('link', { name: /ohjeet/i });
       },
     };
 
@@ -67,9 +67,9 @@ export const findFooter = async (t: TestController) => {
           .expect(selectors.registrationsLink().exists)
           .ok(await getErrorMessage(t));
       },
-      async supportPageLinkIsVisible() {
+      async instructionsPageLinkIsVisible() {
         await t
-          .expect(selectors.supportLink().exists)
+          .expect(selectors.instructionsLink().exists)
           .ok(await getErrorMessage(t));
       },
     };
@@ -90,8 +90,8 @@ export const findFooter = async (t: TestController) => {
       async clickRegistrationsPageLink() {
         await t.click(selectors.registrationsLink());
       },
-      async clickSupportPageLink() {
-        await t.click(selectors.supportLink());
+      async clickInstructionsPageLink() {
+        await t.click(selectors.instructionsLink());
       },
     };
 

--- a/browser-tests/footer/footer.testcafe.ts
+++ b/browser-tests/footer/footer.testcafe.ts
@@ -31,8 +31,8 @@ test('Footer links work', async (t) => {
   await footerLinks.actions.clickEventSearchPageLink();
   await urlUtils.expectations.urlChangedToEventSearchPage();
   // Support page
-  await footerLinks.actions.clickSupportPageLink();
-  await urlUtils.expectations.urlChangedToSupportPage();
+  await footerLinks.actions.clickInstructionsPageLink();
+  await urlUtils.expectations.urlChangedToInstructionsPage();
   // Contact page
   await footerLinks.actions.clickContactPageLink();
   await urlUtils.expectations.urlChangedToContactPage();

--- a/browser-tests/header/header.testcafe.ts
+++ b/browser-tests/header/header.testcafe.ts
@@ -51,5 +51,5 @@ test('Header tabs field work', async (t) => {
   await urlUtils.expectations.urlChangedToEventsPage();
   // Support page
   await headerTabs.actions.clickSupportPageTab();
-  await urlUtils.expectations.urlChangedToSupportPage();
+  await urlUtils.expectations.urlChangedToInstructionsPage();
 });

--- a/browser-tests/help/help.testcafe.ts
+++ b/browser-tests/help/help.testcafe.ts
@@ -26,7 +26,7 @@ test('Side navigation tabs work', async (t) => {
   const sideNavigation = helpPage.sideNavigation();
   const helpPageTitles = helpPage.helpPageTitles();
 
-  await urlUtils.expectations.urlChangedToSupportPage();
+  await urlUtils.expectations.urlChangedToInstructionsPage();
   // Close instructions main level
   await sideNavigation.actions.clickInstructionsButton();
   // Fearures link
@@ -95,6 +95,6 @@ test('Side navigation tabs work', async (t) => {
   await helpPageTitles.expectations.platformTitleIsVisible();
   // Instructions general link
   await sideNavigation.actions.clickInstructionsGeneralLink();
-  await urlUtils.expectations.urlChangedToSupportPage();
+  await urlUtils.expectations.urlChangedToInstructionsPage();
   await helpPageTitles.expectations.instructionsGeneralTitleIsVisible();
 });

--- a/browser-tests/utils/url.utils.ts
+++ b/browser-tests/utils/url.utils.ts
@@ -123,7 +123,7 @@ export const getUrlUtils = (t: TestController) => {
         .expect(getPathname())
         .eql(`/fi/help/technology/source-code`, await getErrorMessage(t));
     },
-    async urlChangedToSupportPage() {
+    async urlChangedToInstructionsPage() {
       await t
         .expect(getPathname())
         .eql(`/fi/help/instructions/general`, await getErrorMessage(t));


### PR DESCRIPTION
## Description :sparkles:

Fixing e2e tests that were broken due to [latest footer changes](https://github.com/City-of-Helsinki/linkedcomponents-ui/pull/314)

## Issues :bug:

### Closes :no_good_woman:

**[DEV-XXX](https://helsinkisolutionoffice.atlassian.net/browse/DEV-XXX):**

### Related :handshake:

## Testing :alembic:

Tested by running tests on local machine

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
