### PR TITLE
fix: Rename admin section navigation button

### DIFF
--- a/src/domain/app/i18n/en.json
+++ b/src/domain/app/i18n/en.json
@@ -5,7 +5,7 @@
   "adminPage": {
     "sideNavigation": {
       "labelAdmin": "Admin",
-      "toggleButtonLabel": "Navigate to admin page"
+      "toggleButtonLabel": "Admin tools"
     },
     "title": "Admin"
   },

--- a/src/domain/app/i18n/fi.json
+++ b/src/domain/app/i18n/fi.json
@@ -5,7 +5,7 @@
   "adminPage": {
     "sideNavigation": {
       "labelAdmin": "Hallinta",
-      "toggleButtonLabel": "Siirry hallintasivulle"
+      "toggleButtonLabel": "Hallintatyökalut"
     },
     "title": "Hallinta"
   },

--- a/src/domain/app/i18n/sv.json
+++ b/src/domain/app/i18n/sv.json
@@ -5,7 +5,7 @@
   "adminPage": {
     "sideNavigation": {
       "labelAdmin": "Admin",
-      "toggleButtonLabel": "Navigera till adminsidan"
+      "toggleButtonLabel": "Admin-verktyg"
     },
     "title": "Admin"
   },


### PR DESCRIPTION
## Description
Rename "Siirry hallintasivulle" button as "Hallintatyökalut"

## Closes
[LINK-1768](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1768)

[LINK-1768]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1768?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ