### PR TITLE
LINK-1936 | Add timeout to SingleSelectComponent value change

### DIFF
--- a/src/common/components/formFields/hooks/__tests__/useMultiSelectFieldProps.test.tsx
+++ b/src/common/components/formFields/hooks/__tests__/useMultiSelectFieldProps.test.tsx
@@ -1,6 +1,6 @@
-import { renderHook } from '@testing-library/react';
+import { renderHook, waitFor } from '@testing-library/react';
 import { Formik } from 'formik';
-import React, { PropsWithChildren } from 'react';
+import { PropsWithChildren } from 'react';
 
 import useMultiSelectFieldProps, {
   UseMultiSelectFieldPropsProps,
@@ -43,7 +43,9 @@ describe('useMultiSelectFieldProps', () => {
 
     result.current.handleChange([]);
 
-    expect(onChange).toBeCalledWith({ target: { id: 'name', value: [] } });
+    await waitFor(() =>
+      expect(onChange).toBeCalledWith({ target: { id: 'name', value: [] } })
+    );
   });
 
   it('should not call onChange if hook is disabled', async () => {

--- a/src/common/components/formFields/hooks/__tests__/useSingleSelectFieldProps.test.tsx
+++ b/src/common/components/formFields/hooks/__tests__/useSingleSelectFieldProps.test.tsx
@@ -1,6 +1,6 @@
-import { renderHook } from '@testing-library/react';
+import { renderHook, waitFor } from '@testing-library/react';
 import { Formik } from 'formik';
-import React, { PropsWithChildren } from 'react';
+import { PropsWithChildren } from 'react';
 
 import useSingleSelectFieldProps, {
   UseSingleSelectFieldPropsProps,
@@ -43,7 +43,9 @@ describe('useSingleSelectFieldProps', () => {
 
     result.current.handleChange(null);
 
-    expect(onChange).toBeCalledWith({ target: { id: 'name', value: null } });
+    await waitFor(() =>
+      expect(onChange).toBeCalledWith({ target: { id: 'name', value: null } })
+    );
   });
 
   it('should not call onChange if hook is disabled', async () => {

--- a/src/common/components/formFields/hooks/useMultiSelectFieldProps.ts
+++ b/src/common/components/formFields/hooks/useMultiSelectFieldProps.ts
@@ -37,9 +37,12 @@ const useMultiSelectFieldProps = ({
     // TODO: HDS Combobox component allowes to remove value even if component
     // is disabled. Remove if statement when that behaviour is fixed to HDS
     if (!disabled) {
-      onChange({
-        target: { id: name, value: selected.map((item) => item.value) },
-      });
+      // Set timeout to prevent Android devices to end up to an infinite loop when changing value
+      setTimeout(() => {
+        onChange({
+          target: { id: name, value: selected.map((item) => item.value) },
+        });
+      }, 5);
     }
   };
 

--- a/src/common/components/formFields/hooks/useSingleSelectFieldProps.ts
+++ b/src/common/components/formFields/hooks/useSingleSelectFieldProps.ts
@@ -41,13 +41,17 @@ const useSingleSelectFieldProps = ({
     // is disabled. Remove if statement when that behaviour is fixed to HDS
     if (!disabled) {
       const newValue = getValue(selected?.value, null);
-      onChange({
-        target: { id: name, value: newValue },
-      });
 
-      if (onChangeCb) {
-        onChangeCb(newValue);
-      }
+      // Set timeout to prevent Android devices to end up to an infinite loop when changing value
+      setTimeout(() => {
+        onChange({
+          target: { id: name, value: newValue },
+        });
+
+        if (onChangeCb) {
+          onChangeCb(newValue);
+        }
+      }, 5);
     }
   };
 

--- a/src/domain/registration/formSections/priceGroups/__tests__/PriceGroupSection.test.tsx
+++ b/src/domain/registration/formSections/priceGroups/__tests__/PriceGroupSection.test.tsx
@@ -5,6 +5,7 @@ import {
   render,
   screen,
   userEvent,
+  waitFor,
 } from '../../../../../utils/testUtils';
 import {
   mockedFreePriceGroupsResponse,
@@ -107,11 +108,11 @@ test('should disable price and vat fields if price group is free', async () => {
   await user.type(priceInput, '10.00');
   expect(priceInput).toHaveValue(10);
 
-  // Price is cleater after changing to a free price group
+  // Price is cleared after changing to a free price group
   await user.click(priceGroupSelectButton);
   const priceGroupOption = screen.getByRole('option', {
     name: priceGroupDescription,
   });
   await user.click(priceGroupOption);
-  expect(priceInput).toHaveValue(0);
+  await waitFor(() => expect(priceInput).toHaveValue(0));
 });


### PR DESCRIPTION
## Description
- Android devices freezes totally when trying to change value of a SingleSelectComponent. Add a short timeout to prevent infinite loop after calling onChange.

## Closes
[LINK-1936](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1936)


[LINK-1936]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1936?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ