### PR TITLE
LINK-1953 | move event description field location in event form

### DIFF
--- a/src/domain/event/formSections/descriptionSection/DescriptionSection.tsx
+++ b/src/domain/event/formSections/descriptionSection/DescriptionSection.tsx
@@ -188,22 +188,25 @@ const DescriptionSection: React.FC<DescriptionSectionProps> = ({
                       required={true}
                     />
                   </FormGroup>
+                  <FormGroup>
+                    <Field
+                      component={TextEditorField}
+                      disabled={!isEditingAllowed}
+                      label={t(`event.form.labelDescription.${type}`, {
+                        langText,
+                      })}
+                      maxLength={CHARACTER_LIMITS.LONG_STRING}
+                      name={`${EVENT_FIELDS.DESCRIPTION}.${selectedLanguage}`}
+                      placeholder={t(
+                        `event.form.placeholderDescription.${type}`
+                      )}
+                      required={true}
+                      sanitizeAfterBlur={sanitizeDescription}
+                    />
+                  </FormGroup>
                 </FieldColumn>
               </FieldRow>
-              <FormGroup>
-                <Field
-                  component={TextEditorField}
-                  disabled={!isEditingAllowed}
-                  label={t(`event.form.labelDescription.${type}`, {
-                    langText,
-                  })}
-                  maxLength={CHARACTER_LIMITS.LONG_STRING}
-                  name={`${EVENT_FIELDS.DESCRIPTION}.${selectedLanguage}`}
-                  placeholder={t(`event.form.placeholderDescription.${type}`)}
-                  required={true}
-                  sanitizeAfterBlur={sanitizeDescription}
-                />
-              </FormGroup>
+
               {isExternalUser && (
                 <FieldRow
                   notification={


### PR DESCRIPTION
## Description :sparkles:
Move event description field to be immediately after short description field

## Closes
[LINK-1953](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1953)

## Screenshot
<img width="1414" alt="Screenshot 2024-04-15 at 8 40 26" src="https://github.com/City-of-Helsinki/linkedcomponents-ui/assets/24706814/d411633b-87c5-4836-a167-594f903ceb6f">


[LINK-1953]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1953?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ