### PR TITLE
fix: update a11y status when filtered attendees are changed

### DIFF
--- a/src/domain/attendanceList/attendeeList/AttendeeList.tsx
+++ b/src/domain/attendanceList/attendeeList/AttendeeList.tsx
@@ -93,10 +93,10 @@ const AttendeeList: React.FC<Props> = ({ registration }) => {
   };
   return (
     <>
-      <SearchStatus count={attendees.length} loading={false} />
+      <SearchStatus count={filteredAttendees.length} loading={false} />
       <AdminSearchRow
         countText={t('attendanceListPage.count', {
-          count: attendees.length,
+          count: filteredAttendees.length,
         })}
         onSearchSubmit={
           /* istanbul ignore next */


### PR DESCRIPTION
## Description
Attendees are filtered on the UI side, so update search status accessibility output when filtered attendees count is changed
