### PR TITLE
LINK-1983 | Rename support page navigation

### DIFF
--- a/e2e/tests/help.spec.ts
+++ b/e2e/tests/help.spec.ts
@@ -14,12 +14,12 @@ test.describe('Help page', () => {
       .getByRole('link', { name: 'Tuki' })
       .click();
     await page
-      .getByLabel('Siirry ohjesivulle')
+      .getByLabel('Lisätietoa palvelusta')
       .getByRole('link', { name: 'Yleistä' })
       .click();
 
     await page
-      .getByLabel('Siirry ohjesivulle')
+      .getByLabel('Lisätietoa palvelusta')
       .getByRole('link', { name: 'Alusta' })
       .click();
     await expect
@@ -27,7 +27,7 @@ test.describe('Help page', () => {
       .toBeVisible();
 
     await page
-      .getByLabel('Siirry ohjesivulle')
+      .getByLabel('Lisätietoa palvelusta')
       .getByRole('link', { name: 'Hallintapaneeli' })
       .click();
     await expect
@@ -35,7 +35,7 @@ test.describe('Help page', () => {
       .toBeVisible();
 
     await page
-      .getByLabel('Siirry ohjesivulle')
+      .getByLabel('Lisätietoa palvelusta')
       .getByRole('link', { name: 'Linked Registration -ohje' })
       .click();
     await expect
@@ -43,7 +43,7 @@ test.describe('Help page', () => {
       .toBeVisible();
 
     await page
-      .getByLabel('Siirry ohjesivulle')
+      .getByLabel('Lisätietoa palvelusta')
       .getByRole('link', { name: 'UKK' })
       .click();
     await expect
@@ -60,7 +60,7 @@ test.describe('Help page', () => {
       .toBeVisible();
 
     await page
-      .getByLabel('Siirry ohjesivulle')
+      .getByLabel('Lisätietoa palvelusta')
       .getByRole('link', { name: 'Rajapinta' })
       .click();
     await expect
@@ -68,7 +68,7 @@ test.describe('Help page', () => {
       .toBeVisible();
 
     await page
-      .getByLabel('Siirry ohjesivulle')
+      .getByLabel('Lisätietoa palvelusta')
       .getByRole('link', { name: 'Kuvaoikeudet' })
       .click();
     await expect
@@ -76,7 +76,7 @@ test.describe('Help page', () => {
       .toBeVisible();
 
     await page
-      .getByLabel('Siirry ohjesivulle')
+      .getByLabel('Lisätietoa palvelusta')
       .getByRole('link', { name: 'Lähdekoodi' })
       .click();
     await expect
@@ -84,7 +84,7 @@ test.describe('Help page', () => {
       .toBeVisible();
 
     await page
-      .getByLabel('Siirry ohjesivulle')
+      .getByLabel('Lisätietoa palvelusta')
       .getByRole('link', { name: 'Dokumentaatio' })
       .click();
     await expect
@@ -93,7 +93,7 @@ test.describe('Help page', () => {
 
     await page.getByRole('button', { name: 'Tuki' }).click();
     await page
-      .getByLabel('Siirry ohjesivulle')
+      .getByLabel('Lisätietoa palvelusta')
       .getByRole('link', { name: 'Käyttöehdot' })
       .click();
     await expect
@@ -101,7 +101,7 @@ test.describe('Help page', () => {
       .toBeVisible();
 
     await page
-      .getByLabel('Siirry ohjesivulle')
+      .getByLabel('Lisätietoa palvelusta')
       .getByRole('link', { name: 'Ota yhteyttä' })
       .click();
     await expect
@@ -109,7 +109,7 @@ test.describe('Help page', () => {
       .toBeVisible();
 
     await page
-      .getByLabel('Siirry ohjesivulle')
+      .getByLabel('Lisätietoa palvelusta')
       .getByRole('link', { name: 'Pyydä käyttöoikeutta' })
       .click();
     await expect

--- a/src/domain/app/i18n/en.json
+++ b/src/domain/app/i18n/en.json
@@ -1348,7 +1348,7 @@
       "labelSupport": "Support",
       "labelTechnology": "Technology",
       "labelTermsOfUse": "Terms of use",
-      "toggleButtonLabel": "Navigate to help page"
+      "toggleButtonLabel": "More information about the service"
     },
     "sourceCodeLinks": {
       "api": "API",

--- a/src/domain/app/i18n/fi.json
+++ b/src/domain/app/i18n/fi.json
@@ -1348,7 +1348,7 @@
       "labelSupport": "Tuki",
       "labelTechnology": "Teknologia",
       "labelTermsOfUse": "Käyttöehdot",
-      "toggleButtonLabel": "Siirry ohjesivulle"
+      "toggleButtonLabel": "Lisätietoa palvelusta"
     },
     "sourceCodeLinks": {
       "api": "rajapinta",

--- a/src/domain/app/i18n/sv.json
+++ b/src/domain/app/i18n/sv.json
@@ -1348,7 +1348,7 @@
       "labelSupport": "Stöd",
       "labelTechnology": "Teknologi",
       "labelTermsOfUse": "Användarvillkor",
-      "toggleButtonLabel": "Navigera till hjälpsidan"
+      "toggleButtonLabel": "Mer information om tjänsten"
     },
     "sourceCodeLinks": {
       "api": "API",


### PR DESCRIPTION
## Description
Rename support page navigation

## Closes
[LINK-1983](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1983)

## Screenshot
<img width="499" alt="Screenshot 2024-04-17 at 15 06 45" src="https://github.com/City-of-Helsinki/linkedcomponents-ui/assets/24706814/a30f534b-920d-42a9-ba87-24c79c4f6ab2">


[LINK-1983]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1983?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ