### PR TITLE
LINK-1966 | fix vitest warnings

### DIFF
--- a/src/common/components/imageSelector/__mocks__/imageSelector.ts
+++ b/src/common/components/imageSelector/__mocks__/imageSelector.ts
@@ -29,15 +29,15 @@ const imagesResponse = {
     },
   },
 };
-const mockedImagesReponse = {
+const mockedImagesResponse = {
   request: { query: ImagesDocument, variables: imagesVariables },
   result: imagesResponse,
 };
 
-const mockedImagesUserWithoutOrganizationsReponse = {
-  ...mockedImagesReponse,
+const mockedImagesUserWithoutOrganizationsResponse = {
+  ...mockedImagesResponse,
   request: {
-    ...mockedImagesReponse.request,
+    ...mockedImagesResponse.request,
     variables: { ...imagesVariables, createdBy: 'me', publisher: '' },
   },
 };
@@ -64,8 +64,8 @@ const mockedLoadMoreImagesResponse = {
 export {
   images,
   loadMoreImages,
-  mockedImagesReponse,
-  mockedImagesUserWithoutOrganizationsReponse,
+  mockedImagesResponse,
+  mockedImagesUserWithoutOrganizationsResponse,
   mockedLoadMoreImagesResponse,
   publisher,
 };

--- a/src/common/components/imageSelector/__tests__/ImageSelector.test.tsx
+++ b/src/common/components/imageSelector/__tests__/ImageSelector.test.tsx
@@ -20,8 +20,8 @@ import {
 import {
   images,
   loadMoreImages,
-  mockedImagesReponse,
-  mockedImagesUserWithoutOrganizationsReponse,
+  mockedImagesResponse,
+  mockedImagesUserWithoutOrganizationsResponse,
   mockedLoadMoreImagesResponse,
   publisher,
 } from '../__mocks__/imageSelector';
@@ -56,7 +56,7 @@ const defaultImageItemProps: ImageItemProps = {
 };
 
 const defaultMocks = [
-  mockedImagesReponse,
+  mockedImagesResponse,
   mockedLoadMoreImagesResponse,
   mockedOrganizationAncestorsResponse,
   mockedUserResponse,
@@ -150,8 +150,8 @@ describe('ImageSelector', () => {
 
   test('should call onChange with external user', async () => {
     const mocks = [
-      mockedImagesUserWithoutOrganizationsReponse,
-      mockedLoadMoreImagesResponse,
+      mockedImagesResponse,
+      mockedImagesUserWithoutOrganizationsResponse,
       mockedOrganizationAncestorsResponse,
       mockedUserWithoutOrganizationsResponse,
     ];

--- a/src/common/components/table/__tests__/Table.test.tsx
+++ b/src/common/components/table/__tests__/Table.test.tsx
@@ -111,6 +111,10 @@ describe('<Table /> spec', () => {
   });
 
   it('should not have basic accessibility issues', async () => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    HTMLCanvasElement.prototype.getContext = vi.fn();
+
     const { container } = render(
       <Table
         caption={caption}

--- a/src/common/components/timeInput/__tests__/TimeInput.test.tsx
+++ b/src/common/components/timeInput/__tests__/TimeInput.test.tsx
@@ -55,6 +55,10 @@ describe('<TimeInput /> spec', () => {
   });
 
   it('should not have basic accessibility issues', async () => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    HTMLCanvasElement.prototype.getContext = vi.fn();
+
     const { container } = renderComponent();
     const results = await axe(container);
     expect(results).toHaveNoViolations();

--- a/src/domain/app/routes/localeRoutes/__tests__/LocaleRoutes.test.tsx
+++ b/src/domain/app/routes/localeRoutes/__tests__/LocaleRoutes.test.tsx
@@ -5,8 +5,8 @@ import React from 'react';
 import { Route, Routes } from 'react-router-dom';
 
 import { mockedRegistrationEventSelectorEventsResponse } from '../../../../../common/components/formFields/registrationEventSelectorField/__mocks__/registrationEventSelectorField';
-import { mockedKeywordsResponse as mockedKeywordSelectorKeywordsReponse } from '../../../../../common/components/keywordSelector/__mocks__/keywordSelector';
-import { mockedPlacesResponse as mockedPlaceSelectorPlacesReponse } from '../../../../../common/components/placeSelector/__mocks__/placeSelector';
+import { mockedKeywordsResponse as mockedKeywordSelectorKeywordsResponse } from '../../../../../common/components/keywordSelector/__mocks__/keywordSelector';
+import { mockedPlacesResponse as mockedPlaceSelectorPlacesResponse } from '../../../../../common/components/placeSelector/__mocks__/placeSelector';
 import { DEPRECATED_ROUTES, ROUTES } from '../../../../../constants';
 import { AttendeeStatus } from '../../../../../generated/graphql';
 import { setFeatureFlags } from '../../../../../test/featureFlags/featureFlags';
@@ -224,12 +224,12 @@ it.each([DEPRECATED_ROUTES.CREATE_EVENT, ROUTES.CREATE_EVENT])(
   async (route) => {
     const { history } = renderRoute({
       mocks: [
-        mockedKeywordSelectorKeywordsReponse,
+        mockedKeywordSelectorKeywordsResponse,
         mockedTopicsKeywordSetResponse,
         mockedAudienceKeywordSetResponse,
         mockedLanguagesResponse,
         mockedOrganizationResponse,
-        mockedPlaceSelectorPlacesReponse,
+        mockedPlaceSelectorPlacesResponse,
         mockedPublisherPriceGroupsResponse,
         mockedUserResponse,
       ],
@@ -254,12 +254,12 @@ it.each([
       mockedEventResponse,
       mockedImageResponse,
       mockedPlaceResponse,
-      mockedKeywordSelectorKeywordsReponse,
+      mockedKeywordSelectorKeywordsResponse,
       mockedTopicsKeywordSetResponse,
       mockedAudienceKeywordSetResponse,
       mockedLanguagesResponse,
       mockedOrganizationResponse,
-      mockedPlaceSelectorPlacesReponse,
+      mockedPlaceSelectorPlacesResponse,
       mockedPublisherPriceGroupsResponse,
       mockedUserResponse,
       mockedOrganizationAncestorsResponse,
@@ -584,7 +584,7 @@ it('should render create keyword set page', async () => {
   const { history } = renderRoute({
     mocks: [
       mockedOrganizationResponse,
-      mockedKeywordSelectorKeywordsReponse,
+      mockedKeywordSelectorKeywordsResponse,
       mockedUserResponse,
       mockedOrganizationAncestorsResponse,
     ],
@@ -605,7 +605,7 @@ it('should render edit keyword set page', async () => {
       mockedKeywordSetResponse,
       mockedOrganizationResponse,
       mockedKeywordResponse,
-      mockedKeywordSelectorKeywordsReponse,
+      mockedKeywordSelectorKeywordsResponse,
       mockedUserResponse,
       mockedOrganizationAncestorsResponse,
     ],

--- a/src/domain/event/__tests__/CreateEventPage.test.tsx
+++ b/src/domain/event/__tests__/CreateEventPage.test.tsx
@@ -44,6 +44,10 @@ import {
   placeAtId,
 } from '../../place/__mocks__/place';
 import {
+  mockedDefaultPriceGroupsResponse,
+  mockedPublisherPriceGroupsResponse,
+} from '../../priceGroup/__mocks__/priceGroups';
+import {
   mockedUserResponse,
   mockedUserWithoutOrganizationsResponse,
 } from '../../user/__mocks__/user';
@@ -77,7 +81,7 @@ beforeEach(() => {
   sessionStorage.clear();
 });
 
-const defaultMocks = [
+const commonMocks = [
   mockedImagesResponse,
   mockedImageResponse,
   mockedUmbrellaEventsResponse,
@@ -90,10 +94,13 @@ const defaultMocks = [
   // PlaceSelector component requires second mock. https://github.com/apollographql/react-apollo/issues/617
   mockedFilteredPlacesResponse,
   mockedFilteredPlacesResponse,
+  mockedDefaultPriceGroupsResponse,
+  mockedPublisherPriceGroupsResponse,
   mockedOrganizationResponse,
   mockedOrganizationAncestorsResponse,
-  mockedUserResponse,
 ];
+
+const defaultMocks = [...commonMocks, mockedUserResponse];
 
 const renderComponent = (mocks: MockedResponse[] = defaultMocks) =>
   render(<CreateEventPage />, {
@@ -182,23 +189,7 @@ test('should focus to first validation error when trying to save draft event', a
 test('should focus to first validation error when trying to save draft event as external user', async () => {
   const user = userEvent.setup();
 
-  const mocks = [
-    mockedImagesResponse,
-    mockedImageResponse,
-    mockedUmbrellaEventsResponse,
-    mockedAudienceKeywordSetResponse,
-    mockedTopicsKeywordSetResponse,
-    mockedKeywordSelectorKeywordsResponse,
-    mockedLanguagesResponse,
-    mockedPlaceResponse,
-    mockedPlacesResponse,
-    // PlaceSelector component requires second mock. https://github.com/apollographql/react-apollo/issues/617
-    mockedFilteredPlacesResponse,
-    mockedFilteredPlacesResponse,
-    mockedOrganizationResponse,
-    mockedOrganizationAncestorsResponse,
-    mockedUserWithoutOrganizationsResponse,
-  ];
+  const mocks = [...commonMocks, mockedUserWithoutOrganizationsResponse];
 
   renderComponent(mocks);
 
@@ -456,23 +447,7 @@ test('should route to event completed page after publishing event', async () => 
 });
 
 test('should render fields for external user', async () => {
-  const mocks = [
-    mockedImagesResponse,
-    mockedImageResponse,
-    mockedUmbrellaEventsResponse,
-    mockedAudienceKeywordSetResponse,
-    mockedTopicsKeywordSetResponse,
-    mockedKeywordSelectorKeywordsResponse,
-    mockedLanguagesResponse,
-    mockedPlaceResponse,
-    mockedPlacesResponse,
-    // PlaceSelector component requires second mock. https://github.com/apollographql/react-apollo/issues/617
-    mockedFilteredPlacesResponse,
-    mockedFilteredPlacesResponse,
-    mockedOrganizationResponse,
-    mockedOrganizationAncestorsResponse,
-    mockedUserWithoutOrganizationsResponse,
-  ];
+  const mocks = [...commonMocks, mockedUserWithoutOrganizationsResponse];
 
   renderComponent(mocks);
 

--- a/src/domain/event/__tests__/EditEventPage.test.tsx
+++ b/src/domain/event/__tests__/EditEventPage.test.tsx
@@ -48,6 +48,10 @@ import {
   mockedPlacesResponse,
 } from '../../place/__mocks__/place';
 import {
+  mockedExternalUserPriceGroupsResponse,
+  mockedPublisherPriceGroupsResponse,
+} from '../../priceGroup/__mocks__/priceGroups';
+import {
   mockedExternalAdminUserResponse,
   mockedUserResponse,
   mockedUserWithoutOrganizationsResponse,
@@ -105,6 +109,8 @@ const baseMocks = [
   mockedUserResponse,
   mockedOrganizationResponse,
   mockedOrganizationAncestorsResponse,
+  mockedPublisherPriceGroupsResponse,
+  mockedExternalUserPriceGroupsResponse,
 ];
 
 const route = ROUTES.EDIT_EVENT.replace(':id', eventId);
@@ -494,6 +500,7 @@ test('should render fields for external user', async () => {
     mockedUserWithoutOrganizationsResponse,
     mockedOrganizationResponse,
     mockedOrganizationAncestorsResponse,
+    mockedPublisherPriceGroupsResponse,
   ];
 
   renderComponent(mocks);

--- a/src/domain/event/formSections/imageSection/__mocks__/imageSection.ts
+++ b/src/domain/event/formSections/imageSection/__mocks__/imageSection.ts
@@ -43,7 +43,7 @@ const mockedImagesResponse: MockedResponse = {
   newData: () => imagesResponse,
 };
 
-const mockedImagesUserWithoutOrganizationsReponse = {
+const mockedImagesUserWithoutOrganizationsResponse = {
   ...mockedImagesResponse,
   request: {
     ...mockedImagesResponse.request,
@@ -59,7 +59,7 @@ const mockedImageResponse: MockedResponse = {
   result: imageResponse,
 };
 
-const mockedImageUserWithoutOrganizationsReponse = {
+const mockedImageUserWithoutOrganizationsResponse = {
   ...mockedImageResponse,
   request: {
     ...mockedImageResponse.request,
@@ -124,8 +124,8 @@ export {
   imageUrl,
   mockedImageResponse,
   mockedImagesResponse,
-  mockedImagesUserWithoutOrganizationsReponse,
-  mockedImageUserWithoutOrganizationsReponse,
+  mockedImagesUserWithoutOrganizationsResponse,
+  mockedImageUserWithoutOrganizationsResponse,
   mockedUploadImage1Response,
   mockedUploadImage1UserWithoutOrganizationsResponse,
   mockedUploadImage2Response,

--- a/src/domain/event/formSections/imageSection/__tests__/ImageSection.test.tsx
+++ b/src/domain/event/formSections/imageSection/__tests__/ImageSection.test.tsx
@@ -38,8 +38,8 @@ import {
   imageUrl,
   mockedImageResponse,
   mockedImagesResponse,
-  mockedImagesUserWithoutOrganizationsReponse,
-  mockedImageUserWithoutOrganizationsReponse,
+  mockedImagesUserWithoutOrganizationsResponse,
+  mockedImageUserWithoutOrganizationsResponse,
   mockedUploadImage1Response,
   mockedUploadImage1UserWithoutOrganizationsResponse,
   mockedUploadImage2Response,
@@ -294,8 +294,8 @@ test('should create and select new image by selecting image file for external us
 
   const mockValues = { ...defaultInitialValues, [EVENT_FIELDS.PUBLISHER]: '' };
   const mocks = [
-    mockedImagesUserWithoutOrganizationsReponse,
-    mockedImageUserWithoutOrganizationsReponse,
+    mockedImagesUserWithoutOrganizationsResponse,
+    mockedImageUserWithoutOrganizationsResponse,
     mockedUploadImage1UserWithoutOrganizationsResponse,
     mockedUploadImage2UserWithoutOrganizationsResponse,
     mockedOrganizationAncestorsResponse,
@@ -327,8 +327,8 @@ test('should create and select new image by entering image url for external user
 
   const mockValues = { ...defaultInitialValues, [EVENT_FIELDS.PUBLISHER]: '' };
   const mocks = [
-    mockedImagesUserWithoutOrganizationsReponse,
-    mockedImageUserWithoutOrganizationsReponse,
+    mockedImagesUserWithoutOrganizationsResponse,
+    mockedImageUserWithoutOrganizationsResponse,
     mockedUploadImage1UserWithoutOrganizationsResponse,
     mockedUploadImage2UserWithoutOrganizationsResponse,
     mockedOrganizationAncestorsResponse,

--- a/src/domain/eventSaved/__tests__/EventSavedPage.test.tsx
+++ b/src/domain/eventSaved/__tests__/EventSavedPage.test.tsx
@@ -22,7 +22,7 @@ const route = ROUTES.EVENT_SAVED.replace(':id', eventId);
 const getMocks = (publicationStatus: PublicationStatus): MockedResponse[] => {
   const event = fakeEvent({ id: eventId, publicationStatus });
   const eventResponse = { data: { event: event } };
-  const mockedEventReponse = {
+  const mockedEventResponse = {
     request: {
       query: EventDocument,
       variables: { id: eventId, createPath: undefined },
@@ -30,7 +30,7 @@ const getMocks = (publicationStatus: PublicationStatus): MockedResponse[] => {
     result: eventResponse,
   };
 
-  return [mockedEventReponse];
+  return [mockedEventResponse];
 };
 
 const getElement = (

--- a/src/domain/priceGroup/__mocks__/priceGroups.ts
+++ b/src/domain/priceGroup/__mocks__/priceGroups.ts
@@ -82,9 +82,23 @@ const mockedPublisherPriceGroupsResponse: MockedResponse = {
   result: publisherPriceGroupsResponse,
 };
 
+const externalUserPriceGroupsVariables = {
+  createPath: undefined,
+  pageSize: PRICE_GROUPS_PAGE_SIZE_LARGE,
+  publisher: ['none', 'others'],
+};
+const mockedExternalUserPriceGroupsResponse: MockedResponse = {
+  request: {
+    query: PriceGroupsDocument,
+    variables: externalUserPriceGroupsVariables,
+  },
+  result: defaultPriceGroupsResponse,
+};
+
 export {
   defaultPriceGroups,
   mockedDefaultPriceGroupsResponse,
+  mockedExternalUserPriceGroupsResponse,
   mockedFreePriceGroupsResponse,
   mockedPublisherPriceGroupsResponse,
   priceGroupDescription,


### PR DESCRIPTION
## Description
LocaleRoutes: 
- Use test specific mocks instead of having common mocks variable which contains all the mocks 
- Add missing mocks to get rid of some warnings

CreateEventPage:
- Add missing mocks to get rid of some warnings

EditEventPage:
- Add missing mocks to get rid of some warnings 

mock HTMLCanvasElement.prototype.getContext function to solve accessibility test warnings

Note that there still are some warnings caused by the same name (Tuki - Tuki) in help page breadcrumbs. This issue will be solved in the LINK-1770 and can be ignored here.

## Closes
[LINK-1966](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1966)

[LINK-1966]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1966?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ