### PR TITLE
LINK-1951 | Fine-tune external user instruction text

### DIFF
--- a/src/domain/app/i18n/en.json
+++ b/src/domain/app/i18n/en.json
@@ -487,7 +487,7 @@
       "buttonUpdateDraft": "Save draft",
       "buttonUpdatePublic": "Save changes",
       "checkboxIsVerified": "I verify that the information I have provided is correct and I undertake to comply with <a href={{url}} target=\"_blank\" rel=\"noopener noreferrer\" aria-label=\"all instructions and regulations {{openInNewTab}}\">all instructions and regulations</a> concerning the courses and events of the City of Helsinki.",
-      "eventDraftStateInfo": "The saved information will automatically be visible to the moderator as well. However, the information can be edited until the moderator publishes the event. The latter can be avoided by writing \"KESKENERÄINEN\" at the beginning of the event title while editing is in progress.",
+      "eventDraftStateInfo": "Saved drafts will automatically be visible to the moderator. The information can be edited until the moderator publishes the event. You can avoid publication by writing \"UNFINISHED\" at the beginning of the event title while editing is in progress.",
       "editButtonPanel": {
         "warningCancelledEvent": "Cancelled events can't be edited.",
         "warningCannotCancelDraft": "Event drafts can't be cancelled.",

--- a/src/domain/app/i18n/fi.json
+++ b/src/domain/app/i18n/fi.json
@@ -487,7 +487,7 @@
       "buttonUpdateDraft": "Tallenna luonnos",
       "buttonUpdatePublic": "Tallenna muutokset",
       "checkboxIsVerified": "Vakuutan, että antamani tiedot ovat oikein ja sitoudun noudattamaan kaikkia Helsingin kaupungin kursseja ja tapahtumia <a href={{url}} target=\"_blank\" rel=\"noopener noreferrer\" aria-label=\"koskevia ohjeita ja säädöksiä {{openInNewTab}}\">koskevia ohjeita ja säädöksiä</a>.",
-      "eventDraftStateInfo": "Tallennetut tiedot tulevat automaattisesti näkyville myös moderoijalle. Tietoja voi kuitenkin muokata, kunnes moderaattori julkaisee tapahtuman. Jälkimmäisen voi välttää kirjoittamalla muokkauksen ajaksi tapahtuman otsikon alkuun \"KESKENERÄINEN\".",
+      "eventDraftStateInfo": "Tallennetut luonnokset tulevat automaattisesti näkyviin moderoijalle. Tietoja voi muokata, kunnes moderoija julkaisee tapahtuman. Julkaisun voi välttää kirjoittamalla muokkauksen ajaksi tapahtuman otsikon alkuun \"KESKENERÄINEN\"",
       "editButtonPanel": {
         "warningCancelledEvent": "Peruttuja tapahtumia ei voi muokata.",
         "warningCannotCancelDraft": "Tapahtumaluonnosta ei voi perua.",

--- a/src/domain/app/i18n/sv.json
+++ b/src/domain/app/i18n/sv.json
@@ -487,7 +487,7 @@
       "buttonUpdateDraft": "Spara utkast",
       "buttonUpdatePublic": "Spara ändringar",
       "checkboxIsVerified": "Jag intygar att de uppgifter jag lämnat är korrekta och jag förbinder mig att följa <a href={{url}} target=\"_blank\" rel=\"noopener noreferrer\" aria-label=\"alla instruktioner och bestämmelser {{openInNewTab}}\">alla instruktioner och bestämmelser</a> gällande Helsingfors stads kurser och evenemang.",
-      "eventDraftStateInfo": "Den sparade informationen kommer automatiskt att vara synlig även för moderatorn. Informationen kan dock redigeras fram till dess att moderatorn publicerar evenemanget. Det senare kan undvikas genom att skriva \"KESKENERÄINEN\" i början av evenemangets titel medan redigeringen pågår.",
+      "eventDraftStateInfo": "Sparade utkast kommer automatiskt att vara synliga för moderatorn. Informationen kan redigeras tills moderatorn publicerar evenemanget. Du kan undvika publicering genom att skriva \"OFULLBORDAD\" i början av evenemangets titel medan redigeringen pågår.",
       "editButtonPanel": {
         "warningCancelledEvent": "Avbokade evenemang kan inte redigeras.",
         "warningCannotCancelDraft": "Evenemangsutkast kan inte annulleras.",


### PR DESCRIPTION
## Description
Fine-tune external user instruction text

## Closes
[LINK-1951](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1951)

## Screenshot
<img width="1445" alt="Screenshot 2024-04-15 at 9 05 56" src="https://github.com/City-of-Helsinki/linkedcomponents-ui/assets/24706814/27742ef4-7dc5-4e22-9bf6-879a7506b84d">


[LINK-1951]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1951?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ