### PR TITLE
LINK-1888 | 3/4 Create price group page

### DIFF
--- a/schema.js
+++ b/schema.js
@@ -12,6 +12,7 @@ module.exports = buildSchema(/* GraphQL */ `
     createKeywordSet(input: CreateKeywordSetMutationInput!): KeywordSet!
     createOrganization(input: CreateOrganizationMutationInput!): Organization!
     createPlace(input: CreatePlaceMutationInput!): Place!
+    createPriceGroup(input: CreatePriceGroupMutationInput!): PriceGroup!
     createRegistration(input: CreateRegistrationMutationInput!): Registration!
     createSeatsReservation(
       input: CreateSeatsReservationMutationInput!
@@ -526,6 +527,13 @@ module.exports = buildSchema(/* GraphQL */ `
     publisher: String
     streetAddress: LocalisedObjectInput
     telephone: LocalisedObjectInput
+  }
+
+  input CreatePriceGroupMutationInput {
+    description: LocalisedObjectInput
+    id: Int
+    isFree: Boolean
+    publisher: String
   }
 
   input UpdatePriceGroupMutationInput {

--- a/src/common/components/menuDropdown/__tests__/MenuDropdown.test.tsx
+++ b/src/common/components/menuDropdown/__tests__/MenuDropdown.test.tsx
@@ -1,5 +1,4 @@
 import { IconPen } from 'hds-react';
-import React from 'react';
 
 import {
   arrowDownKeyPressHelper,
@@ -7,6 +6,7 @@ import {
   configure,
   enterKeyPressHelper,
   escKeyPressHelper,
+  openDropdownMenu,
   render,
   screen,
   tabKeyPressHelper,
@@ -24,33 +24,11 @@ const renderMenuDropdown = (props: MenuDropdownProps) => {
   const getItemAtIndex = (index: number) =>
     screen.getByRole('button', { name: items[index].label });
 
-  return {
-    getItemAtIndex,
-    getElement,
-  };
+  return { getItemAtIndex };
 };
 
-const getElement = (key: 'toggleButton') => {
-  switch (key) {
-    case 'toggleButton':
-      return screen.getByRole('button', { name: defaultProps.buttonLabel });
-  }
-};
-
-const findElement = (key: 'menu') => {
-  switch (key) {
-    case 'menu':
-      return screen.findByRole('region', { name: defaultProps.buttonLabel });
-  }
-};
-
-const openMenu = async () => {
-  const user = userEvent.setup();
-  const toggleButton = getElement('toggleButton');
-  await user.click(toggleButton);
-
-  await findElement('menu');
-};
+const findMenu = () =>
+  screen.findByRole('region', { name: defaultProps.buttonLabel });
 
 const menuShouldBeClosed = async () =>
   await waitFor(() =>
@@ -76,7 +54,7 @@ const defaultProps: MenuDropdownProps = {
 test('changes focused item correctly', async () => {
   const { getItemAtIndex } = renderMenuDropdown(defaultProps);
 
-  await openMenu();
+  await openDropdownMenu(defaultProps.buttonLabel);
 
   arrowDownKeyPressHelper();
   expect(getItemAtIndex(0).className).toStrictEqual(
@@ -108,7 +86,7 @@ test('changes focused item correctly', async () => {
 test('should call onClick when pressing enter key', async () => {
   renderMenuDropdown(defaultProps);
 
-  await openMenu();
+  await openDropdownMenu(defaultProps.buttonLabel);
 
   arrowDownKeyPressHelper();
 
@@ -121,7 +99,7 @@ test('calls onClick callback correctly', async () => {
   const user = userEvent.setup();
   const { getItemAtIndex } = renderMenuDropdown(defaultProps);
 
-  await openMenu();
+  await openDropdownMenu(defaultProps.buttonLabel);
 
   for (const [index, item] of items.entries()) {
     await user.click(getItemAtIndex(index));
@@ -132,7 +110,7 @@ test('calls onClick callback correctly', async () => {
 test('menu should be closed with esc key', async () => {
   renderMenuDropdown(defaultProps);
 
-  await openMenu();
+  await openDropdownMenu(defaultProps.buttonLabel);
   escKeyPressHelper();
   await menuShouldBeClosed();
 });
@@ -140,25 +118,25 @@ test('menu should be closed with esc key', async () => {
 test('menu should be open with arrow up/down key', async () => {
   renderMenuDropdown(defaultProps);
 
-  await openMenu();
+  await openDropdownMenu(defaultProps.buttonLabel);
 
   escKeyPressHelper();
   await menuShouldBeClosed();
 
   arrowDownKeyPressHelper();
-  await findElement('menu');
+  await findMenu();
 
   escKeyPressHelper();
   await menuShouldBeClosed();
 
   arrowUpKeyPressHelper();
-  await findElement('menu');
+  await findMenu();
 });
 
 test('menu should be closed with teb key', async () => {
   renderMenuDropdown(defaultProps);
 
-  await openMenu();
+  await openDropdownMenu(defaultProps.buttonLabel);
 
   tabKeyPressHelper();
   await menuShouldBeClosed();

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -29,6 +29,7 @@ export enum ROUTES {
   CREATE_KEYWORD_SET = '/administration/keyword-sets/create',
   CREATE_ORGANIZATION = '/administration/organizations/create',
   CREATE_PLACE = '/administration/places/create',
+  CREATE_PRICE_GROUP = '/administration/price-groups/create',
   CREATE_REGISTRATION = '/registrations/create',
   CREATE_SIGNUP_GROUP = '/registrations/:registrationId/signup-group/create',
   EDIT_EVENT = '/events/edit/:id',

--- a/src/domain/app/i18n/en.json
+++ b/src/domain/app/i18n/en.json
@@ -78,6 +78,7 @@
     "buttonAddKeywordSet": "Add keyword set",
     "buttonAddOrganization": "Add new organization",
     "buttonAddPlace": "Add place",
+    "buttonAddPriceGroup": "Add customer group",
     "buttonAddRegistration": "Add new",
     "buttonBack": "Back",
     "cancel": "Undo",
@@ -296,6 +297,11 @@
     "pageDescription": "Add new place to Linked Events.",
     "pageTitle": "Add place",
     "title": "Add place"
+  },
+  "createPriceGroupPage": {
+    "pageDescription": "Add new customer group to Linked Events.",
+    "pageTitle": "Add customer group",
+    "title": "Add customer group"
   },
   "createRegistrationPage": {
     "pageTitle": "New registration",

--- a/src/domain/app/i18n/fi.json
+++ b/src/domain/app/i18n/fi.json
@@ -78,6 +78,7 @@
     "buttonAddKeywordSet": "Lisää avainsanaryhmä",
     "buttonAddOrganization": "Lisää uusi organisaatio",
     "buttonAddPlace": "Lisää paikka",
+    "buttonAddPriceGroup": "Lisää asiakasryhmä",
     "buttonAddRegistration": "Lisää uusi",
     "buttonBack": "Takaisin",
     "buttonRemoveFilter": "Poista suodatusehto: {{name}}",
@@ -297,6 +298,11 @@
     "pageDescription": "Lisää uusi paikka Linked Eventsiin.",
     "pageTitle": "Lisää paikka",
     "title": "Lisää paikka"
+  },
+  "createPriceGroupPage": {
+    "pageDescription": "Lisää uusi asiakasryhmä Linked Eventsiin.",
+    "pageTitle": "Lisää asiakasryhmä",
+    "title": "Lisää asiakasryhmä"
   },
   "createRegistrationPage": {
     "pageTitle": "Uusi ilmoittautuminen",

--- a/src/domain/app/i18n/sv.json
+++ b/src/domain/app/i18n/sv.json
@@ -78,6 +78,7 @@
     "buttonAddKeywordSet": "Lägg till nyckelorduppsättningar",
     "buttonAddOrganization": "Lägg till organisation",
     "buttonAddPlace": "Lägg till plats",
+    "buttonAddPriceGroup": "Lägg till kundgrupp",
     "buttonAddRegistration": "Lägg till",
     "buttonBack": "Tillbaka",
     "buttonRemoveFilter": "Ta bort filtret: {{name}}",
@@ -297,6 +298,11 @@
     "pageDescription": "Lägg till ny plats till Linked Events.",
     "pageTitle": "Lägg till plats",
     "title": "Lägg till plats"
+  },
+  "createPriceGroupPage": {
+    "pageDescription": "Lägg till ny kundgrupp till Linked Events.",
+    "pageTitle": "Lägg till kundgrupp",
+    "title": "Lägg till kundgrupp"
   },
   "createRegistrationPage": {
     "pageTitle": "Ny registrering",

--- a/src/domain/app/routes/adminRoutes/AdminRoutes.tsx
+++ b/src/domain/app/routes/adminRoutes/AdminRoutes.tsx
@@ -24,6 +24,9 @@ const CreateOrganizationPage = React.lazy(
 const CreatePlacePage = React.lazy(
   () => import('../../../place/CreatePlacePage')
 );
+const CreatePriceGroupPage = React.lazy(
+  () => import('../../../priceGroup/CreatePriceGroupPage')
+);
 const EditImagePage = React.lazy(() => import('../../../image/EditImagePage'));
 const EditKeywordPage = React.lazy(
   () => import('../../../keyword/EditKeywordPage')
@@ -132,6 +135,10 @@ const AdminPageRoutes: React.FC = () => {
               element={<PlacesPage />}
             />
 
+            <Route
+              path={getAdminRoutePath(ROUTES.CREATE_PRICE_GROUP)}
+              element={<CreatePriceGroupPage />}
+            />
             <Route
               path={getAdminRoutePath(ROUTES.EDIT_PRICE_GROUP)}
               element={<EditPriceGroupPage />}

--- a/src/domain/app/routes/localeRoutes/__tests__/LocaleRoutes.test.tsx
+++ b/src/domain/app/routes/localeRoutes/__tests__/LocaleRoutes.test.tsx
@@ -586,6 +586,16 @@ it('should render price groups page', async () => {
   });
 });
 
+it('should render create price group page', async () => {
+  const { history } = await renderRoute(ROUTES.CREATE_PRICE_GROUP);
+
+  await isPageRendered({
+    history,
+    pageTitle: 'Lisää asiakasryhmä - Linked Events',
+    pathname: '/fi/administration/price-groups/create',
+  });
+});
+
 it('should render edit price group page', async () => {
   const id = priceGroup.id.toString();
   const { history } = await renderRoute(

--- a/src/domain/event/__tests__/EditEventPage.test.tsx
+++ b/src/domain/event/__tests__/EditEventPage.test.tsx
@@ -19,6 +19,7 @@ import {
   loadingSpinnerIsNotInDocument,
   renderWithRoute,
   screen,
+  shouldDeleteInstance,
   userEvent,
   waitFor,
   within,
@@ -264,31 +265,18 @@ test('should delete event', async () => {
     // Request to update event
     mockedDeleteEventResponse,
   ];
-
-  const user = userEvent.setup();
   const { history } = renderComponent(mocks);
 
   await waitLoadingAndFindNameInput();
-  const { menu } = await openMenu();
+  await openMenu();
 
-  const deleteButton = within(menu).getByRole('button', {
-    name: 'Poista tapahtuma',
+  await shouldDeleteInstance({
+    confirmDeleteButtonLabel: 'Poista tapahtuma',
+    deleteButtonLabel: 'Poista tapahtuma',
+    expectedNotificationText: 'Tapahtuma on poistettu',
+    expectedUrl: '/fi/search',
+    history,
   });
-  await user.click(deleteButton);
-
-  const modal = screen.getByRole('dialog', {
-    name: 'Varmista tapahtuman poistaminen',
-  });
-  // Delete event button inside modal
-  const confirmDeleteButton = within(modal).getByRole('button', {
-    name: 'Poista tapahtuma',
-  });
-  await user.click(confirmDeleteButton);
-
-  await waitFor(() => expect(modal).not.toBeInTheDocument(), {
-    timeout: 10000,
-  });
-  expect(history.location.pathname).toBe('/fi/search');
 });
 
 test('should update event', async () => {

--- a/src/domain/event/editButtonPanel/__tests__/EditButtonPanel.test.tsx
+++ b/src/domain/event/editButtonPanel/__tests__/EditButtonPanel.test.tsx
@@ -6,8 +6,10 @@ import {
 } from '../../../../utils/mockLoginHooks';
 import {
   configure,
+  openDropdownMenu,
   render,
   screen,
+  shouldToggleDropdownMenu,
   userEvent,
   waitFor,
   within,
@@ -51,13 +53,11 @@ const renderComponent = ({
   });
 
 const getElement = (
-  key: 'back' | 'menu' | 'publish' | 'toggle' | 'updateDraft' | 'updatePublic'
+  key: 'back' | 'publish' | 'toggle' | 'updateDraft' | 'updatePublic'
 ) => {
   switch (key) {
     case 'back':
       return screen.getByRole('button', { name: 'Takaisin' });
-    case 'menu':
-      return screen.getByRole('region', { name: /valinnat/i });
     case 'publish':
       return screen.getByRole('button', { name: 'Hyväksy ja julkaise' });
     case 'toggle':
@@ -86,26 +86,12 @@ const getMenuButton = (
   }
 };
 
-const openMenu = async () => {
-  const user = userEvent.setup();
-  const toggleButton = getElement('toggle');
-  await user.click(toggleButton);
-  const menu = getElement('menu');
-
-  return { menu, toggleButton };
-};
-
 test('should toggle menu by clicking actions button', async () => {
-  const user = userEvent.setup();
   renderComponent({
     props: { event: { ...event, publicationStatus: PublicationStatus.Draft } },
   });
 
-  const { toggleButton } = await openMenu();
-  await user.click(toggleButton);
-  expect(
-    screen.queryByRole('region', { name: /valinnat/i })
-  ).not.toBeInTheDocument();
+  await shouldToggleDropdownMenu();
 });
 
 test('should show correct buttons for draft event', async () => {
@@ -123,7 +109,7 @@ test('should show correct buttons for draft event', async () => {
     },
   });
 
-  const { menu } = await openMenu();
+  const { menu } = await openDropdownMenu();
 
   getMenuButton('copy', menu);
 
@@ -142,7 +128,7 @@ test('should show correct buttons for draft event', async () => {
   await user.click(publishButton);
   expect(onUpdate).toHaveBeenLastCalledWith(PublicationStatus.Public);
 
-  await openMenu();
+  await openDropdownMenu();
 
   const disabledButtons = [
     getMenuButton('postpone', menu),
@@ -158,7 +144,7 @@ test('all buttons should be disabled when user is not logged in (draft)', async 
     props: { event: { ...event, publicationStatus: PublicationStatus.Draft } },
   });
 
-  const { menu } = await openMenu();
+  const { menu } = await openDropdownMenu();
 
   const disabledButtons = [
     getMenuButton('copy', menu),
@@ -188,7 +174,7 @@ test('should render correct buttons for public event', async () => {
     },
   });
 
-  const { menu } = await openMenu();
+  const { menu } = await openDropdownMenu();
 
   getMenuButton('copy', menu);
 
@@ -197,14 +183,14 @@ test('should render correct buttons for public event', async () => {
   await user.click(postponeButton);
   expect(onPostpone).toBeCalled();
 
-  const { menu: menu2 } = await openMenu();
+  const { menu: menu2 } = await openDropdownMenu();
 
   const cancelButton = getMenuButton('cancel', menu2);
   await waitFor(() => expect(cancelButton).toBeEnabled());
   await user.click(cancelButton);
   expect(onCancel).toBeCalled();
 
-  const { menu: menu3 } = await openMenu();
+  const { menu: menu3 } = await openDropdownMenu();
 
   const deleteButton = getMenuButton('delete', menu3);
   await waitFor(() => expect(deleteButton).toBeEnabled());
@@ -234,7 +220,7 @@ test('only copy and delete button should be enabled when event is cancelled', as
     },
   });
 
-  const { menu } = await openMenu();
+  const { menu } = await openDropdownMenu();
 
   const enabledButtons = [
     getMenuButton('delete', menu),
@@ -256,7 +242,7 @@ test('all buttons should be disabled when user is not logged in (public)', async
     props: { event: { ...event, publicationStatus: PublicationStatus.Public } },
   });
 
-  const { menu } = await openMenu();
+  const { menu } = await openDropdownMenu();
 
   const disabledButtons = [
     getMenuButton('copy', menu),
@@ -274,7 +260,7 @@ test('should route to create event page when clicking copy button', async () => 
     props: { event: { ...event, publicationStatus: PublicationStatus.Public } },
   });
 
-  const { menu } = await openMenu();
+  const { menu } = await openDropdownMenu();
 
   const copyButton = getMenuButton('copy', menu);
   await waitFor(() => expect(copyButton).toBeEnabled());

--- a/src/domain/event/modals/confirmCancelEventModal/__tests__/ConfirmCancelEventModal.test.tsx
+++ b/src/domain/event/modals/confirmCancelEventModal/__tests__/ConfirmCancelEventModal.test.tsx
@@ -3,7 +3,7 @@ import {
   configure,
   render,
   screen,
-  userEvent,
+  shouldClickButton,
 } from '../../../../../utils/testUtils';
 import translations from '../../../../app/i18n/fi.json';
 import { TEST_REGISTRATION_ID } from '../../../../registration/constants';
@@ -70,24 +70,17 @@ test.each([
 
 test('should call onConfirm', async () => {
   const onConfirm = vi.fn();
-  const user = userEvent.setup();
-
   renderComponent({ onConfirm });
 
-  const cancelEventButton = screen.getByRole('button', {
-    name: 'Peruuta tapahtuma',
+  await shouldClickButton({
+    buttonLabel: 'Peruuta tapahtuma',
+    onClick: onConfirm,
   });
-  await user.click(cancelEventButton);
-  expect(onConfirm).toBeCalled();
 });
 
 test('should call onClose', async () => {
   const onClose = vi.fn();
-  const user = userEvent.setup();
-
   renderComponent({ onClose });
 
-  const closeButton = screen.getByRole('button', { name: 'Peruuta' });
-  await user.click(closeButton);
-  expect(onClose).toBeCalled();
+  await shouldClickButton({ buttonLabel: 'Peruuta', onClick: onClose });
 });

--- a/src/domain/event/modals/confirmDeleteEventModal/__tests__/ConfirmDeleteEventModal.test.tsx
+++ b/src/domain/event/modals/confirmDeleteEventModal/__tests__/ConfirmDeleteEventModal.test.tsx
@@ -1,11 +1,9 @@
-import React from 'react';
-
 import generateAtId from '../../../../../utils/generateAtId';
 import {
   configure,
   render,
   screen,
-  userEvent,
+  shouldClickButton,
 } from '../../../../../utils/testUtils';
 import translations from '../../../../app/i18n/fi.json';
 import { TEST_REGISTRATION_ID } from '../../../../registration/constants';
@@ -69,24 +67,17 @@ test.each([
 
 test('should call onConfirm', async () => {
   const onConfirm = vi.fn();
-  const user = userEvent.setup();
-
   renderComponent({ onConfirm });
 
-  const deleteEventButton = screen.getByRole('button', {
-    name: 'Poista tapahtuma',
+  await shouldClickButton({
+    buttonLabel: 'Poista tapahtuma',
+    onClick: onConfirm,
   });
-  await user.click(deleteEventButton);
-  expect(onConfirm).toBeCalled();
 });
 
 test('should call onClose', async () => {
   const onClose = vi.fn();
-  const user = userEvent.setup();
-
   renderComponent({ onClose });
 
-  const closeButton = screen.getByRole('button', { name: 'Peruuta' });
-  await user.click(closeButton);
-  expect(onClose).toBeCalled();
+  await shouldClickButton({ buttonLabel: 'Peruuta', onClick: onClose });
 });

--- a/src/domain/event/modals/confirmPostponeEventModal/__tests__/ConfirmPostponeEventModal.test.tsx
+++ b/src/domain/event/modals/confirmPostponeEventModal/__tests__/ConfirmPostponeEventModal.test.tsx
@@ -1,10 +1,8 @@
-import React from 'react';
-
 import {
   configure,
   render,
   screen,
-  userEvent,
+  shouldClickButton,
 } from '../../../../../utils/testUtils';
 import translations from '../../../../app/i18n/fi.json';
 import {
@@ -50,24 +48,17 @@ test('should render component', async () => {
 
 test('should call onConfirm', async () => {
   const onConfirm = vi.fn();
-  const user = userEvent.setup();
-
   renderComponent({ onConfirm });
 
-  const postponeEventButton = screen.getByRole('button', {
-    name: 'Lykkää tapahtumaa',
+  await shouldClickButton({
+    buttonLabel: 'Lykkää tapahtumaa',
+    onClick: onConfirm,
   });
-  await user.click(postponeEventButton);
-  expect(onConfirm).toBeCalled();
 });
 
 test('should call onClose', async () => {
   const onClose = vi.fn();
-  const user = userEvent.setup();
-
   renderComponent({ onClose });
 
-  const closeButton = screen.getByRole('button', { name: 'Peruuta' });
-  await user.click(closeButton);
-  expect(onClose).toBeCalled();
+  await shouldClickButton({ buttonLabel: 'Peruuta', onClick: onClose });
 });

--- a/src/domain/event/modals/confirmUpdateEventModal/__tests__/ConfirmUpdateEventModal.test.tsx
+++ b/src/domain/event/modals/confirmUpdateEventModal/__tests__/ConfirmUpdateEventModal.test.tsx
@@ -1,10 +1,8 @@
-import React from 'react';
-
 import {
   configure,
   render,
   screen,
-  userEvent,
+  shouldClickButton,
 } from '../../../../../utils/testUtils';
 import translations from '../../../../app/i18n/fi.json';
 import {
@@ -49,22 +47,14 @@ test('should render component', async () => {
 
 test('should call onConfirm', async () => {
   const onConfirm = vi.fn();
-  const user = userEvent.setup();
-
   renderComponent({ onConfirm });
 
-  const updateEventButton = screen.getByRole('button', { name: 'Tallenna' });
-  await user.click(updateEventButton);
-  expect(onConfirm).toBeCalled();
+  await shouldClickButton({ buttonLabel: 'Tallenna', onClick: onConfirm });
 });
 
 test('should call onClose', async () => {
   const onClose = vi.fn();
-  const user = userEvent.setup();
-
   renderComponent({ onClose });
 
-  const closeButton = screen.getByRole('button', { name: 'Peruuta' });
-  await user.click(closeButton);
-  expect(onClose).toBeCalled();
+  await shouldClickButton({ buttonLabel: 'Peruuta', onClick: onClose });
 });

--- a/src/domain/eventSearch/__tests__/EventSearchPage.test.tsx
+++ b/src/domain/eventSearch/__tests__/EventSearchPage.test.tsx
@@ -7,8 +7,8 @@ import {
   loadingSpinnerIsNotInDocument,
   render,
   screen,
+  shouldApplyExpectedMetaData,
   waitFor,
-  waitPageMetaDataToBeSet,
 } from '../../../utils/testUtils';
 import { mockedUserResponse } from '../../user/__mocks__/user';
 import {
@@ -44,16 +44,15 @@ const renderComponent = () =>
   render(<EventSearchPage />, { mocks, routes: [route] });
 
 test('applies expected metadata', async () => {
-  const pageTitle = 'Etsi tapahtumia - Linked Events';
-  const pageDescription =
-    'Hae tapahtumia Linked Eventsistä. Voit suodattaa tuloksia päivämäärän, paikan ja tyypin mukaan.';
-  const pageKeywords =
-    'haku, suodatus, päivämäärä, paikka, linked, events, tapahtuma, hallinta, api, admin, Helsinki, Suomi';
-
   renderComponent();
-  await loadingSpinnerIsNotInDocument();
 
-  await waitPageMetaDataToBeSet({ pageDescription, pageKeywords, pageTitle });
+  await shouldApplyExpectedMetaData({
+    expectedDescription:
+      'Hae tapahtumia Linked Eventsistä. Voit suodattaa tuloksia päivämäärän, paikan ja tyypin mukaan.',
+    expectedKeywords:
+      'haku, suodatus, päivämäärä, paikka, linked, events, tapahtuma, hallinta, api, admin, Helsinki, Suomi',
+    expectedTitle: 'Etsi tapahtumia - Linked Events',
+  });
 });
 
 test('should render events in the event list', async () => {

--- a/src/domain/events/__tests__/EventsPage.test.tsx
+++ b/src/domain/events/__tests__/EventsPage.test.tsx
@@ -8,9 +8,11 @@ import {
   loadingSpinnerIsNotInDocument,
   render,
   screen,
+  shouldApplyExpectedMetaData,
+  shouldClickListPageCreateButton,
+  shouldSortListPageTable,
   userEvent,
   waitFor,
-  waitPageMetaDataToBeSet,
 } from '../../../utils/testUtils';
 import { mockedOrganizationResponse } from '../../organization/__mocks__/organization';
 import { mockedOrganizationAncestorsResponse } from '../../organization/__mocks__/organizationAncestors';
@@ -67,18 +69,14 @@ beforeEach(() => {
 
 const getElement = (
   key:
-    | 'createEventButton'
     | 'draftsTab'
     | 'eventCardType'
     | 'ownPublishedTab'
     | 'publishedTab'
-    | 'sortName'
     | 'waitingApprovalTab'
     | 'waitingApprovalTable'
 ) => {
   switch (key) {
-    case 'createEventButton':
-      return screen.getByRole('button', { name: /lisää uusi tapahtuma/i });
     case 'draftsTab':
       return screen.getByRole('tab', {
         name: `Luonnokset (${draftEventsCount})`,
@@ -93,8 +91,6 @@ const getElement = (
       return screen.getByRole('tab', {
         name: `Julkaistut (${publicEventsCount})`,
       });
-    case 'sortName':
-      return screen.getByRole('button', { name: 'Nimi' });
     case 'waitingApprovalTab':
       return screen.getByRole('tab', {
         name: `Odottaa (${waitingApprovalEventsCount})`,
@@ -132,15 +128,15 @@ const findElement = (
 };
 
 test('should show correct title, description and keywords', async () => {
-  const pageTitle = 'Omat tapahtumat - Linked Events';
-  const pageDescription =
-    'Tapahtumien listaus. Hallinnoi tapahtumia: selaa ja muokkaa tapahtumia.';
-  const pageKeywords =
-    'minun, luetteloni, muokkaa, päivitä, linked, events, tapahtuma, hallinta, api, admin, Helsinki, Suomi';
-
   renderComponent();
 
-  await waitPageMetaDataToBeSet({ pageDescription, pageKeywords, pageTitle });
+  await shouldApplyExpectedMetaData({
+    expectedDescription:
+      'Tapahtumien listaus. Hallinnoi tapahtumia: selaa ja muokkaa tapahtumia.',
+    expectedKeywords:
+      'minun, luetteloni, muokkaa, päivitä, linked, events, tapahtuma, hallinta, api, admin, Helsinki, Suomi',
+    expectedTitle: 'Omat tapahtumat - Linked Events',
+  });
 });
 
 test('should render events page', async () => {
@@ -155,15 +151,13 @@ test('should render events page', async () => {
 });
 
 test('should open create event page', async () => {
-  const user = userEvent.setup();
   const { history } = renderComponent();
 
-  await loadingSpinnerIsNotInDocument(10000);
-
-  const createEventButton = getElement('createEventButton');
-  await user.click(createEventButton);
-
-  expect(history.location.pathname).toBe('/fi/events/create');
+  await shouldClickListPageCreateButton({
+    createButtonLabel: /lisää uusi tapahtuma/i,
+    expectedPathname: '/fi/events/create',
+    history,
+  });
 });
 
 test('should change list type to event card', async () => {
@@ -222,16 +216,13 @@ test('should change active tab to drafts', async () => {
 });
 
 test('should add sort parameter to search query', async () => {
-  const user = userEvent.setup();
-
   const { history } = renderComponent();
 
-  await loadingSpinnerIsNotInDocument(10000);
-
-  const sortNameButton = getElement('sortName');
-  await user.click(sortNameButton);
-
-  expect(history.location.search).toBe('?sort=name');
+  await shouldSortListPageTable({
+    columnHeader: 'Nimi',
+    expectedSearch: '?sort=name',
+    history,
+  });
 });
 
 it('scrolls to event table row and calls history.replace correctly (deletes eventId from state)', async () => {

--- a/src/domain/events/eventActionsDropdown/__tests__/EventActionsDropdown.test.tsx
+++ b/src/domain/events/eventActionsDropdown/__tests__/EventActionsDropdown.test.tsx
@@ -9,8 +9,10 @@ import {
 } from '../../../../utils/mockLoginHooks';
 import {
   configure,
+  openDropdownMenu,
   render,
   screen,
+  shouldToggleDropdownMenu,
   userEvent,
   waitFor,
   within,
@@ -65,15 +67,7 @@ const renderComponent = ({
   });
 
 const getElement = (
-  key:
-    | 'cancel'
-    | 'copy'
-    | 'delete'
-    | 'edit'
-    | 'menu'
-    | 'postpone'
-    | 'toggle'
-    | 'email'
+  key: 'cancel' | 'copy' | 'delete' | 'edit' | 'postpone' | 'email'
 ) => {
   switch (key) {
     case 'cancel':
@@ -84,41 +78,23 @@ const getElement = (
       return screen.getByRole('button', { name: 'Poista tapahtuma' });
     case 'edit':
       return screen.getByRole('button', { name: 'Muokkaa tapahtumaa' });
-    case 'menu':
-      return screen.getByRole('region', { name: /valinnat/i });
     case 'postpone':
       return screen.getByRole('button', { name: 'Lykkää tapahtumaa' });
-    case 'toggle':
-      return screen.getByRole('button', { name: /valinnat/i });
     case 'email':
       return screen.getByRole('button', { name: 'Lähetä sähköposti' });
   }
 };
 
-const openMenu = async () => {
-  const user = userEvent.setup();
-  const toggleButton = getElement('toggle');
-  await user.click(toggleButton);
-  getElement('menu');
-
-  return toggleButton;
-};
-
 test('should toggle menu by clicking actions button', async () => {
-  const user = userEvent.setup();
   renderComponent();
 
-  const toggleButton = await openMenu();
-  await user.click(toggleButton);
-  expect(
-    screen.queryByRole('region', { name: /valinnat/i })
-  ).not.toBeInTheDocument();
+  await shouldToggleDropdownMenu();
 });
 
 test('should render correct buttons for draft event', async () => {
   renderComponent({ props: { event: draftEvent } });
 
-  await openMenu();
+  await openDropdownMenu();
 
   const disabledButtons = [getElement('postpone'), getElement('cancel')];
   disabledButtons.forEach((button) => expect(button).toBeDisabled());
@@ -135,7 +111,7 @@ test('only edit button should be enabled when user is not logged in (draft)', as
   mockUnauthenticatedLoginState();
   renderComponent({ props: { event: draftEvent } });
 
-  await openMenu();
+  await openDropdownMenu();
 
   const disabledButtons = [
     getElement('copy'),
@@ -154,7 +130,7 @@ test('should render correct buttons for public event', async () => {
     props: { event: publicEvent },
   });
 
-  await openMenu();
+  await openDropdownMenu();
 
   const enabledButtons = [
     getElement('cancel'),
@@ -169,7 +145,7 @@ test('should render correct buttons for public event', async () => {
 test('only copy, edit and delete button should be enabled when event is cancelled', async () => {
   renderComponent({ props: { event: cancelledEvent } });
 
-  await openMenu();
+  await openDropdownMenu();
 
   const disabledButtons = [getElement('postpone'), getElement('cancel')];
   disabledButtons.forEach((button) => expect(button).toBeDisabled());
@@ -186,7 +162,7 @@ test('only edit button should be enabled when user is not logged in (public)', a
   mockUnauthenticatedLoginState();
   renderComponent({ props: { event: publicEvent } });
 
-  await openMenu();
+  await openDropdownMenu();
 
   const disabledButtons = [
     getElement('copy'),
@@ -206,7 +182,7 @@ test('should route to create event page when clicking copy button', async () => 
     props: { event: publicEvent },
   });
 
-  await openMenu();
+  await openDropdownMenu();
 
   const copyButton = getElement('copy');
   await waitFor(() => expect(copyButton).toBeEnabled());
@@ -221,7 +197,7 @@ test('should route to edit page when clicking edit button', async () => {
   const user = userEvent.setup();
   const { history } = renderComponent({ props: { event: publicEvent } });
 
-  await openMenu();
+  await openDropdownMenu();
 
   const editButton = getElement('edit');
   await user.click(editButton);
@@ -238,7 +214,7 @@ test('should cancel event', async () => {
 
   renderComponent({ props: { event }, mocks });
 
-  await openMenu();
+  await openDropdownMenu();
 
   const cancelButton = getElement('cancel');
   await user.click(cancelButton);
@@ -260,7 +236,7 @@ test('should delete event', async () => {
 
   renderComponent({ props: { event }, mocks });
 
-  await openMenu();
+  await openDropdownMenu();
 
   const deleteButton = getElement('delete');
   await user.click(deleteButton);
@@ -285,7 +261,7 @@ test('should postpone event', async () => {
 
   renderComponent({ props: { event }, mocks });
 
-  await openMenu();
+  await openDropdownMenu();
 
   const postponeButton = getElement('postpone');
   await user.click(postponeButton);
@@ -315,7 +291,7 @@ test('should call the mailto function when clicking Send Email button', async ()
   const user = userEvent.setup();
   renderComponent({ props: { event: specialEvent }, mocks });
 
-  await openMenu();
+  await openDropdownMenu();
 
   const sendMailButton = getElement('email');
   await user.click(sendMailButton);
@@ -344,7 +320,7 @@ test('should find the email address even when the createdBy field has extra dash
   const user = userEvent.setup();
   renderComponent({ props: { event: specialEvent }, mocks });
 
-  await openMenu();
+  await openDropdownMenu();
 
   const sendMailButton = getElement('email');
   await user.click(sendMailButton);

--- a/src/domain/events/eventList/EventList.tsx
+++ b/src/domain/events/eventList/EventList.tsx
@@ -172,7 +172,7 @@ const EventListContainer: React.FC<EventListContainerProps> = (props) => {
   const { count, onSortChange, ...listProps } = useCommonListProps({
     defaultSort: DEFAULT_EVENT_SORT,
     listId: eventListId,
-    meta: eventsData?.events.meta,
+    meta: eventsData?.events?.meta,
     pageSize: EVENTS_PAGE_SIZE,
   });
 

--- a/src/domain/feedback/hooks/__tests__/useFeedbackServerErrors.test.ts
+++ b/src/domain/feedback/hooks/__tests__/useFeedbackServerErrors.test.ts
@@ -1,7 +1,9 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-import { ApolloError } from '@apollo/client';
-import { act, renderHook } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
 
+import {
+  shouldSetGenericServerErrors,
+  shouldSetServerErrors,
+} from '../../../../utils/testUtils';
 import useFeedbackServerErrors from '../useFeedbackServerErrors';
 
 const getHookWrapper = () => {
@@ -14,33 +16,15 @@ const getHookWrapper = () => {
 it('should set generic server error items', async () => {
   const { result } = getHookWrapper();
 
-  const error = new ApolloError({
-    networkError: {
-      result: { detail: 'Metodi "POST" ei ole sallittu.' },
-    } as any,
-  });
-
-  act(() => result.current.showServerErrors({ error }));
-
-  expect(result.current.serverErrorItems).toEqual([
-    { label: '', message: 'Metodi "POST" ei ole sallittu.' },
-  ]);
+  shouldSetGenericServerErrors(result);
 });
 
 it('should set server error items', async () => {
-  const callbackFn = vi.fn();
   const { result } = getHookWrapper();
 
-  const error = new ApolloError({
-    networkError: {
-      result: { body: ['Arvo saa olla enintään 255 merkkiä pitkä.'] },
-    } as any,
-  });
-
-  act(() => result.current.showServerErrors({ callbackFn, error }));
-
-  expect(result.current.serverErrorItems).toEqual([
-    { label: 'Viesti', message: 'Arvo saa olla enintään 255 merkkiä pitkä.' },
-  ]);
-  expect(callbackFn).toBeCalled();
+  await shouldSetServerErrors(
+    result,
+    { body: ['Arvo saa olla enintään 255 merkkiä pitkä.'] },
+    [{ label: 'Viesti', message: 'Arvo saa olla enintään 255 merkkiä pitkä.' }]
+  );
 });

--- a/src/domain/image/__tests__/CreateImagePage.test.tsx
+++ b/src/domain/image/__tests__/CreateImagePage.test.tsx
@@ -1,16 +1,15 @@
 import { testIds } from '../../../constants';
 import { mockAuthenticatedLoginState } from '../../../utils/mockLoginHooks';
 import {
-  actWait,
   configure,
   fireEvent,
   loadingSpinnerIsNotInDocument,
   mockFile,
   render,
   screen,
+  shouldApplyExpectedMetaData,
   userEvent,
   waitFor,
-  waitPageMetaDataToBeSet,
   within,
 } from '../../../utils/testUtils';
 import {
@@ -113,16 +112,14 @@ const uploadImageByUrl = async () => {
 };
 
 test('applies expected metadata', async () => {
-  const pageTitle = 'Lisää kuva - Linked Events';
-  const pageDescription = 'Lisää uusi kuva Linked Eventsiin.';
-  const pageKeywords =
-    'lisää, uusi, kuva, muokkaa, lataa, linked, events, tapahtuma, hallinta, api, admin, Helsinki, Suomi';
-
   renderComponent();
-  await loadingSpinnerIsNotInDocument();
 
-  await waitPageMetaDataToBeSet({ pageDescription, pageKeywords, pageTitle });
-  await actWait(10);
+  await shouldApplyExpectedMetaData({
+    expectedDescription: 'Lisää uusi kuva Linked Eventsiin.',
+    expectedKeywords:
+      'lisää, uusi, kuva, muokkaa, lataa, linked, events, tapahtuma, hallinta, api, admin, Helsinki, Suomi',
+    expectedTitle: 'Lisää kuva - Linked Events',
+  });
 });
 
 test('should scroll to first validation error input field', async () => {

--- a/src/domain/image/hooks/__tests__/useImageServerErrors.test.ts
+++ b/src/domain/image/hooks/__tests__/useImageServerErrors.test.ts
@@ -1,7 +1,9 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-import { ApolloError } from '@apollo/client';
-import { act, renderHook } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
 
+import {
+  shouldSetGenericServerErrors,
+  shouldSetServerErrors,
+} from '../../../../utils/testUtils';
 import useImageServerErrors from '../useImageServerErrors';
 
 const getHookWrapper = () => {
@@ -14,31 +16,15 @@ const getHookWrapper = () => {
 it('should set generic server error items', async () => {
   const { result } = getHookWrapper();
 
-  const error = new ApolloError({
-    networkError: {
-      result: { detail: 'Metodi "POST" ei ole sallittu.' },
-    } as any,
-  });
-
-  act(() => result.current.showServerErrors({ error }));
-
-  expect(result.current.serverErrorItems).toEqual([
-    { label: '', message: 'Metodi "POST" ei ole sallittu.' },
-  ]);
+  shouldSetGenericServerErrors(result);
 });
 
 it('should set server error items', async () => {
-  const callbackFn = vi.fn();
   const { result } = getHookWrapper();
 
-  const error = new ApolloError({
-    networkError: { result: { name: ['The name must be specified.'] } } as any,
-  });
-
-  act(() => result.current.showServerErrors({ callbackFn, error }));
-
-  expect(result.current.serverErrorItems).toEqual([
-    { label: 'Kuvateksti', message: 'Nimi on pakollinen.' },
-  ]);
-  expect(callbackFn).toBeCalled();
+  await shouldSetServerErrors(
+    result,
+    { name: ['The name must be specified.'] },
+    [{ label: 'Kuvateksti', message: 'Nimi on pakollinen.' }]
+  );
 });

--- a/src/domain/image/modals/confirmDeleteImageModal/__tests__/ConfirmDeleteImageModal.test.tsx
+++ b/src/domain/image/modals/confirmDeleteImageModal/__tests__/ConfirmDeleteImageModal.test.tsx
@@ -1,10 +1,8 @@
-import React from 'react';
-
 import {
   configure,
   render,
-  screen,
-  userEvent,
+  shouldClickButton,
+  shouldRenderDeleteModal,
 } from '../../../../../utils/testUtils';
 import ConfirmDeleteImageModal, {
   ConfirmDeleteImageModalProps,
@@ -24,32 +22,24 @@ const renderComponent = (props?: Partial<ConfirmDeleteImageModalProps>) =>
 
 test('should render component', async () => {
   renderComponent();
-  screen.getByRole('heading', { name: 'Varmista kuvan poistaminen' });
-  screen.getByText('Varoitus!');
-  screen.getByText('Tämä toiminto poistaa kuvan lopullisesti.');
 
-  screen.getByRole('button', { name: 'Poista kuva' });
-  screen.getByRole('button', { name: 'Peruuta' });
+  shouldRenderDeleteModal({
+    confirmButtonLabel: 'Poista kuva',
+    heading: 'Varmista kuvan poistaminen',
+    text: 'Tämä toiminto poistaa kuvan lopullisesti.',
+  });
 });
 
 test('should call onConfirm', async () => {
   const onConfirm = vi.fn();
-  const user = userEvent.setup();
-
   renderComponent({ onConfirm });
 
-  const deleteButton = screen.getByRole('button', { name: 'Poista kuva' });
-  await user.click(deleteButton);
-  expect(onConfirm).toBeCalled();
+  await shouldClickButton({ buttonLabel: 'Poista kuva', onClick: onConfirm });
 });
 
 test('should call onClose', async () => {
   const onClose = vi.fn();
-  const user = userEvent.setup();
-
   renderComponent({ onClose });
 
-  const closeButton = screen.getByRole('button', { name: 'Peruuta' });
-  await user.click(closeButton);
-  expect(onClose).toBeCalled();
+  await shouldClickButton({ buttonLabel: 'Peruuta', onClick: onClose });
 });

--- a/src/domain/images/__tests__/ImagesPage.test.tsx
+++ b/src/domain/images/__tests__/ImagesPage.test.tsx
@@ -8,9 +8,11 @@ import {
   loadingSpinnerIsNotInDocument,
   render,
   screen,
-  userEvent,
+  shouldApplyExpectedMetaData,
+  shouldClickListPageCreateButton,
+  shouldRenderListPage,
+  shouldSortListPageTable,
   waitFor,
-  waitPageMetaDataToBeSet,
 } from '../../../utils/testUtils';
 import { mockedOrganizationAncestorsResponse } from '../../organization/__mocks__/organizationAncestors';
 import { mockedUserResponse } from '../../user/__mocks__/user';
@@ -48,87 +50,50 @@ const renderComponent = (renderOptions: CustomRenderOptions = {}) =>
     ...renderOptions,
   });
 
-const findElement = (key: 'title') => {
-  switch (key) {
-    case 'title':
-      return screen.findByRole('heading', { name: 'Kuvat' });
-  }
-};
-
-const getElement = (
-  key:
-    | 'breadcrumb'
-    | 'createImageButton'
-    | 'searchInput'
-    | 'sortLastModifiedButton'
-    | 'table'
-    | 'title'
-) => {
-  switch (key) {
-    case 'breadcrumb':
-      return screen.getByRole('navigation', { name: 'Murupolku' });
-    case 'createImageButton':
-      return screen.getByRole('button', { name: 'Lisää kuva' });
-    case 'searchInput':
-      return screen.getByRole('combobox', { name: 'Hae kuvia' });
-    case 'sortLastModifiedButton':
-      return screen.getByRole('button', { name: /viimeksi muokattu/i });
-    case 'table':
-      return screen.getByRole('table', {
-        name: 'Kuvat, järjestys Viimeksi muokattu, laskeva',
-      });
-    case 'title':
-      return screen.getByRole('heading', { name: 'Kuvat' });
-  }
-};
+const findHeading = () => screen.findByRole('heading', { name: 'Kuvat' });
 
 test('should render images page', async () => {
   renderComponent();
 
-  await findElement('title');
-  await loadingSpinnerIsNotInDocument();
-  getElement('breadcrumb');
-  getElement('createImageButton');
-  getElement('searchInput');
-  getElement('table');
+  await shouldRenderListPage({
+    createButtonLabel: 'Lisää kuva',
+    heading: 'Kuvat',
+    searchInputLabel: 'Hae kuvia',
+    tableCaption: 'Kuvat, järjestys Viimeksi muokattu, laskeva',
+  });
 });
 
 test('applies expected metadata', async () => {
-  const pageTitle = 'Kuvat - Linked Events';
-  const pageDescription =
-    'Kuvien listaus. Selaa, suodata ja muokkaa Linked Events -kuvia.';
-  const pageKeywords =
-    'kuva, lista, selailla, linked, events, tapahtuma, hallinta, api, admin, Helsinki, Suomi';
-
   renderComponent();
-  await loadingSpinnerIsNotInDocument();
 
-  await waitPageMetaDataToBeSet({ pageDescription, pageKeywords, pageTitle });
+  await shouldApplyExpectedMetaData({
+    expectedDescription:
+      'Kuvien listaus. Selaa, suodata ja muokkaa Linked Events -kuvia.',
+    expectedKeywords:
+      'kuva, lista, selailla, linked, events, tapahtuma, hallinta, api, admin, Helsinki, Suomi',
+    expectedTitle: 'Kuvat - Linked Events',
+  });
 });
 
 test('should open create image page', async () => {
-  const user = userEvent.setup();
   const { history } = renderComponent();
 
-  await findElement('title');
-  await loadingSpinnerIsNotInDocument();
-
-  const createImageButton = getElement('createImageButton');
-  await user.click(createImageButton);
-
-  expect(history.location.pathname).toBe('/fi/administration/images/create');
+  await findHeading();
+  await shouldClickListPageCreateButton({
+    createButtonLabel: 'Lisää kuva',
+    expectedPathname: '/fi/administration/images/create',
+    history,
+  });
 });
 
 test('should add sort parameter to search query', async () => {
-  const user = userEvent.setup();
   const { history } = renderComponent();
 
-  await loadingSpinnerIsNotInDocument();
-
-  const sortLastModifiedButton = getElement('sortLastModifiedButton');
-  await user.click(sortLastModifiedButton);
-
-  expect(history.location.search).toBe('?sort=last_modified_time');
+  await shouldSortListPageTable({
+    columnHeader: 'Viimeksi muokattu',
+    expectedSearch: '?sort=last_modified_time',
+    history,
+  });
 });
 
 it('scrolls to image row and calls history.replace correctly (deletes imageId from state)', async () => {

--- a/src/domain/images/imageActionsDropdown/__tests__/ImageActionsDropdown.test.tsx
+++ b/src/domain/images/imageActionsDropdown/__tests__/ImageActionsDropdown.test.tsx
@@ -3,8 +3,10 @@ import { mockAuthenticatedLoginState } from '../../../../utils/mockLoginHooks';
 import stripLanguageFromPath from '../../../../utils/stripLanguageFromPath';
 import {
   configure,
+  openDropdownMenu,
   render,
   screen,
+  shouldToggleDropdownMenu,
   userEvent,
   waitFor,
   within,
@@ -46,45 +48,23 @@ const renderComponent = () =>
     routes,
   });
 
-const getElement = (key: 'deleteButton' | 'editButton' | 'menu' | 'toggle') => {
-  switch (key) {
-    case 'deleteButton':
-      return screen.getByRole('button', { name: /poista kuva/i });
-    case 'editButton':
-      return screen.getByRole('button', { name: /muokkaa/i });
-    case 'menu':
-      return screen.getByRole('region', { name: /valinnat/i });
-    case 'toggle':
-      return screen.getByRole('button', { name: /valinnat/i });
-  }
-};
+const getDeleteButton = () =>
+  screen.getByRole('button', { name: /poista kuva/i });
 
-const openMenu = async () => {
-  const user = userEvent.setup();
-  const toggleButton = getElement('toggle');
-  await user.click(toggleButton);
-  getElement('menu');
-
-  return toggleButton;
-};
+const getEditButton = () => screen.getByRole('button', { name: /muokkaa/i });
 
 test('should toggle menu by clicking actions button', async () => {
-  const user = userEvent.setup();
   renderComponent();
 
-  const toggleButton = await openMenu();
-  await user.click(toggleButton);
-  expect(
-    screen.queryByRole('region', { name: /valinnat/i })
-  ).not.toBeInTheDocument();
+  await shouldToggleDropdownMenu();
 });
 
 test('should render correct buttons', async () => {
   renderComponent();
 
-  await openMenu();
+  await openDropdownMenu();
 
-  const enabledButtons = [getElement('deleteButton'), getElement('editButton')];
+  const enabledButtons = [getDeleteButton(), getEditButton()];
   enabledButtons.forEach((button) => expect(button).toBeEnabled());
 });
 
@@ -92,9 +72,9 @@ test('should route to edit image page', async () => {
   const user = userEvent.setup();
   const { history } = renderComponent();
 
-  await openMenu();
+  await openDropdownMenu();
 
-  const editButton = getElement('editButton');
+  const editButton = getEditButton();
   await user.click(editButton);
 
   await waitFor(() =>
@@ -112,9 +92,9 @@ test('should delete image', async () => {
   const user = userEvent.setup();
   renderComponent();
 
-  await openMenu();
+  await openDropdownMenu();
 
-  const deleteButton = getElement('deleteButton');
+  const deleteButton = getDeleteButton();
   await user.click(deleteButton);
 
   const withinModal = within(screen.getByRole('dialog'));

--- a/src/domain/images/imageList/ImageList.tsx
+++ b/src/domain/images/imageList/ImageList.tsx
@@ -99,7 +99,7 @@ const ImageListContainer: React.FC = () => {
   const { count, onSearchSubmit, ...listProps } = useCommonListProps({
     defaultSort: DEFAULT_IMAGE_SORT,
     listId: imageListId,
-    meta: imagesData?.images.meta,
+    meta: imagesData?.images?.meta,
     pageSize: IMAGES_PAGE_SIZE,
   });
 

--- a/src/domain/keyword/__tests__/CreateKeywordPage.test.tsx
+++ b/src/domain/keyword/__tests__/CreateKeywordPage.test.tsx
@@ -10,9 +10,9 @@ import {
   loadingSpinnerIsNotInDocument,
   render,
   screen,
+  shouldApplyExpectedMetaData,
   userEvent,
   waitFor,
-  waitPageMetaDataToBeSet,
 } from '../../../utils/testUtils';
 import { mockedOrganizationResponse } from '../../organization/__mocks__/organization';
 import { mockedUserResponse } from '../../user/__mocks__/user';
@@ -86,15 +86,14 @@ test('form should be disabled if user is not authenticated', async () => {
 });
 
 test('applies expected metadata', async () => {
-  const pageTitle = 'Lisää avainsana - Linked Events';
-  const pageDescription = 'Lisää uusi avainsana Linked Eventsiin.';
-  const pageKeywords =
-    'lisää, uusi, avainsana, linked, events, tapahtuma, hallinta, api, admin, Helsinki, Suomi';
-
   renderComponent();
-  await loadingSpinnerIsNotInDocument();
 
-  await waitPageMetaDataToBeSet({ pageDescription, pageKeywords, pageTitle });
+  await shouldApplyExpectedMetaData({
+    expectedDescription: 'Lisää uusi avainsana Linked Eventsiin.',
+    expectedKeywords:
+      'lisää, uusi, avainsana, linked, events, tapahtuma, hallinta, api, admin, Helsinki, Suomi',
+    expectedTitle: 'Lisää avainsana - Linked Events',
+  });
 });
 
 test('should focus to first validation error when trying to save new keyword', async () => {

--- a/src/domain/keyword/hooks/__tests__/useKeywordServerErrors.test.ts
+++ b/src/domain/keyword/hooks/__tests__/useKeywordServerErrors.test.ts
@@ -1,7 +1,9 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-import { ApolloError } from '@apollo/client';
-import { act, renderHook } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
 
+import {
+  shouldSetGenericServerErrors,
+  shouldSetServerErrors,
+} from '../../../../utils/testUtils';
 import useKeywordServerErrors from '../useKeywordServerErrors';
 
 const getHookWrapper = () => {
@@ -14,31 +16,15 @@ const getHookWrapper = () => {
 it('should set generic server error items', async () => {
   const { result } = getHookWrapper();
 
-  const error = new ApolloError({
-    networkError: {
-      result: { detail: 'Metodi "POST" ei ole sallittu.' },
-    } as any,
-  });
-
-  act(() => result.current.showServerErrors({ error }));
-
-  expect(result.current.serverErrorItems).toEqual([
-    { label: '', message: 'Metodi "POST" ei ole sallittu.' },
-  ]);
+  shouldSetGenericServerErrors(result);
 });
 
 it('should set server error items', async () => {
-  const callbackFn = vi.fn();
   const { result } = getHookWrapper();
 
-  const error = new ApolloError({
-    networkError: { result: { name: ['The name must be specified.'] } } as any,
-  });
-
-  act(() => result.current.showServerErrors({ callbackFn, error }));
-
-  expect(result.current.serverErrorItems).toEqual([
-    { label: 'Nimi', message: 'Nimi on pakollinen.' },
-  ]);
-  expect(callbackFn).toBeCalled();
+  await shouldSetServerErrors(
+    result,
+    { name: ['The name must be specified.'] },
+    [{ label: 'Nimi', message: 'Nimi on pakollinen.' }]
+  );
 });

--- a/src/domain/keyword/modals/confirmDeleteKeywordModal/__tests__/ConfirmDeleteKeywordModal.test.tsx
+++ b/src/domain/keyword/modals/confirmDeleteKeywordModal/__tests__/ConfirmDeleteKeywordModal.test.tsx
@@ -1,10 +1,8 @@
-import React from 'react';
-
 import {
   configure,
   render,
-  screen,
-  userEvent,
+  shouldClickButton,
+  shouldRenderDeleteModal,
 } from '../../../../../utils/testUtils';
 import ConfirmDeleteKeywordModal, {
   ConfirmDeleteKeywordModalProps,
@@ -24,30 +22,27 @@ const renderComponent = (props?: Partial<ConfirmDeleteKeywordModalProps>) =>
 
 test('should render component', async () => {
   renderComponent();
-  screen.getByRole('heading', { name: 'Varmista avainsanan poistaminen' });
-  screen.getByText('Varoitus!');
-  screen.getByText('Tämä toiminto poistaa avainsanan lopullisesti.');
 
-  screen.getByRole('button', { name: 'Poista avainsana' });
-  screen.getByRole('button', { name: 'Peruuta' });
+  shouldRenderDeleteModal({
+    confirmButtonLabel: 'Poista avainsana',
+    heading: 'Varmista avainsanan poistaminen',
+    text: 'Tämä toiminto poistaa avainsanan lopullisesti.',
+  });
 });
 
 test('should call onConfirm', async () => {
   const onConfirm = vi.fn();
-  const user = userEvent.setup();
   renderComponent({ onConfirm });
 
-  const deleteButton = screen.getByRole('button', { name: 'Poista avainsana' });
-  await user.click(deleteButton);
-  expect(onConfirm).toBeCalled();
+  await shouldClickButton({
+    buttonLabel: 'Poista avainsana',
+    onClick: onConfirm,
+  });
 });
 
 test('should call onClose', async () => {
   const onClose = vi.fn();
-  const user = userEvent.setup();
   renderComponent({ onClose });
 
-  const closeButton = screen.getByRole('button', { name: 'Peruuta' });
-  await user.click(closeButton);
-  expect(onClose).toBeCalled();
+  await shouldClickButton({ buttonLabel: 'Peruuta', onClick: onClose });
 });

--- a/src/domain/keywordSet/__tests__/CreateKeywordSetPage.test.tsx
+++ b/src/domain/keywordSet/__tests__/CreateKeywordSetPage.test.tsx
@@ -12,9 +12,9 @@ import {
   loadingSpinnerIsNotInDocument,
   render,
   screen,
+  shouldApplyExpectedMetaData,
   userEvent,
   waitFor,
-  waitPageMetaDataToBeSet,
 } from '../../../utils/testUtils';
 import { mockedOrganizationResponse } from '../../organization/__mocks__/organization';
 import { mockedOrganizationAncestorsResponse } from '../../organization/__mocks__/organizationAncestors';
@@ -99,15 +99,14 @@ const fillInputValues = async () => {
 };
 
 test('applies expected metadata', async () => {
-  const pageTitle = 'Lisää avainsanaryhmä - Linked Events';
-  const pageDescription = 'Lisää uusi avainsanaryhmä Linked Eventsiin.';
-  const pageKeywords =
-    'lisää, uusi, avainsana, ryhmä, linked, events, tapahtuma, hallinta, api, admin, Helsinki, Suomi';
-
   renderComponent();
-  await loadingSpinnerIsNotInDocument();
 
-  await waitPageMetaDataToBeSet({ pageDescription, pageKeywords, pageTitle });
+  await shouldApplyExpectedMetaData({
+    expectedDescription: 'Lisää uusi avainsanaryhmä Linked Eventsiin.',
+    expectedKeywords:
+      'lisää, uusi, avainsana, ryhmä, linked, events, tapahtuma, hallinta, api, admin, Helsinki, Suomi',
+    expectedTitle: 'Lisää avainsanaryhmä - Linked Events',
+  });
 });
 
 test('should focus to first validation error when trying to save new keyword set', async () => {

--- a/src/domain/keywordSet/hooks/__tests__/useKeywordSetServerErrors.test.ts
+++ b/src/domain/keywordSet/hooks/__tests__/useKeywordSetServerErrors.test.ts
@@ -1,7 +1,9 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-import { ApolloError } from '@apollo/client';
-import { act, renderHook } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
 
+import {
+  shouldSetGenericServerErrors,
+  shouldSetServerErrors,
+} from '../../../../utils/testUtils';
 import useKeywordSetServerErrors from '../useKeywordSetServerErrors';
 
 const getHookWrapper = () => {
@@ -14,33 +16,15 @@ const getHookWrapper = () => {
 it('should set generic server error items', async () => {
   const { result } = getHookWrapper();
 
-  const error = new ApolloError({
-    networkError: {
-      result: { detail: 'Metodi "POST" ei ole sallittu.' },
-    } as any,
-  });
-
-  act(() => result.current.showServerErrors({ error }));
-
-  expect(result.current.serverErrorItems).toEqual([
-    { label: '', message: 'Metodi "POST" ei ole sallittu.' },
-  ]);
+  shouldSetGenericServerErrors(result);
 });
 
 it('should set server error items', async () => {
-  const callbackFn = vi.fn();
   const { result } = getHookWrapper();
 
-  const error = new ApolloError({
-    networkError: {
-      result: { name: ['The name must be specified.'] },
-    } as any,
-  });
-
-  act(() => result.current.showServerErrors({ callbackFn, error }));
-
-  expect(result.current.serverErrorItems).toEqual([
-    { label: 'Nimi', message: 'Nimi on pakollinen.' },
-  ]);
-  expect(callbackFn).toBeCalled();
+  await shouldSetServerErrors(
+    result,
+    { name: ['The name must be specified.'] },
+    [{ label: 'Nimi', message: 'Nimi on pakollinen.' }]
+  );
 });

--- a/src/domain/keywordSet/modals/confirmDeleteKeywordSetModal/__tests__/ConfirmDeleteKeywordSetModal.test.tsx
+++ b/src/domain/keywordSet/modals/confirmDeleteKeywordSetModal/__tests__/ConfirmDeleteKeywordSetModal.test.tsx
@@ -1,10 +1,8 @@
-import React from 'react';
-
 import {
   configure,
   render,
-  screen,
-  userEvent,
+  shouldClickButton,
+  shouldRenderDeleteModal,
 } from '../../../../../utils/testUtils';
 import ConfirmDeleteKeywordSetModal, {
   ConfirmDeleteKeywordSetModalProps,
@@ -24,32 +22,27 @@ const renderComponent = (props?: Partial<ConfirmDeleteKeywordSetModalProps>) =>
 
 test('should render component', async () => {
   renderComponent();
-  screen.getByRole('heading', { name: 'Varmista avainsanaryhmän poistaminen' });
-  screen.getByText('Varoitus!');
-  screen.getByText('Tämä toiminto poistaa avainsanaryhmän lopullisesti.');
 
-  screen.getByRole('button', { name: 'Poista avainsanaryhmä' });
-  screen.getByRole('button', { name: 'Peruuta' });
+  shouldRenderDeleteModal({
+    confirmButtonLabel: 'Poista avainsanaryhmä',
+    heading: 'Varmista avainsanaryhmän poistaminen',
+    text: 'Tämä toiminto poistaa avainsanaryhmän lopullisesti.',
+  });
 });
 
 test('should call onConfirm', async () => {
   const onConfirm = vi.fn();
-  const user = userEvent.setup();
   renderComponent({ onConfirm });
 
-  const deleteButton = screen.getByRole('button', {
-    name: 'Poista avainsanaryhmä',
+  await shouldClickButton({
+    buttonLabel: 'Poista avainsanaryhmä',
+    onClick: onConfirm,
   });
-  await user.click(deleteButton);
-  expect(onConfirm).toBeCalled();
 });
 
 test('should call onClose', async () => {
   const onClose = vi.fn();
-  const user = userEvent.setup();
   renderComponent({ onClose });
 
-  const closeButton = screen.getByRole('button', { name: 'Peruuta' });
-  await user.click(closeButton);
-  expect(onClose).toBeCalled();
+  await shouldClickButton({ buttonLabel: 'Peruuta', onClick: onClose });
 });

--- a/src/domain/keywordSets/keywordSetActionsDropdown/__tests__/KeywordSetActionsDropdown.test.tsx
+++ b/src/domain/keywordSets/keywordSetActionsDropdown/__tests__/KeywordSetActionsDropdown.test.tsx
@@ -4,8 +4,10 @@ import stripLanguageFromPath from '../../../../utils/stripLanguageFromPath';
 import {
   configure,
   CustomRenderOptions,
+  openDropdownMenu,
   render,
   screen,
+  shouldToggleDropdownMenu,
   userEvent,
   waitFor,
   within,
@@ -49,54 +51,24 @@ const renderComponent = (
     routes: [route],
   });
 
-const findElement = (key: 'deleteButton') => {
-  switch (key) {
-    case 'deleteButton':
-      return screen.findByRole('button', { name: /poista avainsanaryhmä/i });
-  }
-};
+const findDeleteButton = () =>
+  screen.findByRole('button', { name: /poista avainsanaryhmä/i });
 
-const getElement = (key: 'editButton' | 'menu' | 'toggle') => {
-  switch (key) {
-    case 'editButton':
-      return screen.getByRole('button', { name: /muokkaa/i });
-    case 'menu':
-      return screen.getByRole('region', { name: /valinnat/i });
-    case 'toggle':
-      return screen.getByRole('button', { name: /valinnat/i });
-  }
-};
-
-const openMenu = async () => {
-  const user = userEvent.setup();
-  const toggleButton = getElement('toggle');
-  await user.click(toggleButton);
-  getElement('menu');
-
-  return toggleButton;
-};
+const getEditButton = () => screen.getByRole('button', { name: /muokkaa/i });
 
 test('should toggle menu by clicking actions button', async () => {
-  const user = userEvent.setup();
   renderComponent();
 
-  const toggleButton = await openMenu();
-  getElement('editButton');
-  await findElement('deleteButton');
-
-  await user.click(toggleButton);
-  expect(
-    screen.queryByRole('region', { name: /valinnat/i })
-  ).not.toBeInTheDocument();
+  await shouldToggleDropdownMenu();
 });
 
 test('should route to edit keyword set page', async () => {
   const user = userEvent.setup();
   const { history } = renderComponent();
 
-  await openMenu();
+  await openDropdownMenu();
 
-  const editButton = getElement('editButton');
+  const editButton = getEditButton();
   await user.click(editButton);
 
   await waitFor(() =>
@@ -114,9 +86,9 @@ test('should delete keyword set', async () => {
   const user = userEvent.setup();
   renderComponent();
 
-  await openMenu();
+  await openDropdownMenu();
 
-  const deleteButton = await findElement('deleteButton');
+  const deleteButton = await findDeleteButton();
   await user.click(deleteButton);
 
   const dialog = await screen.findByRole(

--- a/src/domain/keywordSets/keywordSetList/KeywordSetList.tsx
+++ b/src/domain/keywordSets/keywordSetList/KeywordSetList.tsx
@@ -107,7 +107,7 @@ const KeywordSetListContainer: React.FC = () => {
   const { count, onSearchSubmit, ...listProps } = useCommonListProps({
     defaultSort: DEFAULT_KEYWORD_SET_SORT,
     listId: keywordSetListId,
-    meta: keywordSetsData?.keywordSets.meta,
+    meta: keywordSetsData?.keywordSets?.meta,
     pageSize: KEYWORD_SETS_PAGE_SIZE,
   });
 

--- a/src/domain/keywords/__tests__/KeywordsPage.test.tsx
+++ b/src/domain/keywords/__tests__/KeywordsPage.test.tsx
@@ -8,9 +8,11 @@ import {
   loadingSpinnerIsNotInDocument,
   render,
   screen,
-  userEvent,
+  shouldApplyExpectedMetaData,
+  shouldClickListPageCreateButton,
+  shouldRenderListPage,
+  shouldSortListPageTable,
   waitFor,
-  waitPageMetaDataToBeSet,
 } from '../../../utils/testUtils';
 import { mockedOrganizationAncestorsResponse } from '../../organization/__mocks__/organizationAncestors';
 import { mockedUserResponse } from '../../user/__mocks__/user';
@@ -48,87 +50,50 @@ const renderComponent = (renderOptions: CustomRenderOptions = {}) =>
     ...renderOptions,
   });
 
-const findElement = (key: 'title') => {
-  switch (key) {
-    case 'title':
-      return screen.findByRole('heading', { name: 'Avainsanat' });
-  }
-};
-
-const getElement = (
-  key:
-    | 'breadcrumb'
-    | 'createKeywordButton'
-    | 'searchInput'
-    | 'sortNameButton'
-    | 'table'
-    | 'title'
-) => {
-  switch (key) {
-    case 'breadcrumb':
-      return screen.getByRole('navigation', { name: 'Murupolku' });
-    case 'createKeywordButton':
-      return screen.getByRole('button', { name: 'Lisää avainsana' });
-    case 'searchInput':
-      return screen.getByRole('combobox', { name: 'Hae avainsanoja' });
-    case 'sortNameButton':
-      return screen.getByRole('button', { name: /nimi/i });
-    case 'table':
-      return screen.getByRole('table', {
-        name: 'Avainsanat, järjestys Tapahtumien lukumäärä, laskeva',
-      });
-    case 'title':
-      return screen.getByRole('heading', { name: 'Avainsanat' });
-  }
-};
+const findHeading = () => screen.findByRole('heading', { name: 'Avainsanat' });
 
 test('should render keywords page', async () => {
   renderComponent();
 
-  await findElement('title');
-  await loadingSpinnerIsNotInDocument();
-  getElement('breadcrumb');
-  getElement('createKeywordButton');
-  getElement('searchInput');
-  getElement('table');
+  await shouldRenderListPage({
+    createButtonLabel: 'Lisää avainsana',
+    heading: 'Avainsanat',
+    searchInputLabel: 'Hae avainsanoja',
+    tableCaption: 'Avainsanat, järjestys Tapahtumien lukumäärä, laskeva',
+  });
 });
 
 test('applies expected metadata', async () => {
-  const pageTitle = 'Avainsanat - Linked Events';
-  const pageDescription =
-    'Avainsanojen listaus. Selaa, suodata ja muokkaa Linked Eventsin avainsanoja.';
-  const pageKeywords =
-    'avainsana, lista, selailla, linked, events, tapahtuma, hallinta, api, admin, Helsinki, Suomi';
-
   renderComponent();
-  await loadingSpinnerIsNotInDocument();
 
-  await waitPageMetaDataToBeSet({ pageDescription, pageKeywords, pageTitle });
+  await shouldApplyExpectedMetaData({
+    expectedDescription:
+      'Avainsanojen listaus. Selaa, suodata ja muokkaa Linked Eventsin avainsanoja.',
+    expectedKeywords:
+      'avainsana, lista, selailla, linked, events, tapahtuma, hallinta, api, admin, Helsinki, Suomi',
+    expectedTitle: 'Avainsanat - Linked Events',
+  });
 });
 
 test('should open create keyword page', async () => {
-  const user = userEvent.setup();
   const { history } = renderComponent();
 
-  await findElement('title');
-  await loadingSpinnerIsNotInDocument();
-
-  const createKeywordButton = getElement('createKeywordButton');
-  await user.click(createKeywordButton);
-
-  expect(history.location.pathname).toBe('/fi/administration/keywords/create');
+  await findHeading();
+  await shouldClickListPageCreateButton({
+    createButtonLabel: 'Lisää avainsana',
+    expectedPathname: '/fi/administration/keywords/create',
+    history,
+  });
 });
 
 test('should add sort parameter to search query', async () => {
-  const user = userEvent.setup();
   const { history } = renderComponent();
 
-  await loadingSpinnerIsNotInDocument();
-
-  const sortNameButton = getElement('sortNameButton');
-  await user.click(sortNameButton);
-
-  expect(history.location.search).toBe('?sort=name');
+  await shouldSortListPageTable({
+    columnHeader: 'Nimi',
+    expectedSearch: '?sort=name',
+    history,
+  });
 });
 
 it('scrolls to keyword row and calls history.replace correctly (deletes keywordId from state)', async () => {

--- a/src/domain/keywords/keywordActionsDropdown/__tests__/KeywordActionsDropdown.test.tsx
+++ b/src/domain/keywords/keywordActionsDropdown/__tests__/KeywordActionsDropdown.test.tsx
@@ -3,8 +3,10 @@ import { mockAuthenticatedLoginState } from '../../../../utils/mockLoginHooks';
 import stripLanguageFromPath from '../../../../utils/stripLanguageFromPath';
 import {
   configure,
+  openDropdownMenu,
   render,
   screen,
+  shouldToggleDropdownMenu,
   userEvent,
   waitFor,
   within,
@@ -48,62 +50,33 @@ const renderComponent = (props?: Partial<KeywordActionsDropdownProps>) =>
     routes,
   });
 
-const findElement = (key: 'deleteButton') => {
-  switch (key) {
-    case 'deleteButton':
-      return screen.findByRole('button', { name: /poista avainsana/i });
-  }
-};
+const findDeleteButton = () =>
+  screen.findByRole('button', { name: /poista avainsana/i });
 
-const getElement = (key: 'deleteButton' | 'editButton' | 'menu' | 'toggle') => {
-  switch (key) {
-    case 'deleteButton':
-      return screen.getByRole('button', { name: /poista avainsana/i });
-    case 'editButton':
-      return screen.getByRole('button', { name: /muokkaa/i });
-    case 'menu':
-      return screen.getByRole('region', { name: /valinnat/i });
-    case 'toggle':
-      return screen.getByRole('button', { name: /valinnat/i });
-  }
-};
-
-const openMenu = async () => {
-  const user = userEvent.setup();
-  const toggleButton = getElement('toggle');
-  await user.click(toggleButton);
-  getElement('menu');
-
-  return toggleButton;
-};
+const getEditButton = () => screen.getByRole('button', { name: /muokkaa/i });
 
 test('should toggle menu by clicking actions button', async () => {
-  const user = userEvent.setup();
   renderComponent();
 
-  const toggleButton = await openMenu();
-  await user.click(toggleButton);
-  expect(
-    screen.queryByRole('region', { name: /valinnat/i })
-  ).not.toBeInTheDocument();
+  await shouldToggleDropdownMenu();
 });
 
 test('should render correct buttons', async () => {
   renderComponent();
 
-  await openMenu();
+  await openDropdownMenu();
 
-  getElement('editButton');
-  await findElement('deleteButton');
+  await findDeleteButton();
+  getEditButton();
 });
 
 test('should route to edit keyword page', async () => {
   const user = userEvent.setup();
   const { history } = renderComponent();
 
-  await openMenu();
+  await openDropdownMenu();
 
-  const editButton = getElement('editButton');
+  const editButton = getEditButton();
   await user.click(editButton);
 
   await waitFor(() =>
@@ -121,9 +94,9 @@ test('should delete keyword', async () => {
   const user = userEvent.setup();
   renderComponent();
 
-  await openMenu();
+  await openDropdownMenu();
 
-  const deleteButton = await findElement('deleteButton');
+  const deleteButton = await findDeleteButton();
   await user.click(deleteButton);
 
   const withinModal = within(screen.getByRole('dialog'));

--- a/src/domain/keywords/keywordList/KeywordList.tsx
+++ b/src/domain/keywords/keywordList/KeywordList.tsx
@@ -102,7 +102,7 @@ const KeywordListContainer: React.FC = () => {
   const { count, onSearchSubmit, ...listProps } = useCommonListProps({
     defaultSort: DEFAULT_KEYWORD_SORT,
     listId: keywordListId,
-    meta: keywordsData?.keywords.meta,
+    meta: keywordsData?.keywords?.meta,
     pageSize: KEYWORDS_PAGE_SIZE,
   });
 

--- a/src/domain/organization/__tests__/CreateOrganizationPage.test.tsx
+++ b/src/domain/organization/__tests__/CreateOrganizationPage.test.tsx
@@ -3,14 +3,13 @@ import { MockedResponse } from '@apollo/client/testing';
 import getValue from '../../../utils/getValue';
 import { mockAuthenticatedLoginState } from '../../../utils/mockLoginHooks';
 import {
-  actWait,
   configure,
   loadingSpinnerIsNotInDocument,
   render,
   screen,
+  shouldApplyExpectedMetaData,
   userEvent,
   waitFor,
-  waitPageMetaDataToBeSet,
 } from '../../../utils/testUtils';
 import {
   mockedOrganizationClassesResponse,
@@ -152,17 +151,16 @@ test('shows all fields', async () => {
 });
 
 test('applies expected metadata', async () => {
-  const pageTitle = 'Lisää organisaatio - Linked Events';
-  const pageDescription = 'Lisää uusi organisaatio Linked Eventsiin.';
-  const pageKeywords =
-    'lisää, uusi, organisaatio, linked, events, tapahtuma, hallinta, api, admin, Helsinki, Suomi';
-
   renderComponent(defaultMocks);
 
-  await loadingSpinnerIsNotInDocument();
+  await shouldApplyExpectedMetaData({
+    expectedDescription: 'Lisää uusi organisaatio Linked Eventsiin.',
+    expectedKeywords:
+      'lisää, uusi, organisaatio, linked, events, tapahtuma, hallinta, api, admin, Helsinki, Suomi',
+    expectedTitle: 'Lisää organisaatio - Linked Events',
+  });
 
-  await waitPageMetaDataToBeSet({ pageDescription, pageKeywords, pageTitle });
-  await actWait(10);
+  await loadingSpinnerIsNotInDocument();
 });
 
 test('should focus to first validation error when trying to save new organization', async () => {

--- a/src/domain/organization/__tests__/EditOrganizationPage.test.tsx
+++ b/src/domain/organization/__tests__/EditOrganizationPage.test.tsx
@@ -7,9 +7,9 @@ import {
   configure,
   renderWithRoute,
   screen,
+  shouldDeleteInstance,
   userEvent,
   waitFor,
-  within,
 } from '../../../utils/testUtils';
 import {
   mockedOrganizationResponse,
@@ -63,10 +63,8 @@ const renderComponent = (mocks: MockedResponse[] = defaultMocks) =>
     path: ROUTES.EDIT_ORGANIZATION,
   });
 
-const findElement = (key: 'deleteButton' | 'nameInput' | 'saveButton') => {
+const findElement = (key: 'nameInput' | 'saveButton') => {
   switch (key) {
-    case 'deleteButton':
-      return screen.findByRole('button', { name: /poista organisaatio/i });
     case 'nameInput':
       return screen.findByLabelText(/nimi/i);
     case 'saveButton':
@@ -115,27 +113,18 @@ test('should scroll to first validation error input field', async () => {
 });
 
 test('should delete organization', async () => {
-  const user = userEvent.setup();
   const { history } = renderComponent([
     ...defaultMocks,
     mockedDeleteOrganizationResponse,
   ]);
 
-  const deleteButton = await findElement('deleteButton');
-  await user.click(deleteButton);
-
-  const dialog = screen.getByRole('dialog', {
-    name: 'Varmista organisaation poistaminen',
+  await shouldDeleteInstance({
+    confirmDeleteButtonLabel: 'Poista organisaatio',
+    deleteButtonLabel: 'Poista organisaatio',
+    expectedNotificationText: 'Organisaatio on poistettu',
+    expectedUrl: `/fi/administration/organizations`,
+    history,
   });
-  const confirmDeleteButton = within(dialog).getByRole('button', {
-    name: 'Poista organisaatio',
-  });
-  await user.click(confirmDeleteButton);
-
-  await waitFor(() =>
-    expect(history.location.pathname).toBe(`/fi/administration/organizations`)
-  );
-  await screen.findByRole('alert', { name: 'Organisaatio on poistettu' });
 });
 
 test('should update organization', async () => {

--- a/src/domain/organization/hooks/__tests__/useOrganizationServerErrors.test.ts
+++ b/src/domain/organization/hooks/__tests__/useOrganizationServerErrors.test.ts
@@ -1,7 +1,9 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-import { ApolloError } from '@apollo/client';
-import { act, renderHook } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
 
+import {
+  shouldSetGenericServerErrors,
+  shouldSetServerErrors,
+} from '../../../../utils/testUtils';
 import useOrganizationServerErrors from '../useOrganizationServerErrors';
 
 const getHookWrapper = () => {
@@ -14,33 +16,15 @@ const getHookWrapper = () => {
 it('should set generic server error items', async () => {
   const { result } = getHookWrapper();
 
-  const error = new ApolloError({
-    networkError: {
-      result: { detail: 'Metodi "POST" ei ole sallittu.' },
-    } as any,
-  });
-
-  act(() => result.current.showServerErrors({ error }));
-
-  expect(result.current.serverErrorItems).toEqual([
-    { label: '', message: 'Metodi "POST" ei ole sallittu.' },
-  ]);
+  shouldSetGenericServerErrors(result);
 });
 
 it('should set server error items', async () => {
-  const callbackFn = vi.fn();
   const { result } = getHookWrapper();
 
-  const error = new ApolloError({
-    networkError: {
-      result: { name: ['The name must be specified.'] },
-    } as any,
-  });
-
-  act(() => result.current.showServerErrors({ callbackFn, error }));
-
-  expect(result.current.serverErrorItems).toEqual([
-    { label: 'Nimi', message: 'Nimi on pakollinen.' },
-  ]);
-  expect(callbackFn).toBeCalled();
+  await shouldSetServerErrors(
+    result,
+    { name: ['The name must be specified.'] },
+    [{ label: 'Nimi', message: 'Nimi on pakollinen.' }]
+  );
 });

--- a/src/domain/organization/modals/confirmDeleteOrganizationModal/__tests__/ConfirmDeleteOrganizationModal.test.tsx
+++ b/src/domain/organization/modals/confirmDeleteOrganizationModal/__tests__/ConfirmDeleteOrganizationModal.test.tsx
@@ -1,10 +1,8 @@
-import React from 'react';
-
 import {
   configure,
   render,
-  screen,
-  userEvent,
+  shouldClickButton,
+  shouldRenderDeleteModal,
 } from '../../../../../utils/testUtils';
 import ConfirmDeleteOrganizationModal, {
   ConfirmDeleteOrganizationModalProps,
@@ -23,53 +21,29 @@ const renderComponent = (
   props?: Partial<ConfirmDeleteOrganizationModalProps>
 ) => render(<ConfirmDeleteOrganizationModal {...defaultProps} {...props} />);
 
-const getElement = (
-  key: 'cancelButton' | 'deleteButton' | 'text' | 'title' | 'warning'
-) => {
-  switch (key) {
-    case 'cancelButton':
-      return screen.getByRole('button', { name: 'Peruuta' });
-    case 'deleteButton':
-      return screen.getByRole('button', { name: 'Poista organisaatio' });
-    case 'text':
-      return screen.getByText(
-        'Tämä toiminto poistaa organisaation lopullisesti.'
-      );
-    case 'title':
-      return screen.getByRole('heading', {
-        name: 'Varmista organisaation poistaminen',
-      });
-    case 'warning':
-      return screen.getByText('Varoitus!');
-  }
-};
-
 test('should render component', async () => {
   renderComponent();
-  getElement('title');
-  getElement('warning');
-  getElement('text');
 
-  getElement('deleteButton');
-  getElement('cancelButton');
+  shouldRenderDeleteModal({
+    confirmButtonLabel: 'Poista organisaatio',
+    heading: 'Varmista organisaation poistaminen',
+    text: 'Tämä toiminto poistaa organisaation lopullisesti.',
+  });
 });
 
 test('should call onConfirm', async () => {
   const onConfirm = vi.fn();
-  const user = userEvent.setup();
   renderComponent({ onConfirm });
 
-  const deleteButton = getElement('deleteButton');
-  await user.click(deleteButton);
-  expect(onConfirm).toBeCalled();
+  await shouldClickButton({
+    buttonLabel: 'Poista organisaatio',
+    onClick: onConfirm,
+  });
 });
 
 test('should call onClose', async () => {
   const onClose = vi.fn();
-  const user = userEvent.setup();
   renderComponent({ onClose });
 
-  const cancelButton = getElement('cancelButton');
-  await user.click(cancelButton);
-  expect(onClose).toBeCalled();
+  await shouldClickButton({ buttonLabel: 'Peruuta', onClick: onClose });
 });

--- a/src/domain/organizations/organizationActionsDropdown/__tests__/OrganizationActionsDropdown.test.tsx
+++ b/src/domain/organizations/organizationActionsDropdown/__tests__/OrganizationActionsDropdown.test.tsx
@@ -4,8 +4,10 @@ import stripLanguageFromPath from '../../../../utils/stripLanguageFromPath';
 import {
   configure,
   CustomRenderOptions,
+  openDropdownMenu,
   render,
   screen,
+  shouldToggleDropdownMenu,
   userEvent,
   waitFor,
   within,
@@ -51,54 +53,25 @@ const renderComponent = (
     routes: [route],
   });
 
-const findElement = (key: 'deleteButton') => {
-  switch (key) {
-    case 'deleteButton':
-      return screen.findByRole('button', { name: /poista organisaatio/i });
-  }
-};
+const findDeleteButton = () =>
+  screen.findByRole('button', { name: /poista organisaatio/i });
 
-const getElement = (key: 'editButton' | 'menu' | 'toggle') => {
-  switch (key) {
-    case 'editButton':
-      return screen.getByRole('button', { name: /muokkaa organisaatiota/i });
-    case 'menu':
-      return screen.getByRole('region', { name: /valinnat/i });
-    case 'toggle':
-      return screen.getByRole('button', { name: /valinnat/i });
-  }
-};
-
-const openMenu = async () => {
-  const user = userEvent.setup();
-  const toggleButton = getElement('toggle');
-  await user.click(toggleButton);
-  getElement('menu');
-
-  return toggleButton;
-};
+const getEditButton = () =>
+  screen.getByRole('button', { name: /muokkaa organisaatiota/i });
 
 test('should toggle menu by clicking actions button', async () => {
-  const user = userEvent.setup();
   renderComponent();
 
-  const toggleButton = await openMenu();
-  getElement('editButton');
-  await findElement('deleteButton');
-
-  await user.click(toggleButton);
-  expect(
-    screen.queryByRole('region', { name: /valinnat/i })
-  ).not.toBeInTheDocument();
+  await shouldToggleDropdownMenu();
 });
 
 test('should route to edit organization page', async () => {
   const user = userEvent.setup();
   const { history } = renderComponent();
 
-  await openMenu();
+  await openDropdownMenu();
 
-  const editButton = getElement('editButton');
+  const editButton = getEditButton();
   await user.click(editButton);
 
   await waitFor(() =>
@@ -116,9 +89,9 @@ test('should delete organization', async () => {
   const user = userEvent.setup();
   renderComponent();
 
-  await openMenu();
+  await openDropdownMenu();
 
-  const deleteButton = await findElement('deleteButton');
+  const deleteButton = await findDeleteButton();
   await user.click(deleteButton);
 
   const withinModal = within(screen.getByRole('dialog'));

--- a/src/domain/place/__tests__/CreatePlacePage.test.tsx
+++ b/src/domain/place/__tests__/CreatePlacePage.test.tsx
@@ -2,14 +2,13 @@ import { MockedResponse } from '@apollo/client/testing';
 
 import { mockAuthenticatedLoginState } from '../../../utils/mockLoginHooks';
 import {
-  actWait,
   configure,
   loadingSpinnerIsNotInDocument,
   render,
   screen,
+  shouldApplyExpectedMetaData,
   userEvent,
   waitFor,
-  waitPageMetaDataToBeSet,
 } from '../../../utils/testUtils';
 import {
   mockedOrganizationResponse,
@@ -80,17 +79,14 @@ const fillInputValues = async () => {
 };
 
 test('applies expected metadata', async () => {
-  const pageTitle = 'Lisää paikka - Linked Events';
-  const pageDescription = 'Lisää uusi paikka Linked Eventsiin.';
-  const pageKeywords =
-    'lisää, uusi, paikka, linked, events, tapahtuma, hallinta, api, admin, Helsinki, Suomi';
-
   renderComponent(defaultMocks);
 
-  await loadingSpinnerIsNotInDocument();
-
-  await waitPageMetaDataToBeSet({ pageDescription, pageKeywords, pageTitle });
-  await actWait(10);
+  await shouldApplyExpectedMetaData({
+    expectedDescription: 'Lisää uusi paikka Linked Eventsiin.',
+    expectedKeywords:
+      'lisää, uusi, paikka, linked, events, tapahtuma, hallinta, api, admin, Helsinki, Suomi',
+    expectedTitle: 'Lisää paikka - Linked Events',
+  });
 });
 
 test('should focus to first validation error when trying to save new place', async () => {

--- a/src/domain/place/hooks/__tests__/usePlaceServerErrors.test.ts
+++ b/src/domain/place/hooks/__tests__/usePlaceServerErrors.test.ts
@@ -1,7 +1,9 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-import { ApolloError } from '@apollo/client';
-import { act, renderHook } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
 
+import {
+  shouldSetGenericServerErrors,
+  shouldSetServerErrors,
+} from '../../../../utils/testUtils';
 import usePlaceServerErrors from '../usePlaceServerErrors';
 
 const getHookWrapper = () => {
@@ -14,35 +16,15 @@ const getHookWrapper = () => {
 it('should set generic server error items', async () => {
   const { result } = getHookWrapper();
 
-  const error = new ApolloError({
-    networkError: {
-      result: { detail: 'Metodi "POST" ei ole sallittu.' },
-    } as any,
-  });
-
-  act(() => result.current.showServerErrors({ error }));
-
-  expect(result.current.serverErrorItems).toEqual([
-    { label: '', message: 'Metodi "POST" ei ole sallittu.' },
-  ]);
+  shouldSetGenericServerErrors(result);
 });
 
 it('should set server error items', async () => {
-  const callbackFn = vi.fn();
   const { result } = getHookWrapper();
 
-  const error = new ApolloError({
-    networkError: {
-      result: {
-        name: ['The name must be specified.'],
-      },
-    } as any,
-  });
-
-  act(() => result.current.showServerErrors({ callbackFn, error }));
-
-  expect(result.current.serverErrorItems).toEqual([
-    { label: 'Nimi', message: 'Nimi on pakollinen.' },
-  ]);
-  expect(callbackFn).toBeCalled();
+  await shouldSetServerErrors(
+    result,
+    { name: ['The name must be specified.'] },
+    [{ label: 'Nimi', message: 'Nimi on pakollinen.' }]
+  );
 });

--- a/src/domain/place/modals/confirmDeletePlaceModal/__tests__/ConfirmDeletePlaceModal.test.tsx
+++ b/src/domain/place/modals/confirmDeletePlaceModal/__tests__/ConfirmDeletePlaceModal.test.tsx
@@ -1,10 +1,8 @@
-import React from 'react';
-
 import {
   configure,
   render,
-  screen,
-  userEvent,
+  shouldClickButton,
+  shouldRenderDeleteModal,
 } from '../../../../../utils/testUtils';
 import ConfirmDeletePlaceModal, {
   ConfirmDeletePlaceModalProps,
@@ -22,52 +20,26 @@ const defaultProps: ConfirmDeletePlaceModalProps = {
 const renderComponent = (props?: Partial<ConfirmDeletePlaceModalProps>) =>
   render(<ConfirmDeletePlaceModal {...defaultProps} {...props} />);
 
-const getComponent = (
-  key: 'buttonCancel' | 'buttonDelete' | 'heading' | 'text' | 'warning'
-) => {
-  switch (key) {
-    case 'buttonCancel':
-      return screen.getByRole('button', { name: 'Peruuta' });
-    case 'buttonDelete':
-      return screen.getByRole('button', { name: 'Poista paikka' });
-    case 'heading':
-      return screen.getByRole('heading', {
-        name: 'Varmista paikan poistaminen',
-      });
-    case 'text':
-      return screen.getByText('Tämä toiminto poistaa paikan lopullisesti.');
-    case 'warning':
-      return screen.getByText('Varoitus!');
-  }
-};
-
 test('should render component', async () => {
   renderComponent();
-  getComponent('heading');
-  getComponent('warning');
-  getComponent('text');
-  getComponent('buttonDelete');
-  screen.getByRole('button', { name: 'Peruuta' });
+
+  shouldRenderDeleteModal({
+    confirmButtonLabel: 'Poista paikka',
+    heading: 'Varmista paikan poistaminen',
+    text: 'Tämä toiminto poistaa paikan lopullisesti.',
+  });
 });
 
 test('should call onConfirm', async () => {
   const onConfirm = vi.fn();
-  const user = userEvent.setup();
   renderComponent({ onConfirm });
 
-  const deleteButton = getComponent('buttonDelete');
-  await user.click(deleteButton);
-
-  expect(onConfirm).toBeCalled();
+  await shouldClickButton({ buttonLabel: 'Poista paikka', onClick: onConfirm });
 });
 
 test('should call onClose', async () => {
   const onClose = vi.fn();
-  const user = userEvent.setup();
   renderComponent({ onClose });
 
-  const closeButton = getComponent('buttonCancel');
-  await user.click(closeButton);
-
-  expect(onClose).toBeCalled();
+  await shouldClickButton({ buttonLabel: 'Peruuta', onClick: onClose });
 });

--- a/src/domain/places/placeActionsDropdown/__tests__/PlaceActionsDropdown.test.tsx
+++ b/src/domain/places/placeActionsDropdown/__tests__/PlaceActionsDropdown.test.tsx
@@ -4,8 +4,10 @@ import stripLanguageFromPath from '../../../../utils/stripLanguageFromPath';
 import {
   configure,
   CustomRenderOptions,
+  openDropdownMenu,
   render,
   screen,
+  shouldToggleDropdownMenu,
   userEvent,
   waitFor,
   within,
@@ -51,43 +53,25 @@ const renderComponent = (
     routes: [route],
   });
 
-const getElement = (key: 'deleteButton' | 'editButton' | 'menu' | 'toggle') => {
+const getElement = (key: 'deleteButton' | 'editButton') => {
   switch (key) {
     case 'deleteButton':
       return screen.getByRole('button', { name: /poista paikka/i });
     case 'editButton':
       return screen.getByRole('button', { name: /muokkaa/i });
-    case 'menu':
-      return screen.getByRole('region', { name: /valinnat/i });
-    case 'toggle':
-      return screen.getByRole('button', { name: /valinnat/i });
   }
 };
 
-const openMenu = async () => {
-  const user = userEvent.setup();
-  const toggleButton = getElement('toggle');
-  await user.click(toggleButton);
-  getElement('menu');
-
-  return toggleButton;
-};
-
 test('should toggle menu by clicking actions button', async () => {
-  const user = userEvent.setup();
   renderComponent();
 
-  const toggleButton = await openMenu();
-  await user.click(toggleButton);
-  expect(
-    screen.queryByRole('region', { name: /valinnat/i })
-  ).not.toBeInTheDocument();
+  await shouldToggleDropdownMenu();
 });
 
 test('should render correct buttons', async () => {
   renderComponent();
 
-  await openMenu();
+  await openDropdownMenu();
 
   const enabledButtons = [getElement('deleteButton'), getElement('editButton')];
   enabledButtons.forEach((button) => expect(button).toBeEnabled());
@@ -97,7 +81,7 @@ test('should route to edit place page', async () => {
   const user = userEvent.setup();
   const { history } = renderComponent();
 
-  await openMenu();
+  await openDropdownMenu();
 
   const editButton = getElement('editButton');
   await user.click(editButton);
@@ -117,7 +101,7 @@ test('should delete place', async () => {
   const user = userEvent.setup();
   renderComponent();
 
-  await openMenu();
+  await openDropdownMenu();
 
   const deleteButton = getElement('deleteButton');
   await user.click(deleteButton);

--- a/src/domain/places/placeList/PlaceList.tsx
+++ b/src/domain/places/placeList/PlaceList.tsx
@@ -100,7 +100,7 @@ const PlaceListContainer: React.FC = () => {
   const { count, onSearchSubmit, ...listProps } = useCommonListProps({
     defaultSort: DEFAULT_PLACE_SORT,
     listId: placeListId,
-    meta: placesData?.places.meta,
+    meta: placesData?.places?.meta,
     pageSize: PLACES_PAGE_SIZE,
   });
 

--- a/src/domain/priceGroup/CreatePriceGroupPage.tsx
+++ b/src/domain/priceGroup/CreatePriceGroupPage.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+import Breadcrumb from '../../common/components/breadcrumb/Breadcrumb';
+import LoadingSpinner from '../../common/components/loadingSpinner/LoadingSpinner';
+import { ROUTES } from '../../constants';
+import PageWrapper from '../app/layout/pageWrapper/PageWrapper';
+import TitleRow from '../app/layout/titleRow/TitleRow';
+import useUser from '../user/hooks/useUser';
+import PriceGroupForm from './priceGroupForm/PriceGroupForm';
+
+const CreatePriceGroupPage: React.FC = () => {
+  const { t } = useTranslation();
+
+  return (
+    <div>
+      <TitleRow
+        breadcrumb={
+          <Breadcrumb
+            list={[
+              { title: t('common.home'), path: ROUTES.HOME },
+              { title: t('adminPage.title'), path: ROUTES.ADMIN },
+              { title: t('priceGroupsPage.title'), path: ROUTES.PRICE_GROUPS },
+              { title: t('createPriceGroupPage.title'), path: null },
+            ]}
+          />
+        }
+        title={t('createPriceGroupPage.title')}
+      />
+
+      <PriceGroupForm />
+    </div>
+  );
+};
+
+const CreatePriceGroupPageWrapper: React.FC = () => {
+  const { loading: loadingUser } = useUser();
+
+  return (
+    <PageWrapper
+      description="createPriceGroupPage.pageDescription"
+      keywords={['keywords.add', 'keywords.new', 'keywords.priceGroup']}
+      title="createPriceGroupPage.pageTitle"
+    >
+      <LoadingSpinner isLoading={loadingUser}>
+        <CreatePriceGroupPage />
+      </LoadingSpinner>
+    </PageWrapper>
+  );
+};
+
+export default CreatePriceGroupPageWrapper;

--- a/src/domain/priceGroup/__mocks__/createPriceGroupPage.ts
+++ b/src/domain/priceGroup/__mocks__/createPriceGroupPage.ts
@@ -1,0 +1,52 @@
+import { MockedResponse } from '@apollo/client/testing';
+
+import { CreatePriceGroupDocument } from '../../../generated/graphql';
+import { fakePriceGroup } from '../../../utils/mockDataUtils';
+import { TEST_PUBLISHER_ID } from '../../organization/constants';
+
+const priceGroupValues = { description: 'Description' };
+
+const payload = {
+  description: {
+    fi: priceGroupValues.description,
+    sv: '',
+    en: '',
+    ru: '',
+    zhHans: '',
+    ar: '',
+  },
+  id: undefined,
+  isFree: false,
+  publisher: TEST_PUBLISHER_ID,
+};
+
+const createPriceGroupVariables = { input: payload };
+
+const createPriceGroupResponse = {
+  data: { createPriceGroup: fakePriceGroup() },
+};
+
+const mockedCreatePriceGroupResponse: MockedResponse = {
+  request: {
+    query: CreatePriceGroupDocument,
+    variables: createPriceGroupVariables,
+  },
+  result: createPriceGroupResponse,
+};
+
+const mockedInvalidCreatePriceGroupResponse: MockedResponse = {
+  request: {
+    query: CreatePriceGroupDocument,
+    variables: createPriceGroupVariables,
+  },
+  error: {
+    ...new Error(),
+    result: { description: ['Tämän kentän arvo ei voi olla "null".'] },
+  } as Error,
+};
+
+export {
+  mockedCreatePriceGroupResponse,
+  mockedInvalidCreatePriceGroupResponse,
+  priceGroupValues,
+};

--- a/src/domain/priceGroup/__tests__/CreatePriceGroupPage.test.tsx
+++ b/src/domain/priceGroup/__tests__/CreatePriceGroupPage.test.tsx
@@ -1,0 +1,132 @@
+import { MockedResponse } from '@apollo/client/testing';
+
+import { mockAuthenticatedLoginState } from '../../../utils/mockLoginHooks';
+import {
+  configure,
+  loadingSpinnerIsNotInDocument,
+  render,
+  screen,
+  shouldApplyExpectedMetaData,
+  userEvent,
+  waitFor,
+} from '../../../utils/testUtils';
+import {
+  mockedOrganizationResponse,
+  organizationName,
+} from '../../organization/__mocks__/organization';
+import { mockedOrganizationAncestorsResponse } from '../../organization/__mocks__/organizationAncestors';
+import { mockedFinancialAdminUserResponse } from '../../user/__mocks__/user';
+import {
+  mockedCreatePriceGroupResponse,
+  mockedInvalidCreatePriceGroupResponse,
+  priceGroupValues,
+} from '../__mocks__/createPriceGroupPage';
+import CreatePriceGroupPage from '../CreatePriceGroupPage';
+
+configure({ defaultHidden: true });
+
+afterEach(() => {
+  vi.resetAllMocks();
+});
+
+beforeEach(() => {
+  mockAuthenticatedLoginState();
+});
+
+const defaultMocks = [
+  mockedOrganizationResponse,
+  mockedOrganizationAncestorsResponse,
+  mockedFinancialAdminUserResponse,
+];
+
+const renderComponent = (mocks: MockedResponse[] = []) =>
+  render(<CreatePriceGroupPage />, { mocks });
+
+const getElement = (
+  key:
+    | 'descriptionInput'
+    | 'publisherInput'
+    | 'publisherToggleButton'
+    | 'saveButton'
+) => {
+  switch (key) {
+    case 'descriptionInput':
+      return screen.getByLabelText(/kuvaus \(suomeksi\)/i);
+    case 'publisherInput':
+      return screen.getByRole('combobox', { name: /julkaisija/i });
+    case 'publisherToggleButton':
+      return screen.getByRole('button', { name: /julkaisija: valikko/i });
+    case 'saveButton':
+      return screen.getByRole('button', { name: /tallenna/i });
+  }
+};
+
+const fillInputValues = async () => {
+  const user = userEvent.setup();
+  const publisherToggleButton = getElement('publisherToggleButton');
+  await user.click(publisherToggleButton);
+  const option = await screen.findByRole('option', { name: organizationName });
+  await user.click(option);
+
+  const descriptionInput = getElement('descriptionInput');
+  await user.type(descriptionInput, priceGroupValues.description);
+};
+
+test('applies expected metadata', async () => {
+  renderComponent(defaultMocks);
+
+  await shouldApplyExpectedMetaData({
+    expectedDescription: 'Lisää uusi asiakasryhmä Linked Eventsiin.',
+    expectedKeywords:
+      'lisää, uusi, asiakasryhmä, linked, events, tapahtuma, hallinta, api, admin, Helsinki, Suomi',
+    expectedTitle: 'Lisää asiakasryhmä - Linked Events',
+  });
+});
+
+test('should focus to first validation error when trying to save new place', async () => {
+  global.HTMLFormElement.prototype.submit = () => vi.fn();
+  const user = userEvent.setup();
+  renderComponent(defaultMocks);
+
+  await loadingSpinnerIsNotInDocument();
+
+  const publisherToggleButton = getElement('publisherToggleButton');
+  const saveButton = getElement('saveButton');
+
+  await user.click(saveButton);
+  await waitFor(() => expect(publisherToggleButton).toHaveFocus());
+});
+
+test('should move to price groups page after creating new price group', async () => {
+  const user = userEvent.setup();
+  const { history } = renderComponent([
+    ...defaultMocks,
+    mockedCreatePriceGroupResponse,
+  ]);
+
+  await loadingSpinnerIsNotInDocument();
+
+  await fillInputValues();
+
+  const saveButton = getElement('saveButton');
+  await user.click(saveButton);
+
+  await waitFor(() =>
+    expect(history.location.pathname).toBe(`/fi/administration/price-groups`)
+  );
+});
+
+test('should show server errors', async () => {
+  const user = userEvent.setup();
+  renderComponent([...defaultMocks, mockedInvalidCreatePriceGroupResponse]);
+
+  await loadingSpinnerIsNotInDocument();
+
+  await fillInputValues();
+
+  const saveButton = getElement('saveButton');
+  await user.click(saveButton);
+
+  await screen.findByText(/lomakkeella on seuraavat virheet/i);
+  screen.getByText(/Tämän kentän arvo ei voi olla "null"./i);
+});

--- a/src/domain/priceGroup/createButtonPanel/CreateButtonPanel.tsx
+++ b/src/domain/priceGroup/createButtonPanel/CreateButtonPanel.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+import ButtonPanel from '../../../common/components/buttonPanel/ButtonPanel';
+import buttonPanelStyles from '../../../common/components/buttonPanel/buttonPanel.module.scss';
+import LoadingButton from '../../../common/components/loadingButton/LoadingButton';
+import { ROUTES } from '../../../constants';
+import useGoBack from '../../../hooks/useGoBack';
+import useAuth from '../../auth/hooks/useAuth';
+import useOrganizationAncestors from '../../organization/hooks/useOrganizationAncestors';
+import useUser from '../../user/hooks/useUser';
+import { PRICE_GROUP_ACTIONS } from '../constants';
+import { getEditPriceGroupButtonProps } from '../utils';
+
+export interface CreateButtonPanelProps {
+  onSave: () => void;
+  publisher: string;
+  saving: PRICE_GROUP_ACTIONS | null;
+}
+
+const CreateButtonPanel: React.FC<CreateButtonPanelProps> = ({
+  onSave,
+  publisher,
+  saving,
+}) => {
+  const { t } = useTranslation();
+
+  const { authenticated } = useAuth();
+  const { user } = useUser();
+
+  const { organizationAncestors } = useOrganizationAncestors(publisher);
+
+  const goBack = useGoBack({ defaultReturnPath: ROUTES.KEYWORDS });
+
+  const buttonProps = getEditPriceGroupButtonProps({
+    action: PRICE_GROUP_ACTIONS.CREATE,
+    authenticated,
+    onClick: onSave,
+    organizationAncestors,
+    publisher,
+    t,
+    user,
+  });
+
+  return (
+    <ButtonPanel
+      onBack={goBack}
+      submitButtons={[
+        <LoadingButton
+          key="save"
+          {...buttonProps}
+          className={buttonPanelStyles.fullWidthOnMobile}
+          disabled={buttonProps.disabled}
+          loading={saving === PRICE_GROUP_ACTIONS.CREATE}
+          type="submit"
+        >
+          {buttonProps.label}
+        </LoadingButton>,
+      ]}
+      withOffset={false}
+    />
+  );
+};
+
+export default CreateButtonPanel;

--- a/src/domain/priceGroup/hooks/usePriceGroupActions.ts
+++ b/src/domain/priceGroup/hooks/usePriceGroupActions.ts
@@ -7,6 +7,7 @@ import {
 import {
   PriceGroupFieldsFragment,
   UpdatePriceGroupMutationInput,
+  useCreatePriceGroupMutation,
   useDeletePriceGroupMutation,
   useUpdatePriceGroupMutation,
 } from '../../../generated/graphql';
@@ -32,6 +33,10 @@ interface Props {
 
 type UsePriceGroupActionsState = {
   closeModal: () => void;
+  createPriceGroup: (
+    values: PriceGroupFormFields,
+    callbacks?: MutationCallbacks<number>
+  ) => Promise<void>;
   deletePriceGroup: (callbacks?: MutationCallbacks<number>) => Promise<void>;
   openModal: PRICE_GROUP_MODALS | null;
   saving: PRICE_GROUP_ACTIONS | null;
@@ -51,6 +56,7 @@ const usePriceGroupActions = ({
   );
   const [saving, setSaving] = useMountedState<PRICE_GROUP_ACTIONS | null>(null);
 
+  const [createPriceGroupMutation] = useCreatePriceGroupMutation();
   const [deletePriceGroupMutation] = useDeletePriceGroupMutation();
   const [updatePriceGroupMutation] = useUpdatePriceGroupMutation();
 
@@ -82,6 +88,30 @@ const usePriceGroupActions = ({
     never,
     number
   >();
+
+  const createPriceGroup = async (
+    values: PriceGroupFormFields,
+    callbacks?: MutationCallbacks<number>
+  ) => {
+    setSaving(PRICE_GROUP_ACTIONS.CREATE);
+    const payload = getPriceGroupPayload(values);
+
+    try {
+      const { data } = await createPriceGroupMutation({
+        variables: { input: payload },
+      });
+
+      await cleanAfterUpdate(data?.createPriceGroup.id as number, callbacks);
+    } catch (error) /* istanbul ignore next */ {
+      handleError({
+        callbacks,
+        error,
+        message: 'Failed to create price group',
+        payload,
+        savingFinished,
+      });
+    }
+  };
 
   const deletePriceGroup = async (callbacks?: MutationCallbacks<number>) => {
     try {
@@ -127,6 +157,7 @@ const usePriceGroupActions = ({
 
   return {
     closeModal,
+    createPriceGroup,
     deletePriceGroup,
     openModal,
     saving,

--- a/src/domain/priceGroup/modals/confirmDeletePriceGroupModal/__tests__/ConfirmDeletePriceGroupModal.test.tsx
+++ b/src/domain/priceGroup/modals/confirmDeletePriceGroupModal/__tests__/ConfirmDeletePriceGroupModal.test.tsx
@@ -1,7 +1,7 @@
 import {
   configure,
   render,
-  shouldCallModalButtonAction,
+  shouldClickButton,
   shouldRenderDeleteModal,
 } from '../../../../../utils/testUtils';
 import ConfirmDeletePriceGroupModal, {
@@ -33,12 +33,15 @@ test('should call onConfirm', async () => {
   const onConfirm = vi.fn();
   renderComponent({ onConfirm });
 
-  await shouldCallModalButtonAction('Poista asiakasryhmä', onConfirm);
+  await shouldClickButton({
+    buttonLabel: 'Poista asiakasryhmä',
+    onClick: onConfirm,
+  });
 });
 
 test('should call onClose', async () => {
   const onClose = vi.fn();
   renderComponent({ onClose });
 
-  await shouldCallModalButtonAction('Peruuta', onClose);
+  await shouldClickButton({ buttonLabel: 'Peruuta', onClick: onClose });
 });

--- a/src/domain/priceGroup/mutation.ts
+++ b/src/domain/priceGroup/mutation.ts
@@ -2,6 +2,18 @@
 import gql from 'graphql-tag';
 
 export const MUTATION_PRICE_GROUP = gql`
+  mutation CreatePriceGroup($input: CreatePriceGroupMutationInput!) {
+    createPriceGroup(input: $input)
+      @rest(
+        type: "PriceGroup"
+        path: "/price_group/"
+        method: "POST"
+        bodyKey: "input"
+      ) {
+      ...priceGroupFields
+    }
+  }
+
   mutation DeletePriceGroup($id: Int!) {
     deletePriceGroup(id: $id)
       @rest(

--- a/src/domain/priceGroup/priceGroupForm/PriceGroupForm.tsx
+++ b/src/domain/priceGroup/priceGroupForm/PriceGroupForm.tsx
@@ -34,6 +34,7 @@ import {
   PRICE_GROUP_FIELDS,
   PRICE_GROUP_INITIAL_VALUES,
 } from '../constants';
+import CreateButtonPanel from '../createButtonPanel/CreateButtonPanel';
 import EditButtonPanel from '../editButtonPanel/EditButtonPanel';
 import usePriceGroupActions from '../hooks/usePriceGroupActions';
 import usePriceGroupServerErrors from '../hooks/usePriceGroupServerErrors';
@@ -65,13 +66,22 @@ const PriceGroupForm: React.FC<PriceGroupFormProps> = ({ priceGroup }) => {
   const { organizationAncestors } =
     useOrganizationAncestors(savedPlacePublisher);
 
-  const { saving, updatePriceGroup } = usePriceGroupActions({ priceGroup });
+  const { createPriceGroup, saving, updatePriceGroup } = usePriceGroupActions({
+    priceGroup,
+  });
 
   const { serverErrorItems, setServerErrorItems, showServerErrors } =
     usePriceGroupServerErrors();
 
   const goToPriceGroupsPage = () => {
     navigate(`/${locale}${ROUTES.PRICE_GROUPS}`);
+  };
+
+  const onCreate = async (values: PriceGroupFormFields) => {
+    await createPriceGroup(values, {
+      onError: (error: ServerError) => showServerErrors({ error }),
+      onSuccess: goToPriceGroupsPage,
+    });
   };
 
   const onUpdate = async (values: PriceGroupFormFields) => {
@@ -151,6 +161,8 @@ const PriceGroupForm: React.FC<PriceGroupFormProps> = ({ priceGroup }) => {
 
             if (priceGroup) {
               await onUpdate(values);
+            } else {
+              await onCreate(values);
             }
           } catch (error) {
             showFormErrors({
@@ -234,7 +246,13 @@ const PriceGroupForm: React.FC<PriceGroupFormProps> = ({ priceGroup }) => {
                 publisher={publisher}
                 saving={saving}
               />
-            ) : null}
+            ) : (
+              <CreateButtonPanel
+                onSave={handleSubmit}
+                publisher={publisher}
+                saving={saving}
+              />
+            )}
           </Form>
         );
       }}

--- a/src/domain/priceGroups/PriceGroupsPage.tsx
+++ b/src/domain/priceGroups/PriceGroupsPage.tsx
@@ -1,10 +1,14 @@
 /* eslint-disable max-len */
+import { IconPlus } from 'hds-react';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router';
 
 import Breadcrumb from '../../common/components/breadcrumb/Breadcrumb';
+import Button from '../../common/components/button/Button';
 import LoadingSpinner from '../../common/components/loadingSpinner/LoadingSpinner';
 import { ROUTES } from '../../constants';
+import useLocale from '../../hooks/useLocale';
 import adminListPageStyles from '../admin/layout/adminListPage.module.scss';
 import AdminListPageWrapper from '../admin/layout/adminListPageWrapper/AdminListPageWrapper';
 import PageWrapper from '../app/layout/pageWrapper/PageWrapper';
@@ -16,6 +20,13 @@ import PriceGroupList from './priceGroupList/PriceGroupList';
 
 const PriceGroupsPage: React.FC = () => {
   const { t } = useTranslation();
+  const locale = useLocale();
+  const navigate = useNavigate();
+
+  const goToCreatePriceGroupPage = () => {
+    navigate(`/${locale}${ROUTES.CREATE_PRICE_GROUP}`);
+  };
+
   return (
     <AdminListPageWrapper>
       <TitleRow
@@ -27,6 +38,16 @@ const PriceGroupsPage: React.FC = () => {
               { title: t('priceGroupsPage.title'), path: null },
             ]}
           />
+        }
+        button={
+          <Button
+            fullWidth={true}
+            iconLeft={<IconPlus aria-hidden={true} />}
+            onClick={goToCreatePriceGroupPage}
+            variant="primary"
+          >
+            {t('common.buttonAddPriceGroup')}
+          </Button>
         }
         title={t('priceGroupsPage.title')}
       />

--- a/src/domain/priceGroups/__tests__/PriceGroupsPage.test.tsx
+++ b/src/domain/priceGroups/__tests__/PriceGroupsPage.test.tsx
@@ -57,11 +57,18 @@ const findHeading = () => {
 };
 
 const getElement = (
-  key: 'breadcrumb' | 'searchInput' | 'sortByDescriptionButton' | 'table'
+  key:
+    | 'breadcrumb'
+    | 'createPriceGroupButton'
+    | 'searchInput'
+    | 'sortByDescriptionButton'
+    | 'table'
 ) => {
   switch (key) {
     case 'breadcrumb':
       return screen.getByRole('navigation', { name: 'Murupolku' });
+    case 'createPriceGroupButton':
+      return screen.getByRole('button', { name: 'Lisää asiakasryhmä' });
     case 'searchInput':
       return screen.getByRole('combobox', { name: 'Hae asiakasryhmiä' });
     case 'sortByDescriptionButton':
@@ -93,6 +100,21 @@ test('applies expected metadata', async () => {
       'asiakasryhmä, lista, linked, events, tapahtuma, hallinta, api, admin, Helsinki, Suomi',
     expectedTitle: 'Asiakasryhmät - Linked Events',
   });
+});
+
+test('should open create price group page', async () => {
+  const user = userEvent.setup();
+  const { history } = renderComponent();
+
+  await findHeading();
+  await loadingSpinnerIsNotInDocument();
+
+  const createPriceGroupButton = getElement('createPriceGroupButton');
+  await user.click(createPriceGroupButton);
+
+  expect(history.location.pathname).toBe(
+    '/fi/administration/price-groups/create'
+  );
 });
 
 test('should add sort parameter to search query', async () => {

--- a/src/domain/priceGroups/__tests__/PriceGroupsPage.test.tsx
+++ b/src/domain/priceGroups/__tests__/PriceGroupsPage.test.tsx
@@ -9,7 +9,9 @@ import {
   render,
   screen,
   shouldApplyExpectedMetaData,
-  userEvent,
+  shouldClickListPageCreateButton,
+  shouldRenderListPage,
+  shouldSortListPageTable,
   waitFor,
 } from '../../../utils/testUtils';
 import { mockedOrganizationResponse } from '../../organization/__mocks__/organization';
@@ -56,38 +58,15 @@ const findHeading = () => {
   return screen.findByRole('heading', { name: 'Asiakasryhmät' });
 };
 
-const getElement = (
-  key:
-    | 'breadcrumb'
-    | 'createPriceGroupButton'
-    | 'searchInput'
-    | 'sortByDescriptionButton'
-    | 'table'
-) => {
-  switch (key) {
-    case 'breadcrumb':
-      return screen.getByRole('navigation', { name: 'Murupolku' });
-    case 'createPriceGroupButton':
-      return screen.getByRole('button', { name: 'Lisää asiakasryhmä' });
-    case 'searchInput':
-      return screen.getByRole('combobox', { name: 'Hae asiakasryhmiä' });
-    case 'sortByDescriptionButton':
-      return screen.getByRole('button', { name: 'Kuvaus' });
-    case 'table':
-      return screen.getByRole('table', {
-        name: 'Asiakasryhmät, järjestys Kuvaus, nouseva',
-      });
-  }
-};
-
 test('should render price groups page', async () => {
   renderComponent();
 
-  await findHeading();
-  await loadingSpinnerIsNotInDocument();
-  getElement('breadcrumb');
-  getElement('searchInput');
-  getElement('table');
+  await shouldRenderListPage({
+    createButtonLabel: 'Lisää asiakasryhmä',
+    heading: 'Asiakasryhmät',
+    searchInputLabel: 'Hae asiakasryhmiä',
+    tableCaption: 'Asiakasryhmät, järjestys Kuvaus, nouseva',
+  });
 });
 
 test('applies expected metadata', async () => {
@@ -103,30 +82,24 @@ test('applies expected metadata', async () => {
 });
 
 test('should open create price group page', async () => {
-  const user = userEvent.setup();
   const { history } = renderComponent();
 
   await findHeading();
-  await loadingSpinnerIsNotInDocument();
-
-  const createPriceGroupButton = getElement('createPriceGroupButton');
-  await user.click(createPriceGroupButton);
-
-  expect(history.location.pathname).toBe(
-    '/fi/administration/price-groups/create'
-  );
+  await shouldClickListPageCreateButton({
+    createButtonLabel: 'Lisää asiakasryhmä',
+    expectedPathname: '/fi/administration/price-groups/create',
+    history,
+  });
 });
 
 test('should add sort parameter to search query', async () => {
-  const user = userEvent.setup();
   const { history } = renderComponent();
 
-  await loadingSpinnerIsNotInDocument();
-
-  const sortByDescriptionButton = getElement('sortByDescriptionButton');
-  await user.click(sortByDescriptionButton);
-
-  expect(history.location.search).toBe('?sort=-description');
+  await shouldSortListPageTable({
+    columnHeader: 'Kuvaus',
+    expectedSearch: '?sort=-description',
+    history,
+  });
 });
 
 it('scrolls to price group id and calls history.replace correctly (deletes priceGroupId from state)', async () => {

--- a/src/domain/priceGroups/priceGroupActionsDropdown/PriceGroupActionsDropdown.tsx
+++ b/src/domain/priceGroups/priceGroupActionsDropdown/PriceGroupActionsDropdown.tsx
@@ -22,7 +22,10 @@ import {
   getPriceGroupFields,
 } from '../../priceGroup/utils';
 import useUser from '../../user/hooks/useUser';
-import { addParamsToPriceGroupQueryString } from '../utils';
+import {
+  addParamsToPriceGroupQueryString,
+  replaceParamsToPriceGroupQueryString,
+} from '../utils';
 
 export interface PriceGroupActionsDropdownProps {
   className?: string;
@@ -55,6 +58,17 @@ const PriceGroupActionsDropdown: React.FC<PriceGroupActionsDropdownProps> = ({
 
     navigate({
       pathname: `/${locale}${ROUTES.EDIT_PRICE_GROUP.replace(':id', id)}`,
+      search: queryString,
+    });
+  };
+
+  const goToPriceGroupsPage = () => {
+    const queryString = replaceParamsToPriceGroupQueryString(search, {
+      page: null,
+    });
+
+    navigate({
+      pathname: `/${locale}${ROUTES.PRICE_GROUPS}`,
       search: queryString,
     });
   };
@@ -102,6 +116,7 @@ const PriceGroupActionsDropdown: React.FC<PriceGroupActionsDropdownProps> = ({
                   label: t('priceGroup.form.notificationPriceGroupDeleted'),
                   type: 'success',
                 });
+                goToPriceGroupsPage();
               },
             });
           }}

--- a/src/domain/priceGroups/priceGroupList/PriceGroupList.tsx
+++ b/src/domain/priceGroups/priceGroupList/PriceGroupList.tsx
@@ -111,7 +111,7 @@ const PriceGroupListContainer: React.FC = () => {
   const { count, onSearchSubmit, ...listProps } = useCommonListProps({
     defaultSort: DEFAULT_PRICE_GROUP_SORT,
     listId: priceGroupListId,
-    meta: priceGroupsData?.priceGroups.meta,
+    meta: priceGroupsData?.priceGroups?.meta,
     pageSize: PRICE_GROUPS_PAGE_SIZE,
   });
 

--- a/src/domain/priceGroups/utils.ts
+++ b/src/domain/priceGroups/utils.ts
@@ -4,6 +4,7 @@ import { PriceGroupsQueryVariables } from '../../generated/graphql';
 import addParamsToQueryString from '../../utils/addParamsToQueryString';
 import getPathBuilder from '../../utils/getPathBuilder';
 import getValue from '../../utils/getValue';
+import replaceParamsToQueryString from '../../utils/replaceParamsToQueryString';
 import stripLanguageFromPath from '../../utils/stripLanguageFromPath';
 import { assertUnreachable } from '../../utils/typescript';
 import {
@@ -64,6 +65,17 @@ export const addParamsToPriceGroupQueryString = (
   queryParams: Partial<PriceGroupSearchParams>
 ): string => {
   return addParamsToQueryString<PriceGroupSearchParams>(
+    queryString,
+    queryParams,
+    getPriceGroupParamValue
+  );
+};
+
+export const replaceParamsToPriceGroupQueryString = (
+  queryString: string,
+  queryParams: Partial<PriceGroupSearchParams>
+): string => {
+  return replaceParamsToQueryString<PriceGroupSearchParams>(
     queryString,
     queryParams,
     getPriceGroupParamValue

--- a/src/domain/registration/editButtonPanel/__tests__/EditButtonPanel.test.tsx
+++ b/src/domain/registration/editButtonPanel/__tests__/EditButtonPanel.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import copyToClipboard from 'copy-to-clipboard';
 
 import { ROUTES } from '../../../../constants';
@@ -8,8 +7,10 @@ import {
 } from '../../../../utils/mockLoginHooks';
 import {
   configure,
+  openDropdownMenu,
   render,
   screen,
+  shouldToggleDropdownMenu,
   userEvent,
   waitFor,
 } from '../../../../utils/testUtils';
@@ -76,7 +77,6 @@ const getElement = (
     | 'delete'
     | 'exportAsExcel'
     | 'markPresent'
-    | 'menu'
     | 'showSignups'
     | 'toggle'
     | 'update'
@@ -96,8 +96,6 @@ const getElement = (
       });
     case 'markPresent':
       return screen.getByRole('button', { name: 'Merkkaa läsnäolijat' });
-    case 'menu':
-      return screen.getByRole('region', { name: /valinnat/i });
     case 'showSignups':
       return screen.getByRole('button', { name: /näytä ilmoittautuneet/i });
     case 'toggle':
@@ -107,24 +105,10 @@ const getElement = (
   }
 };
 
-const openMenu = async () => {
-  const user = userEvent.setup();
-  const toggleButton = getElement('toggle');
-  await user.click(toggleButton);
-  getElement('menu');
-
-  return toggleButton;
-};
-
 test('should toggle menu by clicking actions button', async () => {
-  const user = userEvent.setup();
   renderComponent();
 
-  const toggleButton = await openMenu();
-  await user.click(toggleButton);
-  expect(
-    screen.queryByRole('region', { name: /valinnat/i })
-  ).not.toBeInTheDocument();
+  await shouldToggleDropdownMenu();
 });
 
 test('should render all buttons when user is authenticated', async () => {
@@ -134,7 +118,7 @@ test('should render all buttons when user is authenticated', async () => {
   const user = userEvent.setup();
   renderComponent({ props: { onDelete, onUpdate } });
 
-  await openMenu();
+  await openDropdownMenu();
 
   await findElement('showSignups');
   getElement('copy');
@@ -153,7 +137,7 @@ test('all buttons should be disabled when user is not logged in', async () => {
   mockUnauthenticatedLoginState();
   renderComponent();
 
-  await openMenu();
+  await openDropdownMenu();
 
   const disabledButtons = [
     getElement('copy'),
@@ -171,7 +155,7 @@ test('should route to signups page when clicking show signups button', async () 
   const user = userEvent.setup();
   const { history } = renderComponent();
 
-  await openMenu();
+  await openDropdownMenu();
 
   const showSignupsButton = await findElement('showSignups');
   await user.click(showSignupsButton);
@@ -188,7 +172,7 @@ test('should route to attendance list page when clicking mark present button', a
 
   const { history } = renderComponent();
 
-  await openMenu();
+  await openDropdownMenu();
 
   const markPresentButton = getElement('markPresent');
   await waitFor(() => expect(markPresentButton).toBeEnabled());
@@ -206,7 +190,7 @@ test('should route to attendance list page when clicking mark present button', a
 
 test('should export signups as an excel after clicking export as excel button', async () => {
   renderComponent();
-  await openMenu();
+  await openDropdownMenu();
   const exportAsExcelButton = getElement('exportAsExcel');
   await shouldExportSignupsAsExcel({ exportAsExcelButton, registration });
 });
@@ -215,7 +199,7 @@ test('should route to create registration page when clicking copy button', async
   const user = userEvent.setup();
   const { history } = renderComponent();
 
-  await openMenu();
+  await openDropdownMenu();
 
   const copyButton = getElement('copy');
   await user.click(copyButton);
@@ -229,7 +213,7 @@ test('should copy registration link to clipboard', async () => {
   const user = userEvent.setup();
   renderComponent();
 
-  await openMenu();
+  await openDropdownMenu();
 
   const copyLinkButton = getElement('copyLink');
   await user.click(copyLinkButton);

--- a/src/domain/registration/hooks/__tests__/useRegistrationServerErrors.test.tsx
+++ b/src/domain/registration/hooks/__tests__/useRegistrationServerErrors.test.tsx
@@ -1,7 +1,9 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-import { ApolloError } from '@apollo/client';
-import { act, renderHook } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
 
+import {
+  shouldSetGenericServerErrors,
+  shouldSetServerErrors,
+} from '../../../../utils/testUtils';
 import useRegistrationServerErrors from '../useRegistrationServerErrors';
 
 const getHookWrapper = () => {
@@ -14,81 +16,66 @@ const getHookWrapper = () => {
 it('should set generic server error items', async () => {
   const { result } = getHookWrapper();
 
-  const error = new ApolloError({
-    networkError: {
-      result: { detail: 'Metodi "POST" ei ole sallittu.' },
-    } as any,
-  });
-
-  act(() => result.current.showServerErrors({ error }));
-
-  expect(result.current.serverErrorItems).toEqual([
-    { label: '', message: 'Metodi "POST" ei ole sallittu.' },
-  ]);
+  shouldSetGenericServerErrors(result);
 });
 
 it('should set server error items', async () => {
-  const callbackFn = vi.fn();
   const { result } = getHookWrapper();
 
-  const error = new ApolloError({
-    networkError: {
-      result: {
-        audience_min_age: ['Tämän luvun on oltava vähintään 0.'],
-        audience_max_age: ['Tämän luvun on oltava vähintään 0.'],
-        enrolment_end_time: [
-          'End time cannot be in the past. Please set a future end time.',
-        ],
-        event: ['Tämän kentän arvo ei voi olla "null".'],
-        maximum_attendee_capacity: ['Tämän luvun on oltava vähintään 0.'],
-        minimum_attendee_capacity: ['Tämän luvun on oltava vähintään 0.'],
-        registration_user_accesses: [
-          {
-            is_substitute_user: [
-              "The user's email domain is not one of the allowed domains for substitute users.",
-            ],
-          },
-        ],
-        registration_price_groups: [{ price: 'Kelvollinen luku vaaditaan.' }],
-        waiting_list_capacity: ['Tämän luvun on oltava vähintään 0.'],
+  await shouldSetServerErrors(
+    result,
+    {
+      audience_min_age: ['Tämän luvun on oltava vähintään 0.'],
+      audience_max_age: ['Tämän luvun on oltava vähintään 0.'],
+      enrolment_end_time: [
+        'End time cannot be in the past. Please set a future end time.',
+      ],
+      event: ['Tämän kentän arvo ei voi olla "null".'],
+      maximum_attendee_capacity: ['Tämän luvun on oltava vähintään 0.'],
+      minimum_attendee_capacity: ['Tämän luvun on oltava vähintään 0.'],
+      registration_user_accesses: [
+        {
+          is_substitute_user: [
+            "The user's email domain is not one of the allowed domains for substitute users.",
+          ],
+        },
+      ],
+      registration_price_groups: [{ price: 'Kelvollinen luku vaaditaan.' }],
+      waiting_list_capacity: ['Tämän luvun on oltava vähintään 0.'],
+    },
+    [
+      { label: 'Alaikäraja', message: 'Tämän luvun on oltava vähintään 0.' },
+      { label: 'Yläikäraja', message: 'Tämän luvun on oltava vähintään 0.' },
+      {
+        label: 'Ilmoittautuminen päättyy',
+        message:
+          'Lopetusaika ei voi olla menneisyydessä. Määritä tuleva päättymisaika.',
       },
-    } as any,
-  });
-
-  act(() => result.current.showServerErrors({ callbackFn, error }));
-
-  expect(result.current.serverErrorItems).toEqual([
-    { label: 'Alaikäraja', message: 'Tämän luvun on oltava vähintään 0.' },
-    { label: 'Yläikäraja', message: 'Tämän luvun on oltava vähintään 0.' },
-    {
-      label: 'Ilmoittautuminen päättyy',
-      message:
-        'Lopetusaika ei voi olla menneisyydessä. Määritä tuleva päättymisaika.',
-    },
-    {
-      label: 'Tapahtuma',
-      message: 'Tämän kentän arvo ei voi olla "null".',
-    },
-    {
-      label: 'Paikkojen enimmäismäärä',
-      message: 'Tämän luvun on oltava vähintään 0.',
-    },
-    {
-      label: 'Paikkojen vähimmäismäärä',
-      message: 'Tämän luvun on oltava vähintään 0.',
-    },
-    {
-      label: 'Sijainen',
-      message: 'Käyttäjän sähköpostin verkkotunnus ei ole sallittu sijaiselle.',
-    },
-    {
-      label: 'Hinta (€)',
-      message: 'Kelvollinen luku vaaditaan.',
-    },
-    {
-      label: 'Jonopaikkojen lukumäärä',
-      message: 'Tämän luvun on oltava vähintään 0.',
-    },
-  ]);
-  expect(callbackFn).toBeCalled();
+      {
+        label: 'Tapahtuma',
+        message: 'Tämän kentän arvo ei voi olla "null".',
+      },
+      {
+        label: 'Paikkojen enimmäismäärä',
+        message: 'Tämän luvun on oltava vähintään 0.',
+      },
+      {
+        label: 'Paikkojen vähimmäismäärä',
+        message: 'Tämän luvun on oltava vähintään 0.',
+      },
+      {
+        label: 'Sijainen',
+        message:
+          'Käyttäjän sähköpostin verkkotunnus ei ole sallittu sijaiselle.',
+      },
+      {
+        label: 'Hinta (€)',
+        message: 'Kelvollinen luku vaaditaan.',
+      },
+      {
+        label: 'Jonopaikkojen lukumäärä',
+        message: 'Tämän luvun on oltava vähintään 0.',
+      },
+    ]
+  );
 });

--- a/src/domain/registration/modals/confirmDeleteRegistrationModal/__tests__/ConfirmDeleteRegistrationModal.test.tsx
+++ b/src/domain/registration/modals/confirmDeleteRegistrationModal/__tests__/ConfirmDeleteRegistrationModal.test.tsx
@@ -1,10 +1,8 @@
-import React from 'react';
-
 import {
   configure,
   render,
-  screen,
-  userEvent,
+  shouldClickButton,
+  shouldRenderDeleteModal,
 } from '../../../../../utils/testUtils';
 import ConfirmDeleteRegistrationModal, {
   ConfirmDeleteRegistrationModalProps,
@@ -25,35 +23,27 @@ const renderComponent = (
 
 test('should render component', async () => {
   renderComponent();
-  screen.getByRole('heading', {
-    name: 'Varmista ilmoittautumisen poistaminen',
-  });
-  screen.getByText('Varoitus!');
-  screen.getByText('Tämä toiminto poistaa ilmoittautumisen lopullisesti.');
 
-  screen.getByRole('button', { name: 'Poista ilmoittautuminen' });
-  screen.getByRole('button', { name: 'Peruuta' });
+  shouldRenderDeleteModal({
+    confirmButtonLabel: 'Poista ilmoittautuminen',
+    heading: 'Varmista ilmoittautumisen poistaminen',
+    text: 'Tämä toiminto poistaa ilmoittautumisen lopullisesti.',
+  });
 });
 
 test('should call onConfirm', async () => {
   const onConfirm = vi.fn();
-  const user = userEvent.setup();
   renderComponent({ onConfirm });
 
-  const deleteRegistrationButton = screen.getByRole('button', {
-    name: 'Poista ilmoittautuminen',
+  await shouldClickButton({
+    buttonLabel: 'Poista ilmoittautuminen',
+    onClick: onConfirm,
   });
-  await user.click(deleteRegistrationButton);
-  expect(onConfirm).toBeCalled();
 });
 
 test('should call onClose', async () => {
   const onClose = vi.fn();
-  const user = userEvent.setup();
   renderComponent({ onClose });
 
-  const closeButton = screen.getByRole('button', { name: 'Peruuta' });
-  await user.click(closeButton);
-
-  expect(onClose).toBeCalled();
+  await shouldClickButton({ buttonLabel: 'Peruuta', onClick: onClose });
 });

--- a/src/domain/registrations/__tests__/RegistrationsPage.test.tsx
+++ b/src/domain/registrations/__tests__/RegistrationsPage.test.tsx
@@ -7,9 +7,10 @@ import {
   loadingSpinnerIsNotInDocument,
   render,
   screen,
-  userEvent,
+  shouldApplyExpectedMetaData,
+  shouldClickListPageCreateButton,
+  shouldRenderListPage,
   waitFor,
-  waitPageMetaDataToBeSet,
 } from '../../../utils/testUtils';
 import { mockedOrganizationResponse } from '../../organization/__mocks__/organization';
 import { mockedOrganizationAncestorsResponse } from '../../organization/__mocks__/organizationAncestors';
@@ -37,35 +38,16 @@ const mocks = [
   mockedUserResponse,
 ];
 
-const findElement = (key: 'createRegistrationButton') => {
-  switch (key) {
-    case 'createRegistrationButton':
-      return screen.findByRole('button', { name: /lisää uusi/i });
-  }
-};
-
-const getElement = (key: 'createRegistrationButton' | 'table') => {
-  switch (key) {
-    case 'createRegistrationButton':
-      return screen.getByRole('button', { name: /lisää uusi/i });
-    case 'table':
-      return screen.getByRole('table', {
-        name: /ilmoittautumiset, järjestys viimeksi muokattu, laskeva/i,
-        hidden: true,
-      });
-  }
-};
-
 test('should show correct title, description and keywords', async () => {
-  const pageTitle = 'Ilmoittautuminen - Linked Events';
-  const pageDescription =
-    'Ilmoittautumisten listaus. Selaa, suodata ja muokkaa ilmoittautumisiasi.';
-  const pageKeywords =
-    'ilmoittautuminen, lista, muokkaa, linked, events, tapahtuma, hallinta, api, admin, Helsinki, Suomi';
-
   render(<RegistrationsPage />, { mocks });
 
-  await waitPageMetaDataToBeSet({ pageDescription, pageKeywords, pageTitle });
+  await shouldApplyExpectedMetaData({
+    expectedDescription:
+      'Ilmoittautumisten listaus. Selaa, suodata ja muokkaa ilmoittautumisiasi.',
+    expectedKeywords:
+      'ilmoittautuminen, lista, muokkaa, linked, events, tapahtuma, hallinta, api, admin, Helsinki, Suomi',
+    expectedTitle: 'Ilmoittautuminen - Linked Events',
+  });
 });
 
 test('should render registrations page', async () => {
@@ -73,26 +55,24 @@ test('should render registrations page', async () => {
 
   await loadingSpinnerIsNotInDocument(10000);
 
-  await findElement('createRegistrationButton');
-  getElement('table');
+  await shouldRenderListPage({
+    createButtonLabel: 'Lisää uusi',
+    heading: 'Ilmoittautuminen',
+    searchInputLabel: 'Hae ilmoittautumisia',
+    tableCaption: /ilmoittautumiset, järjestys viimeksi muokattu, laskeva/i,
+  });
 });
 
 test('should open create registration page', async () => {
-  const user = userEvent.setup();
   const { history } = render(<RegistrationsPage />, {
     mocks,
   });
 
-  await loadingSpinnerIsNotInDocument(10000);
-
-  const createRegistrationButton = await findElement(
-    'createRegistrationButton'
-  );
-  await user.click(createRegistrationButton);
-
-  await waitFor(() =>
-    expect(history.location.pathname).toBe('/fi/registrations/create')
-  );
+  await shouldClickListPageCreateButton({
+    createButtonLabel: 'Lisää uusi',
+    expectedPathname: '/fi/registrations/create',
+    history,
+  });
 });
 
 it('scrolls to registration table row and calls history.replace correctly (deletes registrationId from state)', async () => {

--- a/src/domain/registrations/registrationActionsDropdown/__tests__/RegistrationActionsDropdown.test.tsx
+++ b/src/domain/registrations/registrationActionsDropdown/__tests__/RegistrationActionsDropdown.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import copyToClipboard from 'copy-to-clipboard';
 
 import { ROUTES } from '../../../../constants';
@@ -9,8 +8,10 @@ import {
 import {
   configure,
   CustomRenderOptions,
+  openDropdownMenu,
   render,
   screen,
+  shouldToggleDropdownMenu,
   userEvent,
   waitFor,
   within,
@@ -79,9 +80,7 @@ const getElement = (
     | 'edit'
     | 'exportAsExcel'
     | 'markPresent'
-    | 'menu'
     | 'showSignups'
-    | 'toggle'
 ) => {
   switch (key) {
     case 'copy':
@@ -98,42 +97,23 @@ const getElement = (
       });
     case 'markPresent':
       return screen.getByRole('button', { name: 'Merkkaa läsnäolijat' });
-    case 'menu':
-      return screen.getByRole('region', { name: /valinnat/i });
     case 'showSignups':
       return screen.getByRole('button', { name: /näytä ilmoittautuneet/i });
-    case 'toggle':
-      return screen.getByRole('button', { name: /valinnat/i });
   }
 };
 
 const titleDisabled = 'Sinulla ei ole oikeuksia muokata ilmoittautumisia.';
 
-const openMenu = async () => {
-  const user = userEvent.setup();
-  const toggleButton = getElement('toggle');
-  await user.click(toggleButton);
-  getElement('menu');
-
-  return toggleButton;
-};
-
 test('should toggle menu by clicking actions button', async () => {
-  const user = userEvent.setup();
-
   renderComponent();
 
-  const toggleButton = await openMenu();
-  await user.click(toggleButton);
-  expect(
-    screen.queryByRole('region', { name: /valinnat/i })
-  ).not.toBeInTheDocument();
+  await shouldToggleDropdownMenu();
 });
 
 test('should render correct buttons', async () => {
   renderComponent();
 
-  await openMenu();
+  await openDropdownMenu();
 
   getElement('copy');
   getElement('copyLink');
@@ -146,7 +126,7 @@ test('only copy, copy link and edit buttons should be enabled when user is not l
   mockUnauthenticatedLoginState();
   renderComponent();
 
-  await openMenu();
+  await openDropdownMenu();
 
   getElement('copy');
   getElement('copyLink');
@@ -162,7 +142,7 @@ test('should route to edit registration page when clicking edit button', async (
 
   const { history } = renderComponent();
 
-  await openMenu();
+  await openDropdownMenu();
 
   const editButton = await findElement('edit');
   await user.click(editButton);
@@ -180,7 +160,7 @@ test('should route to signups page when clicking show signups button', async () 
 
   const { history } = renderComponent();
 
-  await openMenu();
+  await openDropdownMenu();
 
   const editButton = await findElement('showSignups');
   await user.click(editButton);
@@ -198,7 +178,7 @@ test('should route to attendance list page when clicking mark present button', a
 
   const { history } = renderComponent();
 
-  await openMenu();
+  await openDropdownMenu();
 
   const markPresentButton = getElement('markPresent');
   await user.click(markPresentButton);
@@ -213,7 +193,7 @@ test('should route to attendance list page when clicking mark present button', a
 
 test('should export signups as an excel after clicking export as excel button', async () => {
   renderComponent();
-  await openMenu();
+  await openDropdownMenu();
   const exportAsExcelButton = getElement('exportAsExcel');
 
   await shouldExportSignupsAsExcel({ exportAsExcelButton, registration });
@@ -224,7 +204,7 @@ test('should route to create registration page when clicking copy button', async
 
   const { history } = renderComponent();
 
-  await openMenu();
+  await openDropdownMenu();
 
   const copyButton = getElement('copy');
   await user.click(copyButton);
@@ -239,7 +219,7 @@ test('should copy registration link to clipboard', async () => {
 
   renderComponent();
 
-  await openMenu();
+  await openDropdownMenu();
 
   const copyLinkButton = getElement('copyLink');
   await user.click(copyLinkButton);
@@ -254,7 +234,7 @@ test('should delete registration', async () => {
   const mocks = [...defaultMocks, mockedDeleteRegistrationResponse];
   renderComponent({ mocks });
 
-  await openMenu();
+  await openDropdownMenu();
 
   const deleteButton = await findElement('delete');
   await user.click(deleteButton);

--- a/src/domain/registrations/registrationList/RegistrationList.tsx
+++ b/src/domain/registrations/registrationList/RegistrationList.tsx
@@ -111,7 +111,7 @@ const RegistrationListContainer: React.FC = () => {
   const { count, ...listProps } = useCommonListProps({
     defaultSort: DEFAULT_REGISTRATION_SORT,
     listId: registrationListId,
-    meta: registrationsData?.registrations.meta,
+    meta: registrationsData?.registrations?.meta,
     pageSize: REGISTRATIONS_PAGE_SIZE,
   });
 

--- a/src/domain/signup/__tests__/EditSignupPage.test.tsx
+++ b/src/domain/signup/__tests__/EditSignupPage.test.tsx
@@ -7,6 +7,7 @@ import { mockAuthenticatedLoginState } from '../../../utils/mockLoginHooks';
 import {
   configure,
   fireEvent,
+  openDropdownMenu,
   pasteToTextEditor,
   renderWithRoute,
   screen,
@@ -54,15 +55,6 @@ afterEach(() => {
 beforeEach(() => {
   mockAuthenticatedLoginState();
 });
-
-const openMenu = async () => {
-  const user = userEvent.setup();
-  const toggleButton = getSignupFormElement('toggle');
-  await user.click(toggleButton);
-  const menu = getSignupFormElement('menu');
-
-  return { menu, toggleButton };
-};
 
 const defaultMocks = [
   mockedSignupResponse,
@@ -190,7 +182,7 @@ test('should send message to participant', async () => {
   renderComponent([...defaultMocks, mockedSendMessageResponse]);
 
   await findFirstNameInputs();
-  const { menu } = await openMenu();
+  const { menu } = await openDropdownMenu();
 
   const sendMessageButton = await within(menu).findByRole('button', {
     name: 'Lähetä viesti',

--- a/src/domain/signup/editSignupButtonPanel/__tests__/EditSignupButtonPanel.test.tsx
+++ b/src/domain/signup/editSignupButtonPanel/__tests__/EditSignupButtonPanel.test.tsx
@@ -4,8 +4,10 @@ import { ROUTES } from '../../../../constants';
 import { mockAuthenticatedLoginState } from '../../../../utils/mockLoginHooks';
 import {
   configure,
+  openDropdownMenu,
   render,
   screen,
+  shouldToggleDropdownMenu,
   userEvent,
   waitFor,
 } from '../../../../utils/testUtils';
@@ -77,15 +79,13 @@ const findElement = (key: 'cancelButton') => {
 };
 
 const getElement = (
-  key: 'backButton' | 'cancelButton' | 'menu' | 'saveButton' | 'toggleButton'
+  key: 'backButton' | 'cancelButton' | 'saveButton' | 'toggleButton'
 ) => {
   switch (key) {
     case 'backButton':
       return screen.getByRole('button', { name: 'Takaisin' });
     case 'cancelButton':
       return screen.getByRole('button', { name: 'Peruuta osallistuminen' });
-    case 'menu':
-      return screen.getByRole('region', { name: /valinnat/i });
     case 'saveButton':
       return screen.getByRole('button', { name: 'Tallenna osallistuja' });
     case 'toggleButton':
@@ -93,25 +93,10 @@ const getElement = (
   }
 };
 
-const openMenu = async () => {
-  const user = userEvent.setup();
-  const toggleButton = getElement('toggleButton');
-  await user.click(toggleButton);
-  getElement('menu');
-
-  return toggleButton;
-};
-
 test('should toggle menu by clicking actions button', async () => {
-  const user = userEvent.setup();
   renderComponent();
 
-  const toggleButton = await openMenu();
-  await user.click(toggleButton);
-
-  expect(
-    screen.queryByRole('region', { name: /valinnat/i })
-  ).not.toBeInTheDocument();
+  await shouldToggleDropdownMenu();
 });
 
 test('should call onDelete clicking cancel button', async () => {
@@ -119,7 +104,7 @@ test('should call onDelete clicking cancel button', async () => {
   const user = userEvent.setup();
   renderComponent({ props: { onDelete } });
 
-  await openMenu();
+  await openDropdownMenu();
   const cancelButton = await findElement('cancelButton');
   await user.click(cancelButton);
   expect(onDelete).toBeCalled();

--- a/src/domain/signup/modals/confirmDeleteSignupOrSignupGroupModal/__tests__/ConfirmDeleteSignupOrSignupGroupModal.test.tsx
+++ b/src/domain/signup/modals/confirmDeleteSignupOrSignupGroupModal/__tests__/ConfirmDeleteSignupOrSignupGroupModal.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import {
   fakeSignup,
   fakeSignupGroup,
@@ -8,7 +6,7 @@ import {
   configure,
   render,
   screen,
-  userEvent,
+  shouldClickButton,
 } from '../../../../../utils/testUtils';
 import { registration } from '../../../../registration/__mocks__/registration';
 import { signup } from '../../../__mocks__/signup';
@@ -39,24 +37,19 @@ const renderComponent = (
 
 test('should call onConfirm', async () => {
   const onConfirm = vi.fn();
-  const user = userEvent.setup();
   renderComponent({ onConfirm });
 
-  const cancelEventButton = screen.getByRole('button', {
-    name: 'Peruuta ilmoittautuminen',
+  await shouldClickButton({
+    buttonLabel: 'Peruuta ilmoittautuminen',
+    onClick: onConfirm,
   });
-  await user.click(cancelEventButton);
-  expect(onConfirm).toBeCalled();
 });
 
 test('should call onClose', async () => {
   const onClose = vi.fn();
-  const user = userEvent.setup();
   renderComponent({ onClose });
 
-  const closeButton = screen.getByRole('button', { name: 'Peruuta' });
-  await user.click(closeButton);
-  expect(onClose).toBeCalled();
+  await shouldClickButton({ buttonLabel: 'Peruuta', onClick: onClose });
 });
 
 test('should should list of signup name if signup is defined', async () => {

--- a/src/domain/signup/modals/sendMessageModal/__tests__/SendMessageModal.test.tsx
+++ b/src/domain/signup/modals/sendMessageModal/__tests__/SendMessageModal.test.tsx
@@ -1,11 +1,10 @@
-import React from 'react';
-
 import {
   configure,
   fireEvent,
   pasteToTextEditor,
   render,
   screen,
+  shouldClickButton,
   userEvent,
 } from '../../../../../utils/testUtils';
 import { signupGroup } from '../../../../signupGroup/__mocks__/editSignupGroupPage';
@@ -125,10 +124,7 @@ test('should call onSendMessage when sending message to a signup group', async (
 
 test('should call onClose', async () => {
   const onClose = vi.fn();
-  const user = userEvent.setup();
   renderComponent({ onClose });
 
-  const closeButton = screen.getByRole('button', { name: 'Peruuta' });
-  await user.click(closeButton);
-  expect(onClose).toBeCalled();
+  await shouldClickButton({ buttonLabel: 'Peruuta', onClick: onClose });
 });

--- a/src/domain/signupGroup/modals/confirmDeleteSignupFromFormModal/__tests__/ConfirmDeleteSignupFromFormModal.test.tsx
+++ b/src/domain/signupGroup/modals/confirmDeleteSignupFromFormModal/__tests__/ConfirmDeleteSignupFromFormModal.test.tsx
@@ -1,10 +1,7 @@
-import React from 'react';
-
 import {
   configure,
   render,
-  screen,
-  userEvent,
+  shouldClickButton,
 } from '../../../../../utils/testUtils';
 import ConfirmDeleteSignupFromFormModal, {
   ConfirmDeleteSignupFromFormModalProps,
@@ -26,22 +23,17 @@ const renderComponent = (
 
 test('should call onConfirm', async () => {
   const onConfirm = vi.fn();
-  const user = userEvent.setup();
   renderComponent({ onConfirm });
 
-  const deleteParticipantButton = screen.getByRole('button', {
-    name: 'Poista osallistuja',
+  await shouldClickButton({
+    buttonLabel: 'Poista osallistuja',
+    onClick: onConfirm,
   });
-  await user.click(deleteParticipantButton);
-  expect(onConfirm).toBeCalled();
 });
 
 test('should call onClose', async () => {
   const onClose = vi.fn();
-  const user = userEvent.setup();
   renderComponent({ onClose });
 
-  const closeButton = screen.getByRole('button', { name: 'Peruuta' });
-  await user.click(closeButton);
-  expect(onClose).toBeCalled();
+  await shouldClickButton({ buttonLabel: 'Peruuta', onClick: onClose });
 });

--- a/src/domain/signupGroup/modals/personsAddedToWaitingListModal/__tests__/PersonsAddedToWaitingList.test.tsx
+++ b/src/domain/signupGroup/modals/personsAddedToWaitingListModal/__tests__/PersonsAddedToWaitingList.test.tsx
@@ -1,10 +1,7 @@
-import React from 'react';
-
 import {
   configure,
   render,
-  screen,
-  userEvent,
+  shouldClickButton,
 } from '../../../../../utils/testUtils';
 import PersonsAddedToWaitingListModal, {
   PersonsAddedToWaitingListModalProps,
@@ -22,9 +19,7 @@ const renderComponent = (props: Partial<PersonsAddedToWaitingListModalProps>) =>
 
 test('should call onClose', async () => {
   const onClose = vi.fn();
-  const user = userEvent.setup();
   renderComponent({ onClose });
 
-  const closeButton = screen.getByRole('button', { name: 'Sulje' });
-  await user.click(closeButton);
+  await shouldClickButton({ buttonLabel: 'Sulje', onClick: onClose });
 });

--- a/src/domain/signups/signupActionsDropdown/__tests__/SignupActionsDropdown.test.tsx
+++ b/src/domain/signups/signupActionsDropdown/__tests__/SignupActionsDropdown.test.tsx
@@ -7,9 +7,11 @@ import stripLanguageFromPath from '../../../../utils/stripLanguageFromPath';
 import {
   configure,
   fireEvent,
+  openDropdownMenu,
   pasteToTextEditor,
   render,
   screen,
+  shouldToggleDropdownMenu,
   userEvent,
   waitFor,
   within,
@@ -75,47 +77,27 @@ const renderComponent = ({
     }
   );
 
-const getElement = (
-  key: 'cancel' | 'edit' | 'menu' | 'sendMessage' | 'toggle'
-) => {
+const getElement = (key: 'cancel' | 'edit' | 'sendMessage') => {
   switch (key) {
     case 'cancel':
       return screen.getByRole('button', { name: 'Peruuta osallistuminen' });
     case 'edit':
       return screen.getByRole('button', { name: 'Muokkaa tietoja' });
-    case 'menu':
-      return screen.getByRole('region', { name: /valinnat/i });
     case 'sendMessage':
       return screen.getByRole('button', { name: 'Lähetä viesti' });
-    case 'toggle':
-      return screen.getByRole('button', { name: /valinnat/i });
   }
 };
 
-const openMenu = async () => {
-  const user = userEvent.setup();
-  const toggleButton = getElement('toggle');
-  await user.click(toggleButton);
-  getElement('menu');
-
-  return toggleButton;
-};
-
 test('should toggle menu by clicking actions button', async () => {
-  const user = userEvent.setup();
   renderComponent();
 
-  const toggleButton = await openMenu();
-  await user.click(toggleButton);
-  expect(
-    screen.queryByRole('region', { name: /valinnat/i })
-  ).not.toBeInTheDocument();
+  await shouldToggleDropdownMenu();
 });
 
 test('should render correct buttons', async () => {
   renderComponent();
 
-  await openMenu();
+  await openDropdownMenu();
 
   const enabledButtons = [getElement('cancel'), getElement('edit')];
   enabledButtons.forEach((button) => expect(button).toBeEnabled());
@@ -125,7 +107,7 @@ test("should route to edit signup page when clicking edit button and signup does
   const user = userEvent.setup();
   const { history } = renderComponent({ props: { signup } });
 
-  await openMenu();
+  await openDropdownMenu();
 
   const editButton = getElement('edit');
   await user.click(editButton);
@@ -143,7 +125,7 @@ test('should route to edit signup group page when clicking edit button and signu
     props: { signup: signupWithGroup },
   });
 
-  await openMenu();
+  await openDropdownMenu();
 
   const editButton = getElement('edit');
   await user.click(editButton);
@@ -166,7 +148,7 @@ test('should send message to participant when clicking send message button', asy
   const user = userEvent.setup();
   renderComponent();
 
-  await openMenu();
+  await openDropdownMenu();
 
   const sendMessageButton = getElement('sendMessage');
   await user.click(sendMessageButton);
@@ -197,7 +179,7 @@ test('should try to cancel signup when clicking cancel button', async () => {
   const user = userEvent.setup();
   renderComponent();
 
-  await openMenu();
+  await openDropdownMenu();
 
   const cancelButton = getElement('cancel');
   await user.click(cancelButton);

--- a/src/domain/signups/signupsTable/SignupsTable.tsx
+++ b/src/domain/signups/signupsTable/SignupsTable.tsx
@@ -190,7 +190,7 @@ const SignupsTable: React.FC<SignupsTableProps> = ({
   const { onPageChange, pageCount, pageHref } = useCommonListProps({
     defaultSort: '',
     listId: signupListId,
-    meta: signupsData?.signups.meta,
+    meta: signupsData?.signups?.meta,
     pagePath,
     pageSize: SIGNUPS_PAGE_SIZE,
   });

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -143,6 +143,13 @@ export type CreatePlaceMutationInput = {
   telephone?: InputMaybe<LocalisedObjectInput>;
 };
 
+export type CreatePriceGroupMutationInput = {
+  description?: InputMaybe<LocalisedObjectInput>;
+  id?: InputMaybe<Scalars['Int']['input']>;
+  isFree?: InputMaybe<Scalars['Boolean']['input']>;
+  publisher?: InputMaybe<Scalars['String']['input']>;
+};
+
 export type CreateRegistrationMutationInput = {
   audienceMaxAge?: InputMaybe<Scalars['Int']['input']>;
   audienceMinAge?: InputMaybe<Scalars['Int']['input']>;
@@ -450,6 +457,7 @@ export type Mutation = {
   createKeywordSet: KeywordSet;
   createOrganization: Organization;
   createPlace: Place;
+  createPriceGroup: PriceGroup;
   createRegistration: Registration;
   createSeatsReservation: SeatsReservation;
   createSignupGroup: CreateSignupGroupResponse;
@@ -511,6 +519,11 @@ export type MutationCreateOrganizationArgs = {
 
 export type MutationCreatePlaceArgs = {
   input: CreatePlaceMutationInput;
+};
+
+
+export type MutationCreatePriceGroupArgs = {
+  input: CreatePriceGroupMutationInput;
 };
 
 
@@ -1839,6 +1852,13 @@ export type PlacesQueryVariables = Exact<{
 
 
 export type PlacesQuery = { __typename?: 'Query', places: { __typename?: 'PlacesResponse', meta: { __typename?: 'Meta', count: number, next?: string | null, previous?: string | null }, data: Array<{ __typename?: 'Place', id?: string | null, atId: string, addressRegion?: string | null, contactType?: string | null, dataSource?: string | null, email?: string | null, hasUpcomingEvents?: boolean | null, nEvents?: number | null, publisher?: string | null, postalCode?: string | null, postOfficeBoxNum?: string | null, addressLocality?: { __typename?: 'LocalisedObject', ar?: string | null, en?: string | null, fi?: string | null, ru?: string | null, sv?: string | null, zhHans?: string | null } | null, description?: { __typename?: 'LocalisedObject', ar?: string | null, en?: string | null, fi?: string | null, ru?: string | null, sv?: string | null, zhHans?: string | null } | null, divisions: Array<{ __typename?: 'Division', type?: string | null, name?: { __typename?: 'LocalisedObject', ar?: string | null, en?: string | null, fi?: string | null, ru?: string | null, sv?: string | null, zhHans?: string | null } | null } | null>, infoUrl?: { __typename?: 'LocalisedObject', ar?: string | null, en?: string | null, fi?: string | null, ru?: string | null, sv?: string | null, zhHans?: string | null } | null, name?: { __typename?: 'LocalisedObject', ar?: string | null, en?: string | null, fi?: string | null, ru?: string | null, sv?: string | null, zhHans?: string | null } | null, streetAddress?: { __typename?: 'LocalisedObject', ar?: string | null, en?: string | null, fi?: string | null, ru?: string | null, sv?: string | null, zhHans?: string | null } | null, telephone?: { __typename?: 'LocalisedObject', ar?: string | null, en?: string | null, fi?: string | null, ru?: string | null, sv?: string | null, zhHans?: string | null } | null, position?: { __typename?: 'Position', coordinates: Array<number | null> } | null } | null> } };
+
+export type CreatePriceGroupMutationVariables = Exact<{
+  input: CreatePriceGroupMutationInput;
+}>;
+
+
+export type CreatePriceGroupMutation = { __typename?: 'Mutation', createPriceGroup: { __typename?: 'PriceGroup', id: number, isFree?: boolean | null, publisher?: string | null, description?: { __typename?: 'LocalisedObject', ar?: string | null, en?: string | null, fi?: string | null, ru?: string | null, sv?: string | null, zhHans?: string | null } | null } };
 
 export type DeletePriceGroupMutationVariables = Exact<{
   id: Scalars['Int']['input'];
@@ -4099,6 +4119,39 @@ export function usePlacesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Pla
 export type PlacesQueryHookResult = ReturnType<typeof usePlacesQuery>;
 export type PlacesLazyQueryHookResult = ReturnType<typeof usePlacesLazyQuery>;
 export type PlacesQueryResult = Apollo.QueryResult<PlacesQuery, PlacesQueryVariables>;
+export const CreatePriceGroupDocument = gql`
+    mutation CreatePriceGroup($input: CreatePriceGroupMutationInput!) {
+  createPriceGroup(input: $input) @rest(type: "PriceGroup", path: "/price_group/", method: "POST", bodyKey: "input") {
+    ...priceGroupFields
+  }
+}
+    ${PriceGroupFieldsFragmentDoc}`;
+export type CreatePriceGroupMutationFn = Apollo.MutationFunction<CreatePriceGroupMutation, CreatePriceGroupMutationVariables>;
+
+/**
+ * __useCreatePriceGroupMutation__
+ *
+ * To run a mutation, you first call `useCreatePriceGroupMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useCreatePriceGroupMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [createPriceGroupMutation, { data, loading, error }] = useCreatePriceGroupMutation({
+ *   variables: {
+ *      input: // value for 'input'
+ *   },
+ * });
+ */
+export function useCreatePriceGroupMutation(baseOptions?: Apollo.MutationHookOptions<CreatePriceGroupMutation, CreatePriceGroupMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<CreatePriceGroupMutation, CreatePriceGroupMutationVariables>(CreatePriceGroupDocument, options);
+      }
+export type CreatePriceGroupMutationHookResult = ReturnType<typeof useCreatePriceGroupMutation>;
+export type CreatePriceGroupMutationResult = Apollo.MutationResult<CreatePriceGroupMutation>;
+export type CreatePriceGroupMutationOptions = Apollo.BaseMutationOptions<CreatePriceGroupMutation, CreatePriceGroupMutationVariables>;
 export const DeletePriceGroupDocument = gql`
     mutation DeletePriceGroup($id: Int!) {
   deletePriceGroup(id: $id) @rest(type: "NoContent", path: "/price_group/{args.id}/", method: "DELETE") {

--- a/src/utils/testUtils.tsx
+++ b/src/utils/testUtils.tsx
@@ -218,7 +218,7 @@ const waitPageMetaDataToBeSet = async ({
 // Dropdown menu helpers
 const openDropdownMenu = async (label: string | RegExp = /valinnat/i) => {
   const user = userEvent.setup();
-  const toggleButton = screen.getByRole('button', { name: label });
+  const toggleButton = await screen.findByRole('button', { name: label });
   await user.click(toggleButton);
   const menu = screen.getByRole('region', { name: label });
 
@@ -237,16 +237,6 @@ const shouldToggleDropdownMenu = async (
 };
 
 // Modal helpers
-const shouldCallModalButtonAction = async (
-  buttonLabel: string | RegExp,
-  onClick: Mock
-) => {
-  const user = userEvent.setup();
-  const button = screen.getByRole('button', { name: buttonLabel });
-  await user.click(button);
-  expect(onClick).toBeCalled();
-};
-
 const shouldRenderDeleteModal = ({
   confirmButtonLabel,
   heading,
@@ -263,6 +253,20 @@ const shouldRenderDeleteModal = ({
   expect(
     screen.getByRole('button', { name: confirmButtonLabel })
   ).toBeInTheDocument();
+};
+
+const shouldClickButton = async ({
+  buttonLabel,
+  onClick,
+}: {
+  buttonLabel: string | RegExp;
+  onClick: Mock;
+}) => {
+  const user = userEvent.setup();
+
+  const button = screen.getByRole('button', { name: buttonLabel });
+  await user.click(button);
+  expect(onClick).toBeCalled();
 };
 
 // Server error helpers
@@ -296,6 +300,74 @@ const shouldSetServerErrors = (
 
   expect(result.current.serverErrorItems).toEqual(expectedErrors);
   expect(callbackFn).toBeCalled();
+};
+
+// List pages
+const shouldRenderListPage = async ({
+  createButtonLabel,
+  heading,
+  searchInputLabel,
+  tableCaption,
+}: {
+  createButtonLabel: string | RegExp;
+  heading: string | RegExp;
+  searchInputLabel: string | RegExp;
+  tableCaption: string | RegExp;
+}) => {
+  await screen.findByRole('heading', { name: heading });
+  await loadingSpinnerIsNotInDocument();
+  expect(
+    screen.getByRole('navigation', { name: 'Murupolku' })
+  ).toBeInTheDocument();
+  expect(
+    screen.getByRole('button', { name: createButtonLabel })
+  ).toBeInTheDocument();
+  expect(
+    screen.getByRole('combobox', { name: searchInputLabel })
+  ).toBeInTheDocument();
+  expect(
+    screen.getByRole('table', {
+      name: tableCaption,
+    })
+  );
+};
+
+const shouldClickListPageCreateButton = async ({
+  createButtonLabel,
+  expectedPathname,
+  history,
+}: {
+  createButtonLabel: string | RegExp;
+  expectedPathname: string;
+  history: History;
+}) => {
+  const user = userEvent.setup();
+  await loadingSpinnerIsNotInDocument(10000);
+
+  const createEventButton = screen.getByRole('button', {
+    name: createButtonLabel,
+  });
+  await user.click(createEventButton);
+
+  expect(history.location.pathname).toBe(expectedPathname);
+};
+
+const shouldSortListPageTable = async ({
+  columnHeader,
+  expectedSearch,
+  history,
+}: {
+  columnHeader: string | RegExp;
+  expectedSearch: string;
+  history: History;
+}) => {
+  const user = userEvent.setup();
+  await loadingSpinnerIsNotInDocument();
+
+  const sortButton = screen.getByRole('button', { name: columnHeader });
+  await user.click(sortButton);
+
+  expect(history.location.search).toBe(expectedSearch);
 };
 
 // Edit pages
@@ -365,11 +437,14 @@ export {
   customRender as render,
   renderWithRoute,
   shouldApplyExpectedMetaData,
-  shouldCallModalButtonAction,
+  shouldClickButton,
+  shouldClickListPageCreateButton,
   shouldDeleteInstance,
   shouldRenderDeleteModal,
+  shouldRenderListPage,
   shouldSetGenericServerErrors,
   shouldSetServerErrors,
+  shouldSortListPageTable,
   shouldToggleDropdownMenu,
   tabKeyPressHelper,
   waitPageMetaDataToBeSet,


### PR DESCRIPTION
## Description
Page to create new price groups. Creating price group need financial admin permissions to the publisher organization of the new price group

This is 3rd of the PRs to implement price group admin pages. All PRs are:
- https://github.com/City-of-Helsinki/linkedcomponents-ui/pull/344
- https://github.com/City-of-Helsinki/linkedcomponents-ui/pull/345
- https://github.com/City-of-Helsinki/linkedcomponents-ui/pull/346
- https://github.com/City-of-Helsinki/linkedcomponents-ui/pull/347

## Partially closes
[LINK-1888](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1888)

## Screenshot
<img width="1097" alt="Screenshot 2024-03-03 at 22 10 20" src="https://github.com/City-of-Helsinki/linkedcomponents-ui/assets/24706814/368467fe-01e6-4e94-9d02-6ece9528413d">


[LINK-1888]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1888?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ