### PR TITLE
LINK-1955 | Change short description field type

### DIFF
--- a/src/domain/event/formSections/descriptionSection/DescriptionSection.tsx
+++ b/src/domain/event/formSections/descriptionSection/DescriptionSection.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 
 import Fieldset from '../../../../common/components/fieldset/Fieldset';
 import CheckboxField from '../../../../common/components/formFields/checkboxField/CheckboxField';
+import TextAreaField from '../../../../common/components/formFields/textAreaField/TextAreaField';
 import TextEditorField from '../../../../common/components/formFields/textEditorField/TextEditorField';
 import TextInputField from '../../../../common/components/formFields/textInputField/TextInputField';
 import FormGroup from '../../../../common/components/formGroup/FormGroup';
@@ -175,7 +176,7 @@ const DescriptionSection: React.FC<DescriptionSectionProps> = ({
                   </FormGroup>
                   <FormGroup>
                     <Field
-                      component={TextInputField}
+                      component={TextAreaField}
                       disabled={!isEditingAllowed}
                       label={t(`event.form.labelShortDescription.${type}`, {
                         langText,


### PR DESCRIPTION
## Description
Change short description field type to textarea in event form

## Closes
[LINK-1955](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1955)

## Screenshot
<img width="1421" alt="Screenshot 2024-04-15 at 8 48 19" src="https://github.com/City-of-Helsinki/linkedcomponents-ui/assets/24706814/be896ffa-2b68-466d-9159-ae81ef3db9c8">


[LINK-1955]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ