### PR TITLE
LINK-2004 | fine-tune input components disabled styles

### DIFF
--- a/src/common/components/textEditor/ckeditor.scss
+++ b/src/common/components/textEditor/ckeditor.scss
@@ -1,4 +1,8 @@
 .text-editor {
+  .ck-button.ck-disabled {
+    cursor: not-allowed;
+  }
+
   .ck.ck-editor__main > .ck-editor__editable {
     border: var(--text-editor-border-width) solid
       var(--text-editor-border-color);
@@ -6,14 +10,19 @@
     min-height: var(--text-editor-editor-min-height);
     max-height: var(--text-editor-editor-max-height);
     font-size: var(--fontsize-body-l);
-  
+
     &.ck-focused {
       box-shadow: 0 0 0 var(--outline-width) var(--focus-outline-color);
       transform: translateZ(0);
       transition: 85ms ease-out;
       transition-property: box-shadow, transform;
     }
-  
+
+    &.ck-read-only {
+      background-color: var(--input-background-disabled);
+      cursor: not-allowed;
+    }
+
     h1,
     h2,
     h3,
@@ -49,7 +58,8 @@
         margin: var(--spacing-3-xs) 0;
       }
     }
-    ol, ul {
+    ol,
+    ul {
       padding: 0 var(--spacing-s);
     }
 
@@ -58,12 +68,10 @@
       padding-left: 5px;
     }
   }
-  
+
   &.invalid {
     .ck.ck-editor__main > .ck-editor__editable {
       border-color: var(--color-error);
     }
   }
 }
-
-  

--- a/src/common/components/timeInput/customTimeInput.module.scss
+++ b/src/common/components/timeInput/customTimeInput.module.scss
@@ -6,9 +6,9 @@
   padding: 0 calc(var(--spacing-s) - 3px);
 
   &.disabled {
-    background-color: var(--input-background-disabled);
-    border-color: var(--input-border-color-disabled);
-    color: var(--input-color-disabled);
+    background-color: var(--input-background-disabled) !important;
+    border-color: var(--input-border-color-disabled) !important;
+    color: var(--input-color-disabled) !important;
     cursor: not-allowed;
 
     &:hover {


### PR DESCRIPTION
## Description
Unify text editor and time input components disabled styles with other input components

## Closes
[LINK-2004](https://helsinkisolutionoffice.atlassian.net/browse/LINK-2004)

## Screenshots
<img width="524" alt="Screenshot 2024-05-10 at 15 27 30" src="https://github.com/City-of-Helsinki/linkedcomponents-ui/assets/24706814/a0193d66-e969-4b2b-9327-529c2809b4d1">

<img width="398" alt="Screenshot 2024-05-10 at 15 27 39" src="https://github.com/City-of-Helsinki/linkedcomponents-ui/assets/24706814/68907c55-fe6e-4575-884d-5515a43c7cd8">


[LINK-2004]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-2004?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ