### PR TITLE
LINK-1761 | Improve accessibility of checkbox group

### DIFF
--- a/src/common/components/formFields/checkboxGroupField/CheckboxGroupField.tsx
+++ b/src/common/components/formFields/checkboxGroupField/CheckboxGroupField.tsx
@@ -3,6 +3,7 @@ import { IconAngleDown, IconAngleUp } from 'hds-react';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
+import useAccessibilityNotification from '../../../../hooks/useAccessibilityNotification';
 import { OptionType } from '../../../../types';
 import { getErrorText } from '../../../../utils/validationUtils';
 import Button from '../../button/Button';
@@ -12,7 +13,7 @@ import SelectionGroup, {
 } from '../../selectionGroup/SelectionGroup';
 import styles from './checkboxGroupField.module.scss';
 
-type Props = React.PropsWithChildren<
+export type CheckboxGroupFieldProps = React.PropsWithChildren<
   {
     disabledOptions: string[];
     errorName?: string;
@@ -23,7 +24,7 @@ type Props = React.PropsWithChildren<
     SelectionGroupProps
 >;
 
-const CheckboxGroupField: React.FC<Props> = ({
+const CheckboxGroupField: React.FC<CheckboxGroupFieldProps> = ({
   columns = 2,
   disabled,
   disabledOptions,
@@ -38,6 +39,7 @@ const CheckboxGroupField: React.FC<Props> = ({
   const { t } = useTranslation();
   const [, { error, touched: touchedError }] = useField(errorName || name);
   const [, { touched }] = useField(name);
+  const { setAccessibilityText } = useAccessibilityNotification();
 
   const errorText = getErrorText(error, touched || touchedError, t);
   const [showAll, setShowAll] = React.useState(false);
@@ -48,7 +50,14 @@ const CheckboxGroupField: React.FC<Props> = ({
   );
 
   const toggleShowAll = () => {
-    setShowAll(!showAll);
+    setAccessibilityText(
+      t(
+        showAll
+          ? 'common.checkboxGroup.accessibility.hideOptionsNotification'
+          : 'common.checkboxGroup.accessibility.showAllOptionsNotification'
+      )
+    );
+    setShowAll((o) => !o);
   };
 
   const handleBlur = () => {

--- a/src/common/components/formFields/checkboxGroupField/CheckboxGroupField.tsx
+++ b/src/common/components/formFields/checkboxGroupField/CheckboxGroupField.tsx
@@ -1,11 +1,12 @@
+/* eslint-disable max-len */
 import { FieldProps, useField } from 'formik';
 import { IconAngleDown, IconAngleUp } from 'hds-react';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
-import useAccessibilityNotification from '../../../../hooks/useAccessibilityNotification';
 import { OptionType } from '../../../../types';
 import { getErrorText } from '../../../../utils/validationUtils';
+import { useAccessibilityNotificationContext } from '../../accessibilityNotificationContext/hooks/useAccessibilityNotificationContext';
 import Button from '../../button/Button';
 import Checkbox from '../../checkbox/Checkbox';
 import SelectionGroup, {
@@ -39,7 +40,7 @@ const CheckboxGroupField: React.FC<CheckboxGroupFieldProps> = ({
   const { t } = useTranslation();
   const [, { error, touched: touchedError }] = useField(errorName || name);
   const [, { touched }] = useField(name);
-  const { setAccessibilityText } = useAccessibilityNotification();
+  const { setAccessibilityText } = useAccessibilityNotificationContext();
 
   const errorText = getErrorText(error, touched || touchedError, t);
   const [showAll, setShowAll] = React.useState(false);

--- a/src/common/components/formFields/checkboxGroupField/__tests__/CheckboxGroupField.test.tsx
+++ b/src/common/components/formFields/checkboxGroupField/__tests__/CheckboxGroupField.test.tsx
@@ -1,0 +1,58 @@
+import { Field, Formik } from 'formik';
+import range from 'lodash/range';
+
+import { render, screen, userEvent } from '../../../../../utils/testUtils';
+import CheckboxGroupField, {
+  CheckboxGroupFieldProps,
+} from '../CheckboxGroupField';
+
+const renderComponent = (props?: Partial<CheckboxGroupFieldProps>) =>
+  render(
+    <Formik initialValues={{ fieldName: '' }} onSubmit={() => undefined}>
+      {() => (
+        <Field
+          name="fieldName"
+          component={CheckboxGroupField}
+          label={'Field label'}
+          options={[]}
+          {...props}
+        />
+      )}
+    </Formik>
+  );
+
+test('should toggle visible options', async () => {
+  const user = userEvent.setup();
+
+  const visibleOptionAmount = 5;
+  const options = range(1, visibleOptionAmount * 2).map((index) => ({
+    label: `Option ${index}`,
+    value: index.toString(),
+  }));
+
+  renderComponent({ options, visibleOptionAmount });
+  const defaultOptions = options.slice(0, visibleOptionAmount);
+  const restOptions = options.slice(visibleOptionAmount);
+
+  defaultOptions.forEach(({ label }) => {
+    screen.getByLabelText(label);
+  });
+
+  restOptions.forEach(({ label }) => {
+    expect(screen.queryByLabelText(label)).not.toBeInTheDocument();
+  });
+
+  await user.click(screen.getByRole('button', { name: /näytä lisää/i }));
+  expect(
+    await screen.findByText('Lisää vaihtoehtoja lisätty listaukseen')
+  ).toBeInTheDocument();
+  restOptions.forEach(({ label }) => {
+    screen.getByLabelText(label);
+  });
+
+  await user.click(screen.getByRole('button', { name: /näytä vähemmän/i }));
+  expect(screen.queryByLabelText(restOptions[0].label)).not.toBeInTheDocument();
+  expect(
+    await screen.findByText('Osa vaihtoehdoista piilotettu listauksesta')
+  ).toBeInTheDocument();
+});

--- a/src/domain/app/i18n/en.json
+++ b/src/domain/app/i18n/en.json
@@ -83,6 +83,12 @@
     "buttonBack": "Back",
     "buttonRemoveFilter": "Remove filter: {{name}}",
     "cancel": "Undo",
+    "checkboxGroup": {
+      "accessibility": {
+        "hideOptionsNotification": "Some options hidden from the list",
+        "showAllOptionsNotification": "More options added to the list"
+      }
+    },
     "clear": "Clear",
     "close": "Close",
     "combobox": {

--- a/src/domain/app/i18n/fi.json
+++ b/src/domain/app/i18n/fi.json
@@ -83,6 +83,12 @@
     "buttonBack": "Takaisin",
     "buttonRemoveFilter": "Poista suodatusehto: {{name}}",
     "cancel": "Peruuta",
+    "checkboxGroup": {
+      "accessibility": {
+        "hideOptionsNotification": "Osa vaihtoehdoista piilotettu listauksesta",
+        "showAllOptionsNotification": "Lisää vaihtoehtoja lisätty listaukseen"
+      }
+    },
     "clear": "Tyhjennä",
     "close": "Sulje",
     "combobox": {

--- a/src/domain/app/i18n/sv.json
+++ b/src/domain/app/i18n/sv.json
@@ -83,6 +83,12 @@
     "buttonBack": "Tillbaka",
     "buttonRemoveFilter": "Ta bort filter: {{namn}}",
     "cancel": "Ångra",
+    "checkboxGroup": {
+      "accessibility": {
+        "hideOptionsNotification": "Vissa alternativ dolda från listan",
+        "showAllOptionsNotification": "Fler alternativ har lagts till på listan"
+      }
+    },
     "clear": "Klar",
     "close": "Stäng",
     "combobox": {

--- a/src/domain/event/formSections/audienceSection/AudienceSection.tsx
+++ b/src/domain/event/formSections/audienceSection/AudienceSection.tsx
@@ -43,7 +43,6 @@ const AudienceSection: React.FC<Props> = ({ isEditingAllowed }) => {
             label={t(`event.form.titleAudience`)}
             name={EVENT_FIELDS.AUDIENCE}
             options={audienceOptions}
-            visibleOptionAmount={10}
           />
         </FieldColumn>
       </FieldRow>

--- a/src/domain/event/formSections/audienceSection/__tests__/AudienceSection.test.tsx
+++ b/src/domain/event/formSections/audienceSection/__tests__/AudienceSection.test.tsx
@@ -1,11 +1,9 @@
 import { Formik } from 'formik';
-import React from 'react';
 
 import {
   configure,
   render,
   screen,
-  userEvent,
   waitFor,
 } from '../../../../../utils/testUtils';
 import translations from '../../../../app/i18n/fi.json';
@@ -57,35 +55,14 @@ test('should render audience section', async () => {
   ).toBeInTheDocument();
 });
 
-test('should show 10 first audiences by default and rest by clicking show more', async () => {
-  const user = userEvent.setup();
+test('should show all audience options', async () => {
   renderComponent();
 
   const sortedAudienceNames = audienceNames
     .slice()
     .sort((a, b) => a.localeCompare(b, 'en'));
 
-  await waitFor(() => {
-    expect(screen.queryByLabelText(sortedAudienceNames[0])).toBeInTheDocument();
-  });
-  const defaultKeywords = sortedAudienceNames.slice(0, 10);
-  const restKeywords = sortedAudienceNames.slice(10);
-
-  defaultKeywords.forEach((keyword) => {
-    expect(screen.queryByLabelText(keyword)).toBeInTheDocument();
-  });
-
-  restKeywords.forEach((keyword) => {
-    expect(screen.queryByLabelText(keyword)).not.toBeInTheDocument();
-  });
-
-  await user.click(screen.getByRole('button', { name: /näytä lisää/i }));
-
-  await waitFor(() => {
-    expect(screen.queryByLabelText(restKeywords[0])).toBeInTheDocument();
-  });
-
-  restKeywords.forEach((keyword) => {
-    expect(screen.queryByLabelText(keyword)).toBeInTheDocument();
-  });
+  for (const keyword of sortedAudienceNames) {
+    expect(await screen.findByLabelText(keyword)).toBeInTheDocument();
+  }
 });

--- a/src/domain/event/formSections/classificationSection/ClassificationSection.tsx
+++ b/src/domain/event/formSections/classificationSection/ClassificationSection.tsx
@@ -91,7 +91,6 @@ const ClassificationSection: React.FC<Props> = ({ isEditingAllowed }) => {
             label={t(`event.form.titleMainCategories`)}
             options={keywordOptions}
             name={EVENT_FIELDS.KEYWORDS}
-            visibleOptionAmount={10}
           />
         </FieldColumn>
       </FieldRow>

--- a/src/domain/event/formSections/classificationSection/__tests__/ClassificationSection.test.tsx
+++ b/src/domain/event/formSections/classificationSection/__tests__/ClassificationSection.test.tsx
@@ -1,5 +1,4 @@
 import { Formik } from 'formik';
-import React from 'react';
 
 import getValue from '../../../../../utils/getValue';
 import {
@@ -86,7 +85,6 @@ const getElement = (
     | 'infoTextKeywords'
     | 'infoTextMainCategories'
     | 'mainCategories'
-    | 'showMoreButton'
     | 'titleMainCategories'
     | 'titleNotification'
     | 'toggleButton'
@@ -100,8 +98,6 @@ const getElement = (
       return screen.getByText(/valitse vähintään yksi pääluokka/i);
     case 'mainCategories':
       return screen.getByRole('group', { name: /valitse kategoria\(t\)/i });
-    case 'showMoreButton':
-      return screen.getByRole('button', { name: /näytä lisää/i });
     case 'titleMainCategories':
       return screen.getByRole('heading', { name: /Valitse kategoria\(t\)/i });
     case 'titleNotification':
@@ -127,30 +123,15 @@ test('should render classification section', async () => {
   await findElement('keywordText');
 });
 
-test('should show 10 first topics by default and rest by clicking show more', async () => {
+test('should show all topic options', async () => {
   const sortedKeywords = [...eventTopicNames, removeParticipationName].sort();
-  const defaultKeywords = sortedKeywords.slice(0, 10);
-  const restKeywords = [...sortedKeywords].slice(10);
 
-  const user = userEvent.setup();
   renderComponent();
 
   const mainCategories = getElement('mainCategories');
   await within(mainCategories).findByLabelText(eventTopicNames[0]);
 
-  for (const name of defaultKeywords.slice(1)) {
-    within(mainCategories).getByLabelText(name);
-  }
-  for (const name of restKeywords) {
-    expect(
-      within(mainCategories).queryByLabelText(name)
-    ).not.toBeInTheDocument();
-  }
-
-  await user.click(getElement('showMoreButton'));
-
-  await within(mainCategories).findByLabelText(restKeywords[0]);
-  for (const name of restKeywords.slice(1)) {
+  for (const name of sortedKeywords) {
     within(mainCategories).getByLabelText(name);
   }
 });

--- a/src/domain/event/formSections/languagesSection/LanguagesSection.tsx
+++ b/src/domain/event/formSections/languagesSection/LanguagesSection.tsx
@@ -80,7 +80,6 @@ const LanguagesSection: React.FC<Props> = ({ isEditingAllowed }) => {
             label={t(`event.form.titleInLanguages.${eventType}`)}
             name={EVENT_FIELDS.IN_LANGUAGE}
             options={inLanguageOptions}
-            visibleOptionAmount={10}
           />
         </FieldColumn>
       </FieldRow>


### PR DESCRIPTION
## Description
- Display accessibility notification after showing more or hiding options in checkbox group
- Display all the options in main categories, topics and languages checkbox group

## Closes
[LINK-1761](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1761)

[LINK-1761]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ