### PR TITLE
fix: require exact match in event search test

### DIFF
--- a/e2e/tests/events.spec.ts
+++ b/e2e/tests/events.spec.ts
@@ -102,9 +102,11 @@ test.describe('Event search page', () => {
 
     // Search controls
     await searchInput.fill(textToSearch);
-    await expect(page.getByText('0 tapahtumaa')).not.toBeVisible();
+    await expect(
+      page.getByText('0 tapahtumaa', { exact: true })
+    ).not.toBeVisible();
     await page.locator('button').filter({ hasText: 'Etsi tapahtumia' }).click();
-    await expect(page.getByText('0 tapahtumaa')).toBeVisible();
+    await expect(page.getByText('0 tapahtumaa', { exact: true })).toBeVisible();
   });
 });
 


### PR DESCRIPTION
## Description
The purpose for the original query is to test that 0 results is found. Current query matches also if amount of events ends with 0. e.g. 10280 tapahtumaa. Add exact parameter to avoid the issue.