### PR TITLE
LINK-1900 | Fine-tune authentication

### DIFF
--- a/src/domain/app/routes/adminRoutes/AdminRoutes.tsx
+++ b/src/domain/app/routes/adminRoutes/AdminRoutes.tsx
@@ -126,7 +126,12 @@ const AdminPageRoutes: React.FC = () => {
               element={<PlacesPage />}
             />
 
-            <Route path="*" element={<NotFoundPage />} />
+            <Route
+              path="*"
+              element={
+                <NotFoundPage pathAfterSignIn={`/${locale}${ROUTES.HOME}`} />
+              }
+            />
           </Routes>
         </AdminPageLayout>
       ) : (

--- a/src/domain/app/routes/helpPageRoutes/HelpPageRoutes.tsx
+++ b/src/domain/app/routes/helpPageRoutes/HelpPageRoutes.tsx
@@ -60,7 +60,9 @@ const InstructionsRoutes: React.FC<Props> = ({ locale }) => {
         path={getInstructionsRoutePath(ROUTES.INSTRUCTIONS_REGISTRATION)}
         element={<RegistrationInstructions />}
       />
-      <Route element={<NotFound />} />
+      <Route
+        element={<NotFound pathAfterSignIn={`/${locale}${ROUTES.HOME}`} />}
+      />
     </Routes>
   );
 };
@@ -99,7 +101,9 @@ const TechnologyRoutes: React.FC<Props> = ({ locale }) => {
           path={getTechnologyRoutePath(ROUTES.TECHNOLOGY_SOURCE_CODE)}
           element={<SourceCodePage />}
         />
-        <Route element={<NotFound />} />
+        <Route
+          element={<NotFound pathAfterSignIn={`/${locale}${ROUTES.HOME}`} />}
+        />
       </Routes>
     </React.Suspense>
   );
@@ -130,7 +134,9 @@ const SupportRoutes: React.FC<Props> = ({ locale }) => {
         path={getSupportRoutePath(ROUTES.SUPPORT_TERMS_OF_USE)}
         element={<TermsOfUsePage />}
       />
-      <Route element={<NotFound />} />
+      <Route
+        element={<NotFound pathAfterSignIn={`/${locale}${ROUTES.HOME}`} />}
+      />
     </Routes>
   );
 };
@@ -162,7 +168,10 @@ const HelpPageRoutes: React.FC = () => {
         path={getHelpRoutePath(ROUTES.FEATURES)}
         element={<FeaturesPage />}
       />
-      <Route path="*" element={<NotFound />} />
+      <Route
+        path="*"
+        element={<NotFound pathAfterSignIn={`/${locale}${ROUTES.HOME}`} />}
+      />
     </Routes>
   );
 };

--- a/src/domain/app/routes/localeRoutes/LocaleRoutes.tsx
+++ b/src/domain/app/routes/localeRoutes/LocaleRoutes.tsx
@@ -116,7 +116,10 @@ const LocaleRoutes: React.FC = () => {
               </HelpPageLayout>
             }
           />
-          <Route path="*" element={<NotFound />} />
+          <Route
+            path="*"
+            element={<NotFound pathAfterSignIn={`/${locale}${ROUTES.HOME}`} />}
+          />
         </Routes>
       </React.Suspense>
     </PageLayout>

--- a/src/domain/app/routes/registrationRoutes/RegistrationRoutes.tsx
+++ b/src/domain/app/routes/registrationRoutes/RegistrationRoutes.tsx
@@ -3,6 +3,7 @@ import { Route, Routes } from 'react-router';
 
 import LoadingSpinner from '../../../../common/components/loadingSpinner/LoadingSpinner';
 import { ROUTES } from '../../../../constants';
+import useLocale from '../../../../hooks/useLocale';
 import NotFoundPage from '../../../notFound/NotFound';
 import useUser from '../../../user/hooks/useUser';
 import { areRegistrationRoutesAllowed } from '../../../user/permissions';
@@ -35,6 +36,7 @@ const SignupsPage = React.lazy(() => import('../../../signups/SignupsPage'));
 
 const RegistrationRoutes: React.FC = () => {
   const { loading, user } = useUser();
+  const locale = useLocale();
   const getRegistrationRoutePath = (path: string) =>
     path.replace(ROUTES.REGISTRATIONS, '');
 
@@ -79,7 +81,12 @@ const RegistrationRoutes: React.FC = () => {
             element={<EditSignupPage />}
           />
 
-          <Route path="*" element={<NotFoundPage />} />
+          <Route
+            path="*"
+            element={
+              <NotFoundPage pathAfterSignIn={`/${locale}${ROUTES.HOME}`} />
+            }
+          />
         </Routes>
       ) : (
         <NotFoundPage />

--- a/src/domain/attendanceList/AttendanceListPage.tsx
+++ b/src/domain/attendanceList/AttendanceListPage.tsx
@@ -2,7 +2,6 @@
 
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useLocation } from 'react-router';
 
 import Breadcrumb from '../../common/components/breadcrumb/Breadcrumb';
 import LoadingSpinner from '../../common/components/loadingSpinner/LoadingSpinner';
@@ -83,8 +82,6 @@ const AttendanceListPage: React.FC<AttendanceListPageProps> = ({
 };
 
 const AttendanceListPageWrapper: React.FC = () => {
-  const location = useLocation();
-
   const { loading, registration } = useRegistrationAndEventData({
     overrideRegistrationsVariables: {
       include: [...REGISTRATION_INCLUDES, 'signups'],
@@ -97,7 +94,7 @@ const AttendanceListPageWrapper: React.FC = () => {
       {registration ? (
         <AttendanceListPage registration={registration} />
       ) : (
-        <NotFound pathAfterSignIn={`${location.pathname}${location.search}`} />
+        <NotFound />
       )}
     </LoadingSpinner>
   );

--- a/src/domain/event/EditEventPage.tsx
+++ b/src/domain/event/EditEventPage.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React from 'react';
-import { useLocation, useParams } from 'react-router';
+import { useParams } from 'react-router';
 
 import LoadingSpinner from '../../common/components/loadingSpinner/LoadingSpinner';
 import { useEventQuery } from '../../generated/graphql';
@@ -14,7 +14,6 @@ import useEventFieldOptionsData from './hooks/useEventFieldOptionsData';
 import { eventPathBuilder } from './utils';
 
 const EditEventPageWrapper: React.FC = () => {
-  const location = useLocation();
   const { id } = useParams<{ id: string }>();
   const { loading: loadingUser } = useUser();
 
@@ -42,7 +41,7 @@ const EditEventPageWrapper: React.FC = () => {
       {eventData?.event ? (
         <EventForm event={eventData?.event} refetch={refetch} />
       ) : (
-        <NotFound pathAfterSignIn={`${location.pathname}${location.search}`} />
+        <NotFound />
       )}
     </LoadingSpinner>
   );

--- a/src/domain/image/EditImagePage.tsx
+++ b/src/domain/image/EditImagePage.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useLocation, useNavigate, useParams } from 'react-router';
+import { useNavigate, useParams } from 'react-router';
 
 import Breadcrumb from '../../common/components/breadcrumb/Breadcrumb';
 import Button from '../../common/components/button/Button';
@@ -108,7 +108,6 @@ const EditImagePage: React.FC<Props> = ({ image }) => {
 };
 
 const EditImagePageWrapper: React.FC = () => {
-  const location = useLocation();
   const { loading: loadingUser } = useUser();
   const { id } = useParams<{ id: string }>();
 
@@ -128,13 +127,7 @@ const EditImagePageWrapper: React.FC = () => {
   return (
     <PageWrapper title="editImagePage.pageTitle">
       <LoadingSpinner isLoading={loading}>
-        {image ? (
-          <EditImagePage image={image} />
-        ) : (
-          <NotFound
-            pathAfterSignIn={`${location.pathname}${location.search}`}
-          />
-        )}
+        {image ? <EditImagePage image={image} /> : <NotFound />}
       </LoadingSpinner>
     </PageWrapper>
   );

--- a/src/domain/keyword/EditKeywordPage.tsx
+++ b/src/domain/keyword/EditKeywordPage.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useLocation, useNavigate, useParams } from 'react-router';
+import { useNavigate, useParams } from 'react-router';
 
 import Breadcrumb from '../../common/components/breadcrumb/Breadcrumb';
 import Button from '../../common/components/button/Button';
@@ -115,7 +115,6 @@ const EditKeywordPage: React.FC<Props> = ({ keyword }) => {
 };
 
 const EditKeywordPageWrapper: React.FC = () => {
-  const location = useLocation();
   const { loading: loadingUser } = useUser();
   const { id } = useParams<{ id: string }>();
 
@@ -135,13 +134,7 @@ const EditKeywordPageWrapper: React.FC = () => {
   return (
     <PageWrapper title="editKeywordPage.pageTitle">
       <LoadingSpinner isLoading={loading}>
-        {keyword ? (
-          <EditKeywordPage keyword={keyword} />
-        ) : (
-          <NotFound
-            pathAfterSignIn={`${location.pathname}${location.search}`}
-          />
-        )}
+        {keyword ? <EditKeywordPage keyword={keyword} /> : <NotFound />}
       </LoadingSpinner>
     </PageWrapper>
   );

--- a/src/domain/keywordSet/EditKeywordSetPage.tsx
+++ b/src/domain/keywordSet/EditKeywordSetPage.tsx
@@ -3,7 +3,7 @@
 import { Button } from 'hds-react';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useLocation, useNavigate, useParams } from 'react-router';
+import { useNavigate, useParams } from 'react-router';
 
 import Breadcrumb from '../../common/components/breadcrumb/Breadcrumb';
 import LoadingSpinner from '../../common/components/loadingSpinner/LoadingSpinner';
@@ -118,7 +118,6 @@ const EditKeywordSetPage: React.FC<Props> = ({ keywordSet }) => {
 };
 
 const EditKeywordSetPageWrapper: React.FC = () => {
-  const location = useLocation();
   const { loading: loadingUser } = useUser();
   const { id } = useParams<{ id: string }>();
 
@@ -141,9 +140,7 @@ const EditKeywordSetPageWrapper: React.FC = () => {
         {keywordSet ? (
           <EditKeywordSetPage keywordSet={keywordSet} />
         ) : (
-          <NotFound
-            pathAfterSignIn={`${location.pathname}${location.search}`}
-          />
+          <NotFound />
         )}
       </LoadingSpinner>
     </PageWrapper>

--- a/src/domain/notFound/NotFound.tsx
+++ b/src/domain/notFound/NotFound.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import { useLocation } from 'react-router';
 
 import ErrorPage from '../../common/components/errorPage/ErrorPage';
-import { ROUTES } from '../../constants';
-import useLocale from '../../hooks/useLocale';
 import PageWrapper from '../app/layout/pageWrapper/PageWrapper';
 
 interface Props {
@@ -12,12 +11,12 @@ interface Props {
 
 const NotFoundPage: React.FC<Props> = ({ pathAfterSignIn }) => {
   const { t } = useTranslation();
-  const locale = useLocale();
+  const location = useLocation();
 
   return (
     <PageWrapper title={t('notFound.pageTitle')}>
       <ErrorPage
-        signInPath={pathAfterSignIn ?? `/${locale}${ROUTES.HOME}`}
+        signInPath={pathAfterSignIn ?? `${location.pathname}${location.search}`}
         text={t('notFound.text')}
       />
     </PageWrapper>

--- a/src/domain/organization/EditOrganizationPage.tsx
+++ b/src/domain/organization/EditOrganizationPage.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useLocation, useNavigate, useParams } from 'react-router';
+import { useNavigate, useParams } from 'react-router';
 
 import Breadcrumb from '../../common/components/breadcrumb/Breadcrumb';
 import Button from '../../common/components/button/Button';
@@ -115,7 +115,6 @@ const EditOrganizationPage: React.FC<Props> = ({ organization }) => {
 };
 
 const EditOrganizationPageWrapper: React.FC = () => {
-  const location = useLocation();
   const { loading: loadingUser } = useUser();
   const { id } = useParams<{ id: string }>();
 
@@ -140,9 +139,7 @@ const EditOrganizationPageWrapper: React.FC = () => {
         {organization ? (
           <EditOrganizationPage organization={organization} />
         ) : (
-          <NotFound
-            pathAfterSignIn={`${location.pathname}${location.search}`}
-          />
+          <NotFound />
         )}
       </LoadingSpinner>
     </PageWrapper>

--- a/src/domain/place/EditPlacePage.tsx
+++ b/src/domain/place/EditPlacePage.tsx
@@ -1,7 +1,7 @@
 import { Button } from 'hds-react';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useLocation, useNavigate, useParams } from 'react-router';
+import { useNavigate, useParams } from 'react-router';
 
 import Breadcrumb from '../../common/components/breadcrumb/Breadcrumb';
 import LoadingSpinner from '../../common/components/loadingSpinner/LoadingSpinner';
@@ -106,7 +106,6 @@ const EditPlacePage: React.FC<Props> = ({ place }) => {
 };
 
 const EditPlacePageWrapper: React.FC = () => {
-  const location = useLocation();
   const { loading: loadingUser } = useUser();
   const { id } = useParams<{ id: string }>();
 
@@ -125,13 +124,7 @@ const EditPlacePageWrapper: React.FC = () => {
   return (
     <PageWrapper title="editPlacePage.pageTitle">
       <LoadingSpinner isLoading={loading}>
-        {place ? (
-          <EditPlacePage place={place} />
-        ) : (
-          <NotFound
-            pathAfterSignIn={`${location.pathname}${location.search}`}
-          />
-        )}
+        {place ? <EditPlacePage place={place} /> : <NotFound />}
       </LoadingSpinner>
     </PageWrapper>
   );

--- a/src/domain/registration/EditRegistrationPage.tsx
+++ b/src/domain/registration/EditRegistrationPage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useLocation, useParams } from 'react-router';
+import { useParams } from 'react-router';
 
 import LoadingSpinner from '../../common/components/loadingSpinner/LoadingSpinner';
 import PageWrapper from '../app/layout/pageWrapper/PageWrapper';
@@ -9,7 +9,6 @@ import RegistrationForm from './registrationForm/RegistrationForm';
 import styles from './registrationPage.module.scss';
 
 const EditRegistrationPageWrapper: React.FC = () => {
-  const location = useLocation();
   const { id: registrationId } = useParams<{ id: string }>();
   const { event, loading, refetchRegistration, registration } =
     useRegistrationAndEventData({
@@ -34,7 +33,7 @@ const EditRegistrationPageWrapper: React.FC = () => {
           />
         </PageWrapper>
       ) : (
-        <NotFound pathAfterSignIn={`${location.pathname}${location.search}`} />
+        <NotFound />
       )}
     </LoadingSpinner>
   );

--- a/src/domain/signup/EditSignupPage.tsx
+++ b/src/domain/signup/EditSignupPage.tsx
@@ -2,7 +2,6 @@ import { ApolloQueryResult } from '@apollo/client';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router';
-import { useLocation } from 'react-router-dom';
 
 import LoadingSpinner from '../../common/components/loadingSpinner/LoadingSpinner';
 import {
@@ -96,7 +95,6 @@ const EditSignupPage: React.FC<Props> = ({
 };
 
 const EditSignupPageWrapper: React.FC = () => {
-  const location = useLocation();
   const { signupId } = useParams<{ signupId: string }>();
   const { user } = useUser();
 
@@ -141,7 +139,7 @@ const EditSignupPageWrapper: React.FC = () => {
           </SignupServerErrorsProvider>
         </SignupGroupFormProvider>
       ) : (
-        <NotFound pathAfterSignIn={`${location.pathname}${location.search}`} />
+        <NotFound />
       )}
     </LoadingSpinner>
   );

--- a/src/domain/signupGroup/CreateSignupGroupPage.tsx
+++ b/src/domain/signupGroup/CreateSignupGroupPage.tsx
@@ -1,6 +1,5 @@
 import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useLocation } from 'react-router-dom';
 
 import LoadingSpinner from '../../common/components/loadingSpinner/LoadingSpinner';
 import {
@@ -81,7 +80,6 @@ const CreateSignupGroupPage: React.FC<Props> = ({ event, registration }) => {
 };
 
 const CreateSignupGroupPageWrapper: React.FC = () => {
-  const location = useLocation();
   const { event, loading, registration } = useRegistrationAndEventData({
     shouldFetchEvent: true,
   });
@@ -104,7 +102,7 @@ const CreateSignupGroupPageWrapper: React.FC = () => {
           )}
         </>
       ) : (
-        <NotFound pathAfterSignIn={`${location.pathname}${location.search}`} />
+        <NotFound />
       )}
     </LoadingSpinner>
   );

--- a/src/domain/signupGroup/EditSignupGroupPage.tsx
+++ b/src/domain/signupGroup/EditSignupGroupPage.tsx
@@ -2,7 +2,6 @@ import { ApolloQueryResult } from '@apollo/client';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router';
-import { useLocation } from 'react-router-dom';
 
 import LoadingSpinner from '../../common/components/loadingSpinner/LoadingSpinner';
 import {
@@ -91,7 +90,6 @@ const EditSignupGroupPage: React.FC<Props> = ({
 };
 
 const EditSignupGroupPageWrapper: React.FC = () => {
-  const location = useLocation();
   const { signupGroupId } = useParams<{
     signupGroupId: string;
   }>();
@@ -129,7 +127,7 @@ const EditSignupGroupPageWrapper: React.FC = () => {
           </SignupServerErrorsProvider>
         </SignupGroupFormProvider>
       ) : (
-        <NotFound pathAfterSignIn={`${location.pathname}${location.search}`} />
+        <NotFound />
       )}
     </LoadingSpinner>
   );

--- a/src/domain/signups/SignupsPage.tsx
+++ b/src/domain/signups/SignupsPage.tsx
@@ -3,7 +3,7 @@
 import { IconPlus } from 'hds-react';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useLocation, useNavigate } from 'react-router';
+import { useNavigate } from 'react-router';
 
 import Breadcrumb from '../../common/components/breadcrumb/Breadcrumb';
 import Button from '../../common/components/button/Button';
@@ -228,8 +228,6 @@ const SignupsPage: React.FC<SignupsPageProps> = ({ registration }) => {
 };
 
 const SignupsPageWrapper: React.FC = () => {
-  const location = useLocation();
-
   const { loading, registration } = useRegistrationAndEventData({
     shouldFetchEvent: false,
   });
@@ -241,7 +239,7 @@ const SignupsPageWrapper: React.FC = () => {
           <SignupsPage registration={registration} />
         </SignupGroupFormProvider>
       ) : (
-        <NotFound pathAfterSignIn={`${location.pathname}${location.search}`} />
+        <NotFound />
       )}
     </LoadingSpinner>
   );


### PR DESCRIPTION
## Description
- At the moment unauthenticated user is redirected to the landing page after logging in from registration or admin pages. Change this behaviour so that the same url is opened after logging in.
- Always refresh api tokens in the first render if user is already authenticated to avoid using expired api tokens.

## Closes
[LINK-1900](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1900)

[LINK-1900]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ