### PR TITLE
LINK-1949 | Change column header order in events table

### DIFF
--- a/src/domain/events/eventsTable/EventsTable.tsx
+++ b/src/domain/events/eventsTable/EventsTable.tsx
@@ -90,10 +90,10 @@ const EventsTable: React.FC<EventsTableProps> = ({
             {t('eventsPage.eventsTableColumns.publisher')}
           </th>
           <SortingHeaderCell
-            {...headerColumnProps[EVENT_SORT_OPTIONS.END_TIME]}
+            {...headerColumnProps[EVENT_SORT_OPTIONS.START_TIME]}
           />
           <SortingHeaderCell
-            {...headerColumnProps[EVENT_SORT_OPTIONS.START_TIME]}
+            {...headerColumnProps[EVENT_SORT_OPTIONS.END_TIME]}
           />
           <th className={styles.statusColumn}>
             {t('eventsPage.eventsTableColumns.status')}


### PR DESCRIPTION
## Description
Start and end time column headers are in incorrect order. fix the order in this PR

## Closes
[LINK-1949](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1949)

## Screenshot
<img width="1423" alt="Screenshot 2024-04-15 at 8 31 30" src="https://github.com/City-of-Helsinki/linkedcomponents-ui/assets/24706814/28a56497-4400-4aa1-9df4-c7bd3b5afde3">


[LINK-1949]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ