### PR TITLE
LINK-1750 | Lang attribute for swagger

### DIFF
--- a/src/domain/help/pages/documentationPage/DocumentationPage.tsx
+++ b/src/domain/help/pages/documentationPage/DocumentationPage.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 /* eslint-disable @typescript-eslint/no-require-imports */
 import 'swagger-ui-react/swagger-ui.css';
+import './documentationPage.module.scss';
 
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -91,8 +92,11 @@ const DocumentationPage: React.FC = () => {
         title={t('helpPage.pageTitleDocumentation')}
       />
       {getContent(locale)}
-      {/* @ts-ignore */}
-      <SwaggerUI url={SWAGGER_SCHEMA_URL} />
+
+      <div lang="en">
+        {/* @ts-ignore */}
+        <SwaggerUI url={SWAGGER_SCHEMA_URL} />
+      </div>
     </PageWrapper>
   );
 };

--- a/src/domain/help/pages/documentationPage/documentationPage.module.scss
+++ b/src/domain/help/pages/documentationPage/documentationPage.module.scss
@@ -1,0 +1,3 @@
+:global(.swagger-ui .wrapper) {
+  padding: 0 !important;
+}


### PR DESCRIPTION
## Description
Swagger documentation is only in English so wrap it with div that contains `lang="en"` attribute

## Closes
[LINK-1750](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1750)
