### PR TITLE
LINK-2027 | fine-tune styles of description fields

### DIFF
--- a/src/common/components/textArea/TextArea.tsx
+++ b/src/common/components/textArea/TextArea.tsx
@@ -3,6 +3,7 @@ import { TextArea as BaseTextArea, TextAreaProps } from 'hds-react';
 import React from 'react';
 
 import { useTheme } from '../../../domain/app/theme/Theme';
+import styles from './textArea.module.scss';
 
 const TextArea: React.FC<TextAreaProps> = ({ className, ...rest }) => {
   const { theme } = useTheme();
@@ -12,7 +13,7 @@ const TextArea: React.FC<TextAreaProps> = ({ className, ...rest }) => {
       {({ css, cx }) => (
         <BaseTextArea
           {...rest}
-          className={cx(className, css(theme.textInput))}
+          className={cx(styles.textArea, className, css(theme.textInput))}
         />
       )}
     </ClassNames>

--- a/src/common/components/textArea/__tests__/__snapshots__/TextArea.test.tsx.snap
+++ b/src/common/components/textArea/__tests__/__snapshots__/TextArea.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`should match snapshot 1`] = `
 <div>
   <div
-    class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq css-0"
+    class="TextInput-module_root__2CMNr text-input_hds-text-input__2LODq textArea css-0"
   >
     <label
       class="FieldLabel-module_label__1zrXK "

--- a/src/common/components/textArea/textArea.module.scss
+++ b/src/common/components/textArea/textArea.module.scss
@@ -1,0 +1,5 @@
+.textArea {
+  textarea {
+    resize: none !important;
+  }
+}

--- a/src/common/components/textEditor/textEditor.module.scss
+++ b/src/common/components/textEditor/textEditor.module.scss
@@ -1,11 +1,10 @@
 .textEditor {
   --text-editor-border-width: 1px;
   --text-editor-border-color: var(--color-black-50);
-  --text-editor-editor-max-height: 20rem;
-  --text-editor-editor-min-height: var(--spacing-layout-2-xl);
+  --text-editor-editor-max-height: unset;
+  --text-editor-editor-min-height: 22rem;
 }
 
 .inputWrapper > div {
   display: block;
 }
-


### PR DESCRIPTION
## Description :sparkles:
Prevent to resize text area fields
Make text editor field height to match with description instructions notification

## Closes
[LINK-2027](https://helsinkisolutionoffice.atlassian.net/browse/LINK-2027)

## Screenshots
<img width="996" alt="Screenshot 2024-05-10 at 14 32 53" src="https://github.com/City-of-Helsinki/linkedcomponents-ui/assets/24706814/f19917a9-5355-4f36-ad34-19f8e39814d0">

[LINK-2027]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-2027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ