### PR TITLE
LINK-1908 | Offer usability improvements

### DIFF
--- a/src/domain/event/eventPage.module.scss
+++ b/src/domain/event/eventPage.module.scss
@@ -9,6 +9,7 @@
   }
   h3 {
     font-size: var(--fontsize-heading-s);
+    margin: var(--spacing-m) 0;
     font-weight: normal;
   }
   p {

--- a/src/domain/event/formSections/priceSection/PriceSection.tsx
+++ b/src/domain/event/formSections/priceSection/PriceSection.tsx
@@ -11,6 +11,7 @@ import FieldRow from '../../../app/layout/fieldRow/FieldRow';
 import usePriceGroupOptions from '../../../priceGroup/hooks/usePriceGroupOptions';
 import { PriceGroupOption } from '../../../priceGroup/types';
 import { EVENT_FIELDS } from '../../constants';
+import styles from '../../eventPage.module.scss';
 import FreeEventFields from './freeEventFields/FreeEventFields';
 import Offers from './offers/Offers';
 import PriceNotification from './priceNotification/PriceNotification';
@@ -41,7 +42,11 @@ const PriceSection: React.FC<Props> = ({ isEditingAllowed }) => {
   return (
     <Fieldset heading={t('event.form.sections.price')} hideLegend>
       <h3>{t(`event.form.titlePriceInfo.${type}`)}</h3>
-      <FieldRow notification={<PriceNotification />}>
+      <FieldRow
+        notification={
+          <PriceNotification className={styles.notificationForTitle} />
+        }
+      >
         <FieldColumn>
           <FormGroup>
             <Field

--- a/src/domain/event/formSections/priceSection/__tests__/PriceSection.test.tsx
+++ b/src/domain/event/formSections/priceSection/__tests__/PriceSection.test.tsx
@@ -166,24 +166,25 @@ test('should validate an offer', async () => {
   );
 });
 
-test('should show instructions only once', async () => {
+test('should show instructions for each offer', async () => {
   const user = userEvent.setup();
   renderPriceSection();
 
   getElement('heading');
 
-  // Should be instructions to free event
+  // Should have instructions to free event
   expect(queryElements('instructions')).toHaveLength(1);
 
   await user.click(getElement('hasPriceCheckbox'));
 
   await waitFor(() => expect(queryElements('priceInputs')).toHaveLength(1));
+  expect(queryElements('instructions')).toHaveLength(2);
 
   const addOfferButton = await findAddOfferButton();
   await user.click(addOfferButton);
 
   await waitFor(() => expect(queryElements('priceInputs')).toHaveLength(2));
-  expect(queryElements('instructions')).toHaveLength(1);
+  expect(queryElements('instructions')).toHaveLength(3);
 });
 
 test('should show add price group button only if registration is planned', async () => {

--- a/src/domain/event/formSections/priceSection/offers/offer/Offer.tsx
+++ b/src/domain/event/formSections/priceSection/offers/offer/Offer.tsx
@@ -8,7 +8,9 @@ import FormGroup from '../../../../../../common/components/formGroup/FormGroup';
 import { featureFlagUtils } from '../../../../../../utils/featureFlags';
 import FieldRow from '../../../../../app/layout/fieldRow/FieldRow';
 import { EVENT_FIELDS, EVENT_OFFER_FIELDS } from '../../../../constants';
+import styles from '../../../../eventPage.module.scss';
 import FieldWithButton from '../../../../layout/FieldWithButton';
+import PriceNotification from '../../priceNotification/PriceNotification';
 import OfferPriceGroups from './offerPriceGroups/OfferPriceGroups';
 
 type Props = {
@@ -39,7 +41,11 @@ const Offer: React.FC<Props> = ({
 
   return (
     <>
-      <FieldRow>
+      <FieldRow
+        notification={
+          <PriceNotification className={styles.secondNotification} />
+        }
+      >
         <FieldWithButton
           button={
             showDelete && (

--- a/src/domain/event/formSections/priceSection/offers/offer/Offer.tsx
+++ b/src/domain/event/formSections/priceSection/offers/offer/Offer.tsx
@@ -70,19 +70,6 @@ const Offer: React.FC<Props> = ({
               />
             </FormGroup>
             <FormGroup>
-              <h3>{t('event.form.titleOfferInfoUrl')}</h3>
-              <MultiLanguageField
-                disabled={!isEditingAllowed}
-                labelKey={`event.form.labelOfferInfoUrl`}
-                languages={eventInfoLanguages}
-                name={getFieldName(
-                  offerPath,
-                  EVENT_OFFER_FIELDS.OFFER_INFO_URL
-                )}
-                placeholderKey={`event.form.placeholderOfferInfoUrl`}
-              />
-            </FormGroup>
-            <FormGroup>
               <h3>{t('event.form.titleOfferDescription')}</h3>
               <MultiLanguageField
                 disabled={!isEditingAllowed}
@@ -93,6 +80,19 @@ const Offer: React.FC<Props> = ({
                   EVENT_OFFER_FIELDS.OFFER_DESCRIPTION
                 )}
                 placeholderKey={`event.form.placeholderOfferDescription`}
+              />
+            </FormGroup>
+            <FormGroup>
+              <h3>{t('event.form.titleOfferInfoUrl')}</h3>
+              <MultiLanguageField
+                disabled={!isEditingAllowed}
+                labelKey={`event.form.labelOfferInfoUrl`}
+                languages={eventInfoLanguages}
+                name={getFieldName(
+                  offerPath,
+                  EVENT_OFFER_FIELDS.OFFER_INFO_URL
+                )}
+                placeholderKey={`event.form.placeholderOfferInfoUrl`}
               />
             </FormGroup>
           </>

--- a/src/domain/event/formSections/priceSection/priceNotification/PriceNotification.tsx
+++ b/src/domain/event/formSections/priceSection/priceNotification/PriceNotification.tsx
@@ -1,17 +1,21 @@
 import { useField } from 'formik';
+import { FC } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import Notification from '../../../../../common/components/notification/Notification';
 import { EVENT_FIELDS } from '../../../constants';
-import styles from '../../../eventPage.module.scss';
 
-const PriceNotification = () => {
+type PriceNotificationProps = {
+  className?: string;
+};
+
+const PriceNotification: FC<PriceNotificationProps> = ({ className }) => {
   const { t } = useTranslation();
   const [{ value: type }] = useField({ name: EVENT_FIELDS.TYPE });
 
   return (
     <Notification
-      className={styles.notificationForTitle}
+      className={className}
       label={t(`event.form.notificationTitleOffers`)}
       type="info"
     >


### PR DESCRIPTION
## Description
Display notification for each offer
Swap description and info url fields order

## Closes
[LINK-1908](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1908)

## Screenshot
<img width="1216" alt="Screenshot 2024-04-10 at 11 33 22" src="https://github.com/City-of-Helsinki/linkedcomponents-ui/assets/24706814/85b09954-36da-4816-9821-7f7cf733f58d">


[LINK-1908]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1908?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ