### PR TITLE
LINK-2051 | hide instruction notifications from admin users

### DIFF
--- a/src/common/components/headingWithTooltip/HeadingWithTooltip.tsx
+++ b/src/common/components/headingWithTooltip/HeadingWithTooltip.tsx
@@ -1,0 +1,48 @@
+import classNames from 'classnames';
+import { Tooltip } from 'hds-react';
+import { FC, ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import styles from './headingWithTooltip.module.scss';
+
+export type HeadingWithTooltipProps = {
+  className?: string;
+  heading: string;
+  showTooltip: boolean;
+  tag: 'h2' | 'h3';
+  tooltipContent: ReactNode;
+  tooltipLabel: string;
+};
+
+const HeadingWithTooltip: FC<HeadingWithTooltipProps> = ({
+  className,
+  heading,
+  showTooltip,
+  tag: Heading,
+  tooltipContent,
+  tooltipLabel,
+}) => {
+  const { t } = useTranslation();
+  return (
+    <Heading
+      className={classNames(
+        { [styles.headingWithTooltip]: showTooltip },
+        className
+      )}
+    >
+      {heading}
+      {showTooltip && (
+        <Tooltip
+          buttonClassName={styles.tooltipButton}
+          buttonLabel={t('common.showInstructions')}
+          tooltipClassName={styles.tooltipContent}
+          tooltipLabel={tooltipLabel}
+        >
+          {tooltipContent}
+        </Tooltip>
+      )}
+    </Heading>
+  );
+};
+
+export default HeadingWithTooltip;

--- a/src/common/components/headingWithTooltip/headingWithTooltip.module.scss
+++ b/src/common/components/headingWithTooltip/headingWithTooltip.module.scss
@@ -1,0 +1,17 @@
+.headingWithTooltip {
+  align-items: center;
+  display: flex;
+  grid-column-gap: var(--spacing-2-xs);
+  justify-content: flex-start;
+}
+
+.tooltipButton {
+  align-items: center;
+  display: flex;
+}
+
+.tooltipContent {
+  p:last-of-type {
+    margin-bottom: 0;
+  }
+}

--- a/src/common/components/notification/Notification.tsx
+++ b/src/common/components/notification/Notification.tsx
@@ -13,6 +13,8 @@ export type NotificationProps = { id?: string } & HdsNotificationProps;
 const Notification: React.FC<NotificationProps> = ({
   className,
   id,
+  label,
+  notificationAriaLabel,
   type = 'success',
   ...rest
 }) => {
@@ -29,6 +31,13 @@ const Notification: React.FC<NotificationProps> = ({
               className,
               css(theme.notification.type?.[type])
             )}
+            label={label}
+            notificationAriaLabel={
+              /* istanbul ignore next */
+              typeof label === 'string'
+                ? label ?? notificationAriaLabel
+                : notificationAriaLabel
+            }
             type={type}
           />
         </div>

--- a/src/domain/app/i18n/en.json
+++ b/src/domain/app/i18n/en.json
@@ -259,6 +259,7 @@
     "save": "Save",
     "search": "Search",
     "select": "Select",
+    "showInstructions": "Show instructions",
     "showLess": "Show less",
     "showMore": "Show more",
     "showMoreWithCount": "Show more ({{count}})",

--- a/src/domain/app/i18n/fi.json
+++ b/src/domain/app/i18n/fi.json
@@ -259,6 +259,7 @@
     "save": "Tallenna",
     "search": "Etsi",
     "select": "Valitse",
+    "showInstructions": "Näytä ohjeet",
     "showLess": "Näytä vähemmän",
     "showMore": "Näytä lisää",
     "showMoreWithCount": "Näytä lisää ({{count}})",

--- a/src/domain/app/i18n/sv.json
+++ b/src/domain/app/i18n/sv.json
@@ -259,6 +259,7 @@
     "save": "Spara",
     "search": "Sök",
     "select": "Välj",
+    "showInstructions": "Visa instruktioner",
     "showLess": "Visa mindre",
     "showMore": "Visa mer",
     "showMoreWithCount": "Visa mer ({{count}})",

--- a/src/domain/app/layout/section/Section.tsx
+++ b/src/domain/app/layout/section/Section.tsx
@@ -1,21 +1,39 @@
 import classNames from 'classnames';
 import React from 'react';
 
+import HeadingWithTooltip from '../../../../common/components/headingWithTooltip/HeadingWithTooltip';
 import styles from './section.module.scss';
 
 type Props = {
   className?: string;
+  showTooltip?: boolean;
   title: string;
+  tooltipContent?: React.ReactElement;
+  tooltipLabel?: string;
 };
 
 const Section: React.FC<React.PropsWithChildren<Props>> = ({
   children,
   className,
+  showTooltip = false,
   title,
+  tooltipContent,
+  tooltipLabel,
 }) => {
   return (
     <div className={classNames(styles.section, className)}>
-      <h2>{title}</h2>
+      {tooltipContent ? (
+        <HeadingWithTooltip
+          heading={title}
+          showTooltip={showTooltip}
+          tag="h2"
+          tooltipContent={tooltipContent}
+          tooltipLabel={tooltipLabel ?? title}
+        />
+      ) : (
+        <h2>{title}</h2>
+      )}
+
       {children}
     </div>
   );

--- a/src/domain/event/__tests__/CreateEventPage.test.tsx
+++ b/src/domain/event/__tests__/CreateEventPage.test.tsx
@@ -48,6 +48,7 @@ import {
   mockedPublisherPriceGroupsResponse,
 } from '../../priceGroup/__mocks__/priceGroups';
 import {
+  mockedSuperuserResponse,
   mockedUserResponse,
   mockedUserWithoutOrganizationsResponse,
 } from '../../user/__mocks__/user';
@@ -64,7 +65,10 @@ import {
 import { EVENT_EXTERNAL_USER_INITIAL_VALUES, EVENT_FIELDS } from '../constants';
 import CreateEventPage from '../CreateEventPage';
 import { EventFormFields } from '../types';
-import { testExternalUserFields } from './eventTestUtils';
+import {
+  testExternalUserFields,
+  testInstructionNotifications,
+} from './eventTestUtils';
 
 configure({ defaultHidden: true });
 
@@ -465,4 +469,31 @@ test('should render fields for external user', async () => {
   await loadingSpinnerIsNotInDocument();
 
   await testExternalUserFields();
+});
+
+test('should render instruction notifications for external user', async () => {
+  const mocks = [...commonMocks, mockedUserWithoutOrganizationsResponse];
+
+  renderComponent(mocks);
+
+  await loadingSpinnerIsNotInDocument();
+
+  await testInstructionNotifications(true);
+});
+
+test('should not render instruction notifications for admin user', async () => {
+  renderComponent(defaultMocks);
+
+  await loadingSpinnerIsNotInDocument();
+
+  await testInstructionNotifications(false);
+});
+
+test('should not render instruction notifications for superuser', async () => {
+  const mocks = [...commonMocks, mockedSuperuserResponse];
+  renderComponent(mocks);
+
+  await loadingSpinnerIsNotInDocument();
+
+  await testInstructionNotifications(false);
 });

--- a/src/domain/event/__tests__/eventTestUtils.ts
+++ b/src/domain/event/__tests__/eventTestUtils.ts
@@ -82,3 +82,40 @@ export const testExternalUserFields = async () => {
     }
   }
 };
+
+export const testInstructionNotifications = async (
+  shouldBeVisible: boolean
+) => {
+  const notificationTitles: string[] = [
+    'Tapahtumatietojen syöttökielet',
+    'Tapahtuman kielet (ohjauskielet)',
+    'Tapahtuman julkaisija',
+    'Tapahtuman järjestäjä',
+    'Tapahtuman kuvaus',
+    'Ympäristösertifikaatti',
+    'Tapahtuman ajankohdat',
+    'Tapahtumapaikka',
+    'Tapahtuma sosiaalisessa mediassa',
+    'Tapahtumaan liittyvä kuva',
+    'Tapahtuman video',
+    'Tapahtuman luokittelu',
+    'Lisää avainsanoja',
+    'Kohderyhmät',
+    'Ikärajoitukset',
+    'Ilmoittautumisaika',
+    'Osallistujamäärä',
+  ];
+
+  for (const title of notificationTitles) {
+    const notification = screen.queryByRole('region', { name: title });
+
+    if (shouldBeVisible) {
+      expect(notification).toBeInTheDocument();
+    } else {
+      expect(notification).not.toBeInTheDocument();
+    }
+  }
+  expect(
+    screen.queryByRole('region', { name: 'Julkaisu' })
+  ).toBeInTheDocument();
+};

--- a/src/domain/event/eventForm/EventForm.tsx
+++ b/src/domain/event/eventForm/EventForm.tsx
@@ -48,20 +48,24 @@ import EventAuthenticationNotification from '../eventAuthenticationNotification/
 import EventInfo from '../eventInfo/EventInfo';
 import styles from '../eventPage.module.scss';
 import AdditionalInfoSection from '../formSections/additionalInfoSection/AdditionalInfoSection';
+import AudienceInstructions from '../formSections/audienceSection/audienceInstructions/AudienceInstructions';
 import AudienceSection from '../formSections/audienceSection/AudienceSection';
 import ChannelsSection from '../formSections/channelsSection/ChannelsSection';
 import ClassificationSection from '../formSections/classificationSection/ClassificationSection';
+import DescriptionInstructions from '../formSections/descriptionSection/descriptionInstructions/DescriptionInstructions';
 import DescriptionSection from '../formSections/descriptionSection/DescriptionSection';
 import EventStateInfoSection from '../formSections/eventStateInfoSection/EventStateInfoSection';
 import ExternalUserContact from '../formSections/externalUserContact/ExternalUserContact';
 import ImageSection from '../formSections/imageSection/ImageSection';
 import LanguagesSection from '../formSections/languagesSection/LanguagesSection';
 import LinksToEventsSection from '../formSections/linksToEventsSection/LinksToEventsSection';
+import LocationInstructions from '../formSections/placeSection/locationInstructions/LocationInstructions';
 import PlaceSection from '../formSections/placeSection/PlaceSection';
 import PriceSection from '../formSections/priceSection/PriceSection';
 import RegistrationSection from '../formSections/registrationSection/RegistrationSection';
 import ResponsibilitiesSection from '../formSections/responsibilitiesSection/ResponsibilitiesSection';
 import SummarySection from '../formSections/summarySection/SummarySection';
+import TimeInstructions from '../formSections/timeSection/timeInstructions/TimeInstructions';
 import TimeSection from '../formSections/timeSection/TimeSection';
 import PublicationListLinks from '../formSections/typeSection/publicationListLinks/PublicationListLinks';
 import TypeSection from '../formSections/typeSection/TypeSection';
@@ -81,6 +85,7 @@ import {
   getEventInitialValues,
   scrollToFirstError,
   shouldShowTypeSection,
+  showTooltipInstructions,
 } from '../utils';
 import {
   draftEventSchema,
@@ -144,7 +149,9 @@ const EventForm: React.FC<EventFormProps> = ({
   const [, , { setValue: setMainCategories }] = useField<string[]>({
     name: EVENT_FIELDS.MAIN_CATEGORIES,
   });
-  const [{ value: type }] = useField<EVENT_TYPE>({ name: EVENT_FIELDS.TYPE });
+  const [{ value: eventType }] = useField<EVENT_TYPE>({
+    name: EVENT_FIELDS.TYPE,
+  });
 
   const { serverErrorItems, setServerErrorItems, showServerErrors } =
     useEventServerErrors();
@@ -437,15 +444,19 @@ const EventForm: React.FC<EventFormProps> = ({
                 label={t('event.form.notificationTitlePublication')}
                 type="info"
               >
-                <p>{t(`event.form.infoTextPublication.paragraph1.${type}`)}</p>
+                <p>
+                  {t(`event.form.infoTextPublication.paragraph1.${eventType}`)}
+                </p>
                 <p>
                   {t('event.form.infoTextPublication.paragraph2.sentence1')}{' '}
-                  <PublicationListLinks links={PUBLICATION_LIST_LINKS[type]} />{' '}
+                  <PublicationListLinks
+                    links={PUBLICATION_LIST_LINKS[eventType]}
+                  />{' '}
                   {t('event.form.infoTextPublication.paragraph2.sentence2')}
                 </p>
                 <p>
                   {t(
-                    `event.form.infoTextPublication.paragraph3.sentence1.${type}`
+                    `event.form.infoTextPublication.paragraph3.sentence1.${eventType}`
                   )}{' '}
                   {t('event.form.infoTextPublication.paragraph3.sentence2')}
                 </p>
@@ -487,7 +498,13 @@ const EventForm: React.FC<EventFormProps> = ({
                   savedEvent={event}
                 />
               </Section>
-              <Section title={t('event.form.sections.description')}>
+              <Section
+                showTooltip={showTooltipInstructions(user)}
+                title={t('event.form.sections.description')}
+                tooltipContent={
+                  <DescriptionInstructions eventType={eventType} />
+                }
+              >
                 <DescriptionSection
                   isEditingAllowed={isEditingAllowed}
                   isExternalUser={isExternalUser}
@@ -495,13 +512,25 @@ const EventForm: React.FC<EventFormProps> = ({
                   setSelectedLanguage={setDescriptionLanguage}
                 />
               </Section>
-              <Section title={t('event.form.sections.time')}>
+              <Section
+                showTooltip={showTooltipInstructions(user)}
+                title={t('event.form.sections.time')}
+                tooltipContent={<TimeInstructions eventType={eventType} />}
+                tooltipLabel={t(
+                  `event.form.notificationTitleEventTimes.${eventType}`
+                )}
+              >
                 <TimeSection
                   isEditingAllowed={isEditingAllowed}
                   savedEvent={event}
                 />
               </Section>
-              <Section title={t('event.form.sections.place')}>
+              <Section
+                showTooltip={showTooltipInstructions(user)}
+                title={t('event.form.sections.place')}
+                tooltipContent={<LocationInstructions eventType={eventType} />}
+                tooltipLabel={t('event.form.notificationTitleLocation')}
+              >
                 <PlaceSection
                   isEditingAllowed={isEditingAllowed}
                   isExternalUser={isExternalUser}
@@ -525,7 +554,12 @@ const EventForm: React.FC<EventFormProps> = ({
               <Section title={t('event.form.sections.classification')}>
                 <ClassificationSection isEditingAllowed={isEditingAllowed} />
               </Section>
-              <Section title={t('event.form.sections.audience')}>
+              <Section
+                showTooltip={showTooltipInstructions(user)}
+                title={t('event.form.sections.audience')}
+                tooltipContent={<AudienceInstructions eventType={eventType} />}
+                tooltipLabel={t(`event.form.titleAudience`)}
+              >
                 <AudienceSection isEditingAllowed={isEditingAllowed} />
               </Section>
               <Section title={t('event.form.sections.additionalInfo')}>
@@ -625,7 +659,7 @@ const EventFormWrapper: React.FC<EventFormWrapperProps> = (props) => {
       validateOnBlur={true}
       validateOnChange={true}
     >
-      {({ errors, setErrors, setTouched, values }) => {
+      {({ setErrors, setTouched, values }) => {
         return (
           <FormikPersist
             name={FORM_NAMES.EVENT_FORM}

--- a/src/domain/event/formSections/additionalInfoSection/AdditionalInfoSection.tsx
+++ b/src/domain/event/formSections/additionalInfoSection/AdditionalInfoSection.tsx
@@ -7,13 +7,22 @@ import DateInputField from '../../../../common/components/formFields/dateInputFi
 import NumberInputField from '../../../../common/components/formFields/numberInputField/NumberInputField';
 import TimeInputField from '../../../../common/components/formFields/timeInputField/TimeInputField';
 import FormGroup from '../../../../common/components/formGroup/FormGroup';
+import HeadingWithTooltip from '../../../../common/components/headingWithTooltip/HeadingWithTooltip';
 import Notification from '../../../../common/components/notification/Notification';
 import getDatePickerInitialMonth from '../../../../utils/getDatePickerInitialMonth';
 import FieldColumn from '../../../app/layout/fieldColumn/FieldColumn';
 import FieldRow from '../../../app/layout/fieldRow/FieldRow';
 import SplittedRow from '../../../app/layout/splittedRow/SplittedRow';
+import useUser from '../../../user/hooks/useUser';
 import { EVENT_FIELDS } from '../../constants';
 import styles from '../../eventPage.module.scss';
+import {
+  showNotificationInstructions,
+  showTooltipInstructions,
+} from '../../utils';
+import AttendeeCapacityInstructions from './attendeeCapacityInstructions/AttendeeCapacityInstructions';
+import AudienceAgeInstructions from './audienceAgeInstructions/AudienceAgeInstructions';
+import EnrolmentTimeInstructions from './enrolmentTimeInstructions/EnrolmentTimeInstructions';
 
 export interface AdditionalInfoSectionProps {
   isEditingAllowed: boolean;
@@ -25,6 +34,8 @@ const AdditionalInfoSection: React.FC<AdditionalInfoSectionProps> = ({
   isExternalUser,
 }) => {
   const { t } = useTranslation();
+  const { user } = useUser();
+
   const [{ value: type }] = useField({ name: EVENT_FIELDS.TYPE });
   const [{ value: enrolmentStartTime }] = useField({
     name: EVENT_FIELDS.ENROLMENT_START_TIME_DATE,
@@ -32,16 +43,24 @@ const AdditionalInfoSection: React.FC<AdditionalInfoSectionProps> = ({
 
   return (
     <Fieldset heading={t('event.form.sections.additionalInfo')} hideLegend>
-      <h3>{t(`event.form.titleAudienceAge`)}</h3>
+      <HeadingWithTooltip
+        heading={t('event.form.titleAudienceAge')}
+        showTooltip={showTooltipInstructions(user)}
+        tag="h3"
+        tooltipContent={<AudienceAgeInstructions eventType={type} />}
+        tooltipLabel={t('event.form.titleAudienceAge')}
+      />
       <FieldRow
         notification={
-          <Notification
-            className={styles.notificationForTitle}
-            label={t(`event.form.titleAudienceAge`)}
-            type="info"
-          >
-            <p>{t(`event.form.infoTextAudienceAge.${type}`)}</p>
-          </Notification>
+          showNotificationInstructions(user) ? (
+            <Notification
+              className={styles.notificationForTitle}
+              label={t('event.form.titleAudienceAge')}
+              type="info"
+            >
+              <AudienceAgeInstructions eventType={type} />
+            </Notification>
+          ) : undefined
         }
       >
         <FieldColumn>
@@ -70,18 +89,25 @@ const AdditionalInfoSection: React.FC<AdditionalInfoSectionProps> = ({
         </FieldColumn>
       </FieldRow>
 
-      <h3 className={styles.noTopMargin}>
-        {t(`event.form.titleEnrolmentTime`)}
-      </h3>
+      <HeadingWithTooltip
+        className={styles.noTopMargin}
+        heading={t('event.form.titleEnrolmentTime')}
+        showTooltip={showTooltipInstructions(user)}
+        tag="h3"
+        tooltipContent={<EnrolmentTimeInstructions eventType={type} />}
+        tooltipLabel={t('event.form.titleEnrolmentTime')}
+      />
       <FieldRow
         notification={
-          <Notification
-            className={styles.notificationForTitle}
-            label={t(`event.form.titleEnrolmentTime`)}
-            type="info"
-          >
-            <p>{t(`event.form.infoTextEnrolmentTime.${type}`)}</p>
-          </Notification>
+          showNotificationInstructions(user) ? (
+            <Notification
+              className={styles.notificationForTitle}
+              label={t(`event.form.titleEnrolmentTime`)}
+              type="info"
+            >
+              <EnrolmentTimeInstructions eventType={type} />
+            </Notification>
+          ) : undefined
         }
       >
         <FieldColumn>
@@ -131,21 +157,25 @@ const AdditionalInfoSection: React.FC<AdditionalInfoSectionProps> = ({
         </FieldColumn>
       </FieldRow>
 
-      <h3 className={styles.noTopMargin}>
-        {t(`event.form.titleAttendeeCapacity`)}
-      </h3>
+      <HeadingWithTooltip
+        className={styles.noTopMargin}
+        heading={t('event.form.titleAttendeeCapacity')}
+        showTooltip={showTooltipInstructions(user)}
+        tag="h3"
+        tooltipContent={<AttendeeCapacityInstructions eventType={type} />}
+        tooltipLabel={t('event.form.titleAttendeeCapacity')}
+      />
       <FieldRow
         notification={
-          <Notification
-            className={styles.notificationForTitle}
-            label={t(`event.form.titleAttendeeCapacity`)}
-            type="info"
-          >
-            <p>{t('event.form.infoTextAttendeeCapacity1')}</p>
-            <p>{t(`event.form.infoTextAttendeeCapacity2.${type}`)}</p>
-            <p>{t('event.form.infoTextAttendeeCapacity3')}</p>
-            <p>{t(`event.form.infoTextAttendeeCapacity4.${type}`)}</p>
-          </Notification>
+          showNotificationInstructions(user) ? (
+            <Notification
+              className={styles.notificationForTitle}
+              label={t('event.form.titleAttendeeCapacity')}
+              type="info"
+            >
+              <AttendeeCapacityInstructions eventType={type} />
+            </Notification>
+          ) : undefined
         }
       >
         <FieldColumn>

--- a/src/domain/event/formSections/additionalInfoSection/__tests__/AdditionalInfoSection.test.tsx
+++ b/src/domain/event/formSections/additionalInfoSection/__tests__/AdditionalInfoSection.test.tsx
@@ -1,6 +1,7 @@
 import { Formik } from 'formik';
 import { ObjectSchema } from 'yup';
 
+import { mockAuthenticatedLoginState } from '../../../../../utils/mockLoginHooks';
 import {
   configure,
   render,
@@ -9,6 +10,7 @@ import {
   within,
 } from '../../../../../utils/testUtils';
 import translations from '../../../../app/i18n/fi.json';
+import { mockedUserResponse } from '../../../../user/__mocks__/user';
 import { EVENT_FIELDS, EVENT_TYPE } from '../../../constants';
 import {
   externalUserEventSchema,
@@ -51,6 +53,16 @@ const defaultProps: AdditionalInfoSectionProps = {
   isExternalUser: false,
 };
 
+afterEach(() => {
+  vi.resetAllMocks();
+});
+
+beforeEach(() => {
+  mockAuthenticatedLoginState();
+});
+
+const mocks = [mockedUserResponse];
+
 const renderComponent = (
   initialValues?: Partial<InitialValues>,
   props?: Partial<AdditionalInfoSectionProps>,
@@ -65,7 +77,8 @@ const renderComponent = (
       validationSchema={schema}
     >
       <AdditionalInfoSection {...defaultProps} {...props} />
-    </Formik>
+    </Formik>,
+    { mocks }
   );
 
   return {

--- a/src/domain/event/formSections/additionalInfoSection/attendeeCapacityInstructions/AttendeeCapacityInstructions.tsx
+++ b/src/domain/event/formSections/additionalInfoSection/attendeeCapacityInstructions/AttendeeCapacityInstructions.tsx
@@ -1,0 +1,23 @@
+import { FC } from 'react';
+import { useTranslation } from 'react-i18next';
+
+export type AttendeeCapacityInstructionsProps = {
+  eventType: string;
+};
+
+const AttendeeCapacityInstructions: FC<AttendeeCapacityInstructionsProps> = ({
+  eventType,
+}) => {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <p>{t('event.form.infoTextAttendeeCapacity1')}</p>
+      <p>{t(`event.form.infoTextAttendeeCapacity2.${eventType}`)}</p>
+      <p>{t('event.form.infoTextAttendeeCapacity3')}</p>
+      <p>{t(`event.form.infoTextAttendeeCapacity4.${eventType}`)}</p>
+    </>
+  );
+};
+
+export default AttendeeCapacityInstructions;

--- a/src/domain/event/formSections/additionalInfoSection/audienceAgeInstructions/AudienceAgeInstructions.tsx
+++ b/src/domain/event/formSections/additionalInfoSection/audienceAgeInstructions/AudienceAgeInstructions.tsx
@@ -1,0 +1,16 @@
+import { FC } from 'react';
+import { useTranslation } from 'react-i18next';
+
+export type AudienceAgeInstructionsProps = {
+  eventType: string;
+};
+
+const AudienceAgeInstructions: FC<AudienceAgeInstructionsProps> = ({
+  eventType,
+}) => {
+  const { t } = useTranslation();
+
+  return <p>{t(`event.form.infoTextAudienceAge.${eventType}`)}</p>;
+};
+
+export default AudienceAgeInstructions;

--- a/src/domain/event/formSections/additionalInfoSection/enrolmentTimeInstructions/EnrolmentTimeInstructions.tsx
+++ b/src/domain/event/formSections/additionalInfoSection/enrolmentTimeInstructions/EnrolmentTimeInstructions.tsx
@@ -1,0 +1,16 @@
+import { FC } from 'react';
+import { useTranslation } from 'react-i18next';
+
+export type EnrolmentTimeInstructionsProps = {
+  eventType: string;
+};
+
+const EnrolmentTimeInstructions: FC<EnrolmentTimeInstructionsProps> = ({
+  eventType,
+}) => {
+  const { t } = useTranslation();
+
+  return <p>{t(`event.form.infoTextEnrolmentTime.${eventType}`)}</p>;
+};
+
+export default EnrolmentTimeInstructions;

--- a/src/domain/event/formSections/audienceSection/AudienceSection.tsx
+++ b/src/domain/event/formSections/audienceSection/AudienceSection.tsx
@@ -7,9 +7,12 @@ import CheckboxGroupField from '../../../../common/components/formFields/checkbo
 import Notification from '../../../../common/components/notification/Notification';
 import FieldColumn from '../../../app/layout/fieldColumn/FieldColumn';
 import FieldRow from '../../../app/layout/fieldRow/FieldRow';
+import useUser from '../../../user/hooks/useUser';
 import { EVENT_FIELDS } from '../../constants';
 import styles from '../../eventPage.module.scss';
 import useAudienceOptions from '../../hooks/useAudienceOptions';
+import { showNotificationInstructions } from '../../utils';
+import AudienceInstructions from './audienceInstructions/AudienceInstructions';
 
 interface Props {
   isEditingAllowed: boolean;
@@ -17,6 +20,7 @@ interface Props {
 
 const AudienceSection: React.FC<Props> = ({ isEditingAllowed }) => {
   const { t } = useTranslation();
+  const { user } = useUser();
 
   const audienceOptions = useAudienceOptions();
 
@@ -26,13 +30,15 @@ const AudienceSection: React.FC<Props> = ({ isEditingAllowed }) => {
     <Fieldset heading={t('event.form.sections.audience')} hideLegend>
       <FieldRow
         notification={
-          <Notification
-            className={styles.notificationForTitle}
-            label={t(`event.form.titleAudience`)}
-            type="info"
-          >
-            <p>{t(`event.form.infoTextAudience.${type}`)}</p>
-          </Notification>
+          showNotificationInstructions(user) ? (
+            <Notification
+              className={styles.notificationForTitle}
+              label={t(`event.form.titleAudience`)}
+              type="info"
+            >
+              <AudienceInstructions eventType={type} />
+            </Notification>
+          ) : undefined
         }
       >
         <FieldColumn>

--- a/src/domain/event/formSections/audienceSection/__tests__/AudienceSection.test.tsx
+++ b/src/domain/event/formSections/audienceSection/__tests__/AudienceSection.test.tsx
@@ -1,5 +1,6 @@
 import { Formik } from 'formik';
 
+import { mockAuthenticatedLoginState } from '../../../../../utils/mockLoginHooks';
 import {
   configure,
   render,
@@ -9,6 +10,7 @@ import {
 import translations from '../../../../app/i18n/fi.json';
 import { mockedTopicsKeywordSetResponse } from '../../../../keywordSet/__mocks__/keywordSets';
 import { mockedLanguagesResponse } from '../../../../language/__mocks__/language';
+import { mockedUserWithoutOrganizationsResponse } from '../../../../user/__mocks__/user';
 import { EVENT_FIELDS, EVENT_TYPE } from '../../../constants';
 import {
   audienceNames,
@@ -20,10 +22,19 @@ configure({ defaultHidden: true });
 
 const type = EVENT_TYPE.General;
 
+afterEach(() => {
+  vi.resetAllMocks();
+});
+
+beforeEach(() => {
+  mockAuthenticatedLoginState();
+});
+
 const mocks = [
   mockedAudiencesKeywordSetResponse,
   mockedLanguagesResponse,
   mockedTopicsKeywordSetResponse,
+  mockedUserWithoutOrganizationsResponse,
 ];
 
 const renderComponent = () =>

--- a/src/domain/event/formSections/audienceSection/audienceInstructions/AudienceInstructions.tsx
+++ b/src/domain/event/formSections/audienceSection/audienceInstructions/AudienceInstructions.tsx
@@ -1,0 +1,14 @@
+import { FC } from 'react';
+import { useTranslation } from 'react-i18next';
+
+export type AudienceInstructionsProps = {
+  eventType: string;
+};
+
+const AudienceInstructions: FC<AudienceInstructionsProps> = ({ eventType }) => {
+  const { t } = useTranslation();
+
+  return <p>{t(`event.form.infoTextAudience.${eventType}`)}</p>;
+};
+
+export default AudienceInstructions;

--- a/src/domain/event/formSections/channelsSection/ChannelsSection.tsx
+++ b/src/domain/event/formSections/channelsSection/ChannelsSection.tsx
@@ -5,12 +5,19 @@ import { useTranslation } from 'react-i18next';
 import Fieldset from '../../../../common/components/fieldset/Fieldset';
 import MultiLanguageField from '../../../../common/components/formFields/multiLanguageField/MultiLanguageField';
 import FormGroup from '../../../../common/components/formGroup/FormGroup';
+import HeadingWithTooltip from '../../../../common/components/headingWithTooltip/HeadingWithTooltip';
 import Notification from '../../../../common/components/notification/Notification';
 import FieldColumn from '../../../app/layout/fieldColumn/FieldColumn';
 import FieldRow from '../../../app/layout/fieldRow/FieldRow';
+import useUser from '../../../user/hooks/useUser';
 import { EVENT_FIELDS } from '../../constants';
 import styles from '../../eventPage.module.scss';
+import {
+  showNotificationInstructions,
+  showTooltipInstructions,
+} from '../../utils';
 import ExternalLinks from './externalLinks/ExternalLinks';
+import SocialMediaInstructions from './socialMediaInstructions/SocialMediaInstructions';
 
 interface Props {
   isEditingAllowed: boolean;
@@ -18,6 +25,8 @@ interface Props {
 
 const ChannelsSection: React.FC<Props> = ({ isEditingAllowed }) => {
   const { t } = useTranslation();
+  const { user } = useUser();
+
   const [{ value: type }] = useField(EVENT_FIELDS.TYPE);
   const [{ value: eventInfoLanguages }] = useField({
     name: EVENT_FIELDS.EVENT_INFO_LANGUAGES,
@@ -39,16 +48,25 @@ const ChannelsSection: React.FC<Props> = ({ isEditingAllowed }) => {
           </FormGroup>
         </FieldColumn>
       </FieldRow>
-      <h3>{t(`event.form.titleSocialMedia.${type}`)}</h3>
+
+      <HeadingWithTooltip
+        heading={t(`event.form.titleSocialMedia.${type}`)}
+        showTooltip={showTooltipInstructions(user)}
+        tag="h3"
+        tooltipContent={<SocialMediaInstructions eventType={type} />}
+        tooltipLabel={t(`event.form.titleSocialMedia.${type}`)}
+      />
       <FieldRow
         notification={
-          <Notification
-            className={styles.notificationForTitle}
-            label={t(`event.form.titleSocialMedia.${type}`)}
-            type="info"
-          >
-            <p>{t(`event.form.infoTextSocialMedia.${type}`)}</p>
-          </Notification>
+          showNotificationInstructions(user) ? (
+            <Notification
+              className={styles.notificationForTitle}
+              label={t(`event.form.titleSocialMedia.${type}`)}
+              type="info"
+            >
+              <SocialMediaInstructions eventType={type} />
+            </Notification>
+          ) : undefined
         }
       >
         <ExternalLinks isEditingAllowed={isEditingAllowed} />

--- a/src/domain/event/formSections/channelsSection/__tests__/ChannelsSection.test.tsx
+++ b/src/domain/event/formSections/channelsSection/__tests__/ChannelsSection.test.tsx
@@ -5,6 +5,7 @@ import {
   EMPTY_MULTI_LANGUAGE_OBJECT,
   LE_DATA_LANGUAGES,
 } from '../../../../../constants';
+import { mockAuthenticatedLoginState } from '../../../../../utils/mockLoginHooks';
 import {
   configure,
   render,
@@ -13,6 +14,7 @@ import {
   waitFor,
 } from '../../../../../utils/testUtils';
 import translations from '../../../../app/i18n/fi.json';
+import { mockedUserResponse } from '../../../../user/__mocks__/user';
 import { EVENT_FIELDS, EVENT_TYPE } from '../../../constants';
 import { publicEventSchema } from '../../../validation';
 import ChannelsSection from '../ChannelsSection';
@@ -20,6 +22,16 @@ import ChannelsSection from '../ChannelsSection';
 configure({ defaultHidden: true });
 
 const type = EVENT_TYPE.General;
+
+afterEach(() => {
+  vi.resetAllMocks();
+});
+
+beforeEach(() => {
+  mockAuthenticatedLoginState();
+});
+
+const mocks = [mockedUserResponse];
 
 const renderComponent = () =>
   render(
@@ -37,7 +49,8 @@ const renderComponent = () =>
       validationSchema={publicEventSchema}
     >
       <ChannelsSection isEditingAllowed={true} />
-    </Formik>
+    </Formik>,
+    { mocks }
   );
 
 const findElements = (key: 'deleteButtons' | 'facebookLinks') => {

--- a/src/domain/event/formSections/channelsSection/socialMediaInstructions/SocialMediaInstructions.tsx
+++ b/src/domain/event/formSections/channelsSection/socialMediaInstructions/SocialMediaInstructions.tsx
@@ -1,0 +1,16 @@
+import { FC } from 'react';
+import { useTranslation } from 'react-i18next';
+
+export type SocialMediaInstructionsProps = {
+  eventType: string;
+};
+
+const SocialMediaInstructions: FC<SocialMediaInstructionsProps> = ({
+  eventType,
+}) => {
+  const { t } = useTranslation();
+
+  return <p>{t(`event.form.infoTextSocialMedia.${eventType}`)}</p>;
+};
+
+export default SocialMediaInstructions;

--- a/src/domain/event/formSections/classificationSection/ClassificationSection.tsx
+++ b/src/domain/event/formSections/classificationSection/ClassificationSection.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next';
 import Fieldset from '../../../../common/components/fieldset/Fieldset';
 import CheckboxGroupField from '../../../../common/components/formFields/checkboxGroupField/CheckboxGroupField';
 import KeywordSelectorField from '../../../../common/components/formFields/keywordSelectorField/KeywordSelectorField';
+import HeadingWithTooltip from '../../../../common/components/headingWithTooltip/HeadingWithTooltip';
 import Notification from '../../../../common/components/notification/Notification';
 import useLocale from '../../../../hooks/useLocale';
 import getValue from '../../../../utils/getValue';
@@ -15,9 +16,16 @@ import FieldRow from '../../../app/layout/fieldRow/FieldRow';
 import { REMOTE_PARTICIPATION_KEYWORD } from '../../../keyword/constants';
 import { getKeywordOption } from '../../../keywordSet/utils';
 import { INTERNET_PLACE_ID } from '../../../place/constants';
+import useUser from '../../../user/hooks/useUser';
 import { EVENT_FIELDS } from '../../constants';
 import styles from '../../eventPage.module.scss';
 import useEventFieldOptionsData from '../../hooks/useEventFieldOptionsData';
+import {
+  showNotificationInstructions,
+  showTooltipInstructions,
+} from '../../utils';
+import KeywordsInstructions from './keywordsInstructions/KeywordsInstructions';
+import MainCategoriesInstructions from './mainCategoriesInstructions/MainCategoriesInstructions';
 
 interface Props {
   isEditingAllowed: boolean;
@@ -26,6 +34,7 @@ interface Props {
 const ClassificationSection: React.FC<Props> = ({ isEditingAllowed }) => {
   const { t } = useTranslation();
   const locale = useLocale();
+  const { user } = useUser();
 
   const [{ value: type }] = useField({ name: EVENT_FIELDS.TYPE });
   const [{ value: eventLocation }] = useField({ name: EVENT_FIELDS.LOCATION });
@@ -69,16 +78,24 @@ const ClassificationSection: React.FC<Props> = ({ isEditingAllowed }) => {
 
   return (
     <Fieldset heading={t('event.form.sections.classification')} hideLegend>
-      <h3>{t(`event.form.titleMainCategories`)}</h3>
+      <HeadingWithTooltip
+        heading={t(`event.form.titleMainCategories`)}
+        showTooltip={showTooltipInstructions(user)}
+        tag="h3"
+        tooltipContent={<MainCategoriesInstructions eventType={type} />}
+        tooltipLabel={t(`event.form.notificationTitleMainCategories.${type}`)}
+      />
       <FieldRow
         notification={
-          <Notification
-            className={styles.notificationForTitle}
-            label={t(`event.form.notificationTitleMainCategories.${type}`)}
-            type="info"
-          >
-            <p>{t(`event.form.infoTextMainCategories.${type}`)}</p>
-          </Notification>
+          showNotificationInstructions(user) ? (
+            <Notification
+              className={styles.notificationForTitle}
+              label={t(`event.form.notificationTitleMainCategories.${type}`)}
+              type="info"
+            >
+              <MainCategoriesInstructions eventType={type} />
+            </Notification>
+          ) : undefined
         }
       >
         <FieldColumn>
@@ -95,16 +112,24 @@ const ClassificationSection: React.FC<Props> = ({ isEditingAllowed }) => {
         </FieldColumn>
       </FieldRow>
 
-      <h3>{t(`event.form.titleKeywords`)}</h3>
+      <HeadingWithTooltip
+        heading={t('event.form.titleKeywords')}
+        showTooltip={showTooltipInstructions(user)}
+        tag="h3"
+        tooltipContent={<KeywordsInstructions eventType={type} />}
+        tooltipLabel={t('event.form.titleKeywords')}
+      />
       <FieldRow
         notification={
-          <Notification
-            className={styles.notificationForTitle}
-            label={t(`event.form.titleKeywords`)}
-            type="info"
-          >
-            <p>{t(`event.form.infoTextKeywords.${type}`)}</p>
-          </Notification>
+          showNotificationInstructions(user) ? (
+            <Notification
+              className={styles.notificationForTitle}
+              label={t(`event.form.titleKeywords`)}
+              type="info"
+            >
+              <KeywordsInstructions eventType={type} />
+            </Notification>
+          ) : undefined
         }
       >
         <FieldColumn>

--- a/src/domain/event/formSections/classificationSection/__tests__/ClassificationSection.test.tsx
+++ b/src/domain/event/formSections/classificationSection/__tests__/ClassificationSection.test.tsx
@@ -1,6 +1,7 @@
 import { Formik } from 'formik';
 
 import getValue from '../../../../../utils/getValue';
+import { mockAuthenticatedLoginState } from '../../../../../utils/mockLoginHooks';
 import {
   configure,
   render,
@@ -12,6 +13,7 @@ import {
 import { mockedAudienceKeywordSetResponse } from '../../../../keywordSet/__mocks__/keywordSets';
 import { mockedLanguagesResponse } from '../../../../language/__mocks__/language';
 import { INTERNET_PLACE_ID } from '../../../../place/constants';
+import { mockedUserResponse } from '../../../../user/__mocks__/user';
 import { EVENT_FIELDS, EVENT_TYPE } from '../../../constants';
 import { publicEventSchema } from '../../../validation';
 import {
@@ -28,6 +30,14 @@ import ClassificationSection from '../ClassificationSection';
 
 configure({ defaultHidden: true });
 
+afterEach(() => {
+  vi.resetAllMocks();
+});
+
+beforeEach(() => {
+  mockAuthenticatedLoginState();
+});
+
 const type = EVENT_TYPE.General;
 
 const mocks = [
@@ -37,6 +47,7 @@ const mocks = [
   mockedKeywordResponse,
   mockedKeywordsResponse,
   mockedLanguagesResponse,
+  mockedUserResponse,
 ];
 
 type InitialValues = {

--- a/src/domain/event/formSections/classificationSection/keywordsInstructions/KeywordsInstructions.tsx
+++ b/src/domain/event/formSections/classificationSection/keywordsInstructions/KeywordsInstructions.tsx
@@ -1,0 +1,14 @@
+import { FC } from 'react';
+import { useTranslation } from 'react-i18next';
+
+export type KeywordsInstructionsProps = {
+  eventType: string;
+};
+
+const KeywordsInstructions: FC<KeywordsInstructionsProps> = ({ eventType }) => {
+  const { t } = useTranslation();
+
+  return <p>{t(`event.form.infoTextKeywords.${eventType}`)}</p>;
+};
+
+export default KeywordsInstructions;

--- a/src/domain/event/formSections/classificationSection/mainCategoriesInstructions/MainCategoriesInstructions.tsx
+++ b/src/domain/event/formSections/classificationSection/mainCategoriesInstructions/MainCategoriesInstructions.tsx
@@ -1,0 +1,16 @@
+import { FC } from 'react';
+import { useTranslation } from 'react-i18next';
+
+export type MainCategoriesInstructionsProps = {
+  eventType: string;
+};
+
+const MainCategoriesInstructions: FC<MainCategoriesInstructionsProps> = ({
+  eventType,
+}) => {
+  const { t } = useTranslation();
+
+  return <p>{t(`event.form.infoTextMainCategories.${eventType}`)}</p>;
+};
+
+export default MainCategoriesInstructions;

--- a/src/domain/event/formSections/descriptionSection/DescriptionSection.tsx
+++ b/src/domain/event/formSections/descriptionSection/DescriptionSection.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 import { Field, useField, useFormikContext } from 'formik';
 import React, { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -16,14 +17,17 @@ import lowerCaseFirstLetter from '../../../../utils/lowerCaseFirstLetter';
 import skipFalsyType from '../../../../utils/skipFalsyType';
 import FieldColumn from '../../../app/layout/fieldColumn/FieldColumn';
 import FieldRow from '../../../app/layout/fieldRow/FieldRow';
-import {
-  EVENT_FIELDS,
-  EVENT_TEXT_FIELD_MAX_LENGTH,
-  EVENT_TYPE,
-} from '../../constants';
+import useUser from '../../../user/hooks/useUser';
+import { EVENT_FIELDS, EVENT_TEXT_FIELD_MAX_LENGTH } from '../../constants';
 import useLanguageTabOptions from '../../hooks/useLanguageTabOptions';
 import useSortedInfoLanguages from '../../hooks/useSortedInfoLanguages';
-import { formatSingleDescription } from '../../utils';
+import {
+  formatSingleDescription,
+  showNotificationInstructions,
+  showTooltipInstructions,
+} from '../../utils';
+import DescriptionInstructions from './descriptionInstructions/DescriptionInstructions';
+import EnvironmentalCertificateInstructions from './environmentalCertificateInstruction/EnvironmentalCertificateInstructions';
 
 const FIELDS = [
   EVENT_FIELDS.DESCRIPTION,
@@ -45,6 +49,8 @@ const DescriptionSection: React.FC<DescriptionSectionProps> = ({
   setSelectedLanguage,
 }) => {
   const { t } = useTranslation();
+  const { user } = useUser();
+
   const [{ value: eventInfoLanguages }] = useField<LE_DATA_LANGUAGES[]>({
     name: EVENT_FIELDS.EVENT_INFO_LANGUAGES,
   });
@@ -112,57 +118,16 @@ const DescriptionSection: React.FC<DescriptionSectionProps> = ({
             <TabPanel key={value}>
               <FieldRow
                 notification={
-                  <Notification
-                    label={t(`event.form.notificationTitleDescription.${type}`)}
-                    type="info"
-                  >
-                    <p
-                      dangerouslySetInnerHTML={{
-                        __html: t(
-                          `event.form.infoTextDescription.${type}.paragraph1`
-                        ),
-                      }}
-                    />
-                    <p>
-                      {t(`event.form.infoTextDescription.${type}.paragraph2`)}
-                    </p>
-                    <p
-                      dangerouslySetInnerHTML={{
-                        __html: t(
-                          `event.form.infoTextDescription.${type}.paragraph3`,
-                          {
-                            openInNewTab: t('common.openInNewTab'),
-                          }
-                        ),
-                      }}
-                    />
-                    {type === EVENT_TYPE.General && (
-                      <>
-                        <p>
-                          {t(
-                            `event.form.infoTextDescription.${type}.paragraph4`
-                          )}
-                        </p>
-                        <p>
-                          {t(
-                            `event.form.infoTextDescription.${type}.paragraph5`
-                          )}
-                        </p>
-                        <ul style={{ paddingInlineStart: 'var(--spacing-s)' }}>
-                          {Object.values(
-                            t(
-                              `event.form.infoTextDescription.${type}.exclusions`,
-                              {
-                                returnObjects: true,
-                              }
-                            )
-                          ).map((exlusion, index) => (
-                            <li key={index}>{exlusion as string}</li>
-                          ))}
-                        </ul>
-                      </>
-                    )}
-                  </Notification>
+                  showNotificationInstructions(user) ? (
+                    <Notification
+                      label={t(
+                        `event.form.notificationTitleDescription.${type}`
+                      )}
+                      type="info"
+                    >
+                      <DescriptionInstructions eventType={type} />
+                    </Notification>
+                  ) : undefined
                 }
               >
                 <FieldColumn>
@@ -221,20 +186,16 @@ const DescriptionSection: React.FC<DescriptionSectionProps> = ({
               {isExternalUser && (
                 <FieldRow
                   notification={
-                    <Notification
-                      label={t(
-                        'event.form.notificationTitleEnvironmentalCertificate'
-                      )}
-                      type="info"
-                    >
-                      <p
-                        dangerouslySetInnerHTML={{
-                          __html: t(
-                            'event.form.infoTextEnvironmentalCertificate'
-                          ),
-                        }}
-                      />
-                    </Notification>
+                    showNotificationInstructions(user) ? (
+                      <Notification
+                        label={t(
+                          'event.form.notificationTitleEnvironmentalCertificate'
+                        )}
+                        type="info"
+                      >
+                        <EnvironmentalCertificateInstructions />
+                      </Notification>
+                    ) : undefined
                   }
                 >
                   <FormGroup>
@@ -256,6 +217,17 @@ const DescriptionSection: React.FC<DescriptionSectionProps> = ({
                         label={t('event.form.labelEnvironmentalCertificate')}
                         name={EVENT_FIELDS.ENVIRONMENTAL_CERTIFICATE}
                         required
+                        {...(showTooltipInstructions(user)
+                          ? {
+                              tooltipButtonLabel: t('common.showInstructions'),
+                              tooltipLabel: t(
+                                'event.form.labelEnvironmentalCertificate'
+                              ),
+                              tooltipText: (
+                                <EnvironmentalCertificateInstructions />
+                              ),
+                            }
+                          : {})}
                       ></Field>
                     </FieldColumn>
                   </FormGroup>

--- a/src/domain/event/formSections/descriptionSection/__tests__/DescriptionSection.test.tsx
+++ b/src/domain/event/formSections/descriptionSection/__tests__/DescriptionSection.test.tsx
@@ -7,6 +7,7 @@ import {
   LE_DATA_LANGUAGES,
 } from '../../../../../constants';
 import { MultiLanguageObject } from '../../../../../types';
+import { mockAuthenticatedLoginState } from '../../../../../utils/mockLoginHooks';
 import {
   configure,
   mockString,
@@ -14,6 +15,7 @@ import {
   screen,
   userEvent,
 } from '../../../../../utils/testUtils';
+import { mockedUserResponse } from '../../../../user/__mocks__/user';
 import { EVENT_FIELDS, EVENT_TYPE } from '../../../constants';
 import {
   externalUserEventSchema,
@@ -56,6 +58,16 @@ const defaultProps: DescriptionSectionProps = {
   setSelectedLanguage: vi.fn(),
 };
 
+afterEach(() => {
+  vi.resetAllMocks();
+});
+
+beforeEach(() => {
+  mockAuthenticatedLoginState();
+});
+
+const mocks = [mockedUserResponse];
+
 const renderComponent = (
   initialValues?: Partial<InitialValues>,
   props?: Partial<DescriptionSectionProps>,
@@ -69,7 +81,8 @@ const renderComponent = (
       validationSchema={schema}
     >
       <DescriptionSection {...defaultProps} {...props} />
-    </Formik>
+    </Formik>,
+    { mocks }
   );
 
   return {

--- a/src/domain/event/formSections/descriptionSection/descriptionInstructions/DescriptionInstructions.tsx
+++ b/src/domain/event/formSections/descriptionSection/descriptionInstructions/DescriptionInstructions.tsx
@@ -1,0 +1,49 @@
+import { FC } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { EVENT_TYPE } from '../../../constants';
+
+export type DescriptionInstructionsProps = {
+  eventType: string;
+};
+
+const DescriptionInstructions: FC<DescriptionInstructionsProps> = ({
+  eventType,
+}) => {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <p
+        dangerouslySetInnerHTML={{
+          __html: t(`event.form.infoTextDescription.${eventType}.paragraph1`),
+        }}
+      />
+      <p>{t(`event.form.infoTextDescription.${eventType}.paragraph2`)}</p>
+      <p
+        dangerouslySetInnerHTML={{
+          __html: t(`event.form.infoTextDescription.${eventType}.paragraph3`, {
+            openInNewTab: t('common.openInNewTab'),
+          }),
+        }}
+      />
+      {eventType === EVENT_TYPE.General && (
+        <>
+          <p>{t(`event.form.infoTextDescription.${eventType}.paragraph4`)}</p>
+          <p>{t(`event.form.infoTextDescription.${eventType}.paragraph5`)}</p>
+          <ul style={{ paddingInlineStart: 'var(--spacing-s)' }}>
+            {Object.values(
+              t(`event.form.infoTextDescription.${eventType}.exclusions`, {
+                returnObjects: true,
+              })
+            ).map((exlusion) => (
+              <li key={exlusion}>{exlusion}</li>
+            ))}
+          </ul>
+        </>
+      )}
+    </>
+  );
+};
+
+export default DescriptionInstructions;

--- a/src/domain/event/formSections/descriptionSection/environmentalCertificateInstruction/EnvironmentalCertificateInstructions.tsx
+++ b/src/domain/event/formSections/descriptionSection/environmentalCertificateInstruction/EnvironmentalCertificateInstructions.tsx
@@ -1,0 +1,16 @@
+import { FC } from 'react';
+import { useTranslation } from 'react-i18next';
+
+const EnvironmentalCertificateInstructions: FC = () => {
+  const { t } = useTranslation();
+
+  return (
+    <p
+      dangerouslySetInnerHTML={{
+        __html: t('event.form.infoTextEnvironmentalCertificate'),
+      }}
+    />
+  );
+};
+
+export default EnvironmentalCertificateInstructions;

--- a/src/domain/event/formSections/imageSection/ImageSection.tsx
+++ b/src/domain/event/formSections/imageSection/ImageSection.tsx
@@ -11,6 +11,7 @@ import { useTranslation } from 'react-i18next';
 import Button from '../../../../common/components/button/Button';
 import Fieldset from '../../../../common/components/fieldset/Fieldset';
 import FormGroup from '../../../../common/components/formGroup/FormGroup';
+import HeadingWithTooltip from '../../../../common/components/headingWithTooltip/HeadingWithTooltip';
 import ImagePreview from '../../../../common/components/imagePreview/ImagePreview';
 import { PAGE_SIZE } from '../../../../common/components/imageSelector/constants';
 import Modal from '../../../../common/components/modal/Modal';
@@ -35,7 +36,12 @@ import { imagePathBuilder } from '../../../image/utils';
 import useUser from '../../../user/hooks/useUser';
 import { EVENT_FIELDS } from '../../constants';
 import eventPageStyles from '../../eventPage.module.scss';
+import {
+  showNotificationInstructions,
+  showTooltipInstructions,
+} from '../../utils';
 import ImageDetailsFields from './imageDetailsFields/ImageDetailsFields';
+import ImageInstructions from './imageInstructions/ImageInstructions';
 import styles from './imageSection.module.scss';
 
 interface Props {
@@ -45,7 +51,7 @@ interface Props {
 const ImageSection: React.FC<Props> = ({ isEditingAllowed }) => {
   const { t } = useTranslation();
   const apolloClient = useApolloClient() as ApolloClient<NormalizedCacheObject>;
-  const { loading: loadingUser, externalUser } = useUser();
+  const { loading: loadingUser, externalUser, user } = useUser();
 
   const { closeModal, openModal, setOpenModal, uploadImage } =
     useImageUpdateActions({});
@@ -138,25 +144,25 @@ const ImageSection: React.FC<Props> = ({ isEditingAllowed }) => {
       )}
 
       <Fieldset heading={t('event.form.sections.image')} hideLegend>
-        <h3>{t(`event.form.titleImage.${type}`)}</h3>
+        <HeadingWithTooltip
+          heading={t(`event.form.titleImage.${type}`)}
+          showTooltip={showTooltipInstructions(user)}
+          tag="h3"
+          tooltipContent={<ImageInstructions eventType={type} />}
+          tooltipLabel={t(`event.form.notificationTitleImage.${type}`)}
+        />
+
         <FieldRow
           notification={
-            <Notification
-              className={eventPageStyles.notificationForTitle}
-              label={t(`event.form.notificationTitleImage.${type}`)}
-              type="info"
-            >
-              <p
-                dangerouslySetInnerHTML={{
-                  __html: t(`event.form.infoTextImage1.${type}`, {
-                    openInNewTab: t('common.openInNewTab'),
-                  }),
-                }}
-              />
-              <p>{t(`event.form.infoTextImage2`)}</p>
-              <p>{t(`event.form.infoTextImage3`)}</p>
-              <p>{t(`event.form.infoTextImage4`)}</p>
-            </Notification>
+            showNotificationInstructions(user) ? (
+              <Notification
+                className={eventPageStyles.notificationForTitle}
+                label={t(`event.form.notificationTitleImage.${type}`)}
+                type="info"
+              >
+                <ImageInstructions eventType={type} />
+              </Notification>
+            ) : undefined
           }
         >
           <FieldColumn

--- a/src/domain/event/formSections/imageSection/imageInstructions/ImageInstructions.tsx
+++ b/src/domain/event/formSections/imageSection/imageInstructions/ImageInstructions.tsx
@@ -1,0 +1,27 @@
+import { FC } from 'react';
+import { useTranslation } from 'react-i18next';
+
+export type ImageInstructionsProps = {
+  eventType: string;
+};
+
+const ImageInstructions: FC<ImageInstructionsProps> = ({ eventType }) => {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <p
+        dangerouslySetInnerHTML={{
+          __html: t(`event.form.infoTextImage1.${eventType}`, {
+            openInNewTab: t('common.openInNewTab'),
+          }),
+        }}
+      />
+      <p>{t(`event.form.infoTextImage2`)}</p>
+      <p>{t(`event.form.infoTextImage3`)}</p>
+      <p>{t(`event.form.infoTextImage4`)}</p>
+    </>
+  );
+};
+
+export default ImageInstructions;

--- a/src/domain/event/formSections/languagesSection/LanguagesSection.tsx
+++ b/src/domain/event/formSections/languagesSection/LanguagesSection.tsx
@@ -4,14 +4,22 @@ import { useTranslation } from 'react-i18next';
 
 import Fieldset from '../../../../common/components/fieldset/Fieldset';
 import CheckboxGroupField from '../../../../common/components/formFields/checkboxGroupField/CheckboxGroupField';
+import HeadingWithTooltip from '../../../../common/components/headingWithTooltip/HeadingWithTooltip';
 import Notification from '../../../../common/components/notification/Notification';
 import { ORDERED_LE_DATA_LANGUAGES } from '../../../../constants';
 import { OptionType } from '../../../../types';
 import FieldColumn from '../../../app/layout/fieldColumn/FieldColumn';
 import FieldRow from '../../../app/layout/fieldRow/FieldRow';
 import useLanguageOptions from '../../../language/hooks/useLanguageOptions';
+import useUser from '../../../user/hooks/useUser';
 import { EVENT_FIELDS } from '../../constants';
 import styles from '../../eventPage.module.scss';
+import {
+  showNotificationInstructions,
+  showTooltipInstructions,
+} from '../../utils';
+import InfoLanguagesInstructions from './infoLanguagesInstructions/InfoLanguagesInstructions';
+import InLanguagesInstructions from './inLanguagesInstructions/InLanguageInstructions';
 
 interface Props {
   isEditingAllowed: boolean;
@@ -19,7 +27,9 @@ interface Props {
 
 const LanguagesSection: React.FC<Props> = ({ isEditingAllowed }) => {
   const { t } = useTranslation();
-  const [{ value: eventType }] = useField({ name: EVENT_FIELDS.TYPE });
+  const { user } = useUser();
+
+  const [{ value: eventType }] = useField<string>({ name: EVENT_FIELDS.TYPE });
   const inLanguageOptions = useLanguageOptions({ idKey: 'atId' });
   const eventInfoLanguageOptions: OptionType[] = ORDERED_LE_DATA_LANGUAGES.map(
     (type) => ({
@@ -30,20 +40,24 @@ const LanguagesSection: React.FC<Props> = ({ isEditingAllowed }) => {
 
   return (
     <Fieldset heading={t('event.form.sections.languages')} hideLegend>
-      <h3>{t(`event.form.titleInfoLanguages.${eventType}`)}</h3>
+      <HeadingWithTooltip
+        heading={t(`event.form.titleInfoLanguages.${eventType}`)}
+        showTooltip={showTooltipInstructions(user)}
+        tag="h3"
+        tooltipContent={<InfoLanguagesInstructions eventType={eventType} />}
+        tooltipLabel={t(`event.form.titleInfoLanguages.${eventType}`)}
+      />
       <FieldRow
         notification={
-          <Notification
-            className={styles.notificationForTitle}
-            label={t(`event.form.titleInfoLanguages.${eventType}`)}
-            type="info"
-          >
-            <p
-              dangerouslySetInnerHTML={{
-                __html: t(`event.form.infoTextInfoLanguages.${eventType}`),
-              }}
-            />
-          </Notification>
+          showNotificationInstructions(user) ? (
+            <Notification
+              className={styles.notificationForTitle}
+              label={t(`event.form.titleInfoLanguages.${eventType}`)}
+              type="info"
+            >
+              <InfoLanguagesInstructions eventType={eventType} />
+            </Notification>
+          ) : undefined
         }
       >
         <FieldColumn>
@@ -60,16 +74,24 @@ const LanguagesSection: React.FC<Props> = ({ isEditingAllowed }) => {
         </FieldColumn>
       </FieldRow>
 
-      <h3>{t(`event.form.titleInLanguages.${eventType}`)}</h3>
+      <HeadingWithTooltip
+        heading={t(`event.form.titleInLanguages.${eventType}`)}
+        showTooltip={showTooltipInstructions(user)}
+        tag="h3"
+        tooltipContent={<InLanguagesInstructions eventType={eventType} />}
+        tooltipLabel={t(`event.form.titleInLanguages.${eventType}`)}
+      />
       <FieldRow
         notification={
-          <Notification
-            className={styles.notificationForTitle}
-            label={t(`event.form.titleInLanguages.${eventType}`)}
-            type="info"
-          >
-            <p>{t(`event.form.infoTextInLanguages.${eventType}`)}</p>
-          </Notification>
+          showNotificationInstructions(user) ? (
+            <Notification
+              className={styles.notificationForTitle}
+              label={t(`event.form.titleInLanguages.${eventType}`)}
+              type="info"
+            >
+              <InLanguagesInstructions eventType={eventType} />
+            </Notification>
+          ) : undefined
         }
       >
         <FieldColumn>

--- a/src/domain/event/formSections/languagesSection/inLanguagesInstructions/InLanguageInstructions.tsx
+++ b/src/domain/event/formSections/languagesSection/inLanguagesInstructions/InLanguageInstructions.tsx
@@ -1,0 +1,16 @@
+import { FC } from 'react';
+import { useTranslation } from 'react-i18next';
+
+export type InLanguagesInstructionsProps = {
+  eventType: string;
+};
+
+const InLanguagesInstructions: FC<InLanguagesInstructionsProps> = ({
+  eventType,
+}) => {
+  const { t } = useTranslation();
+
+  return <p>{t(`event.form.infoTextInLanguages.${eventType}`)}</p>;
+};
+
+export default InLanguagesInstructions;

--- a/src/domain/event/formSections/languagesSection/infoLanguagesInstructions/InfoLanguagesInstructions.tsx
+++ b/src/domain/event/formSections/languagesSection/infoLanguagesInstructions/InfoLanguagesInstructions.tsx
@@ -1,0 +1,22 @@
+import { FC } from 'react';
+import { useTranslation } from 'react-i18next';
+
+export type InfoLanguagesInstructionsProps = {
+  eventType: string;
+};
+
+const InfoLanguagesInstructions: FC<InfoLanguagesInstructionsProps> = ({
+  eventType,
+}) => {
+  const { t } = useTranslation();
+
+  return (
+    <p
+      dangerouslySetInnerHTML={{
+        __html: t(`event.form.infoTextInfoLanguages.${eventType}`),
+      }}
+    />
+  );
+};
+
+export default InfoLanguagesInstructions;

--- a/src/domain/event/formSections/placeSection/PlaceSection.tsx
+++ b/src/domain/event/formSections/placeSection/PlaceSection.tsx
@@ -12,8 +12,11 @@ import Notification from '../../../../common/components/notification/Notificatio
 import parseIdFromAtId from '../../../../utils/parseIdFromAtId';
 import FieldColumn from '../../../app/layout/fieldColumn/FieldColumn';
 import FieldRow from '../../../app/layout/fieldRow/FieldRow';
+import useUser from '../../../user/hooks/useUser';
 import { EVENT_ENVIRONMENT_VALUE, EVENT_FIELDS } from '../../constants';
 import stylesEventPage from '../../eventPage.module.scss';
+import { showNotificationInstructions } from '../../utils';
+import LocationInstructions from './locationInstructions/LocationInstructions';
 import styles from './placeSection.module.scss';
 
 interface Props {
@@ -26,6 +29,7 @@ const PlaceSection: React.FC<Props> = ({
   isExternalUser,
 }) => {
   const { t } = useTranslation();
+  const { user } = useUser();
 
   const [{ value: type }] = useField({ name: EVENT_FIELDS.TYPE });
   const [{ value: location }] = useField({ name: EVENT_FIELDS.LOCATION });
@@ -45,24 +49,15 @@ const PlaceSection: React.FC<Props> = ({
       <h3>{t(`event.form.titleLocation`)}</h3>
       <FieldRow
         notification={
-          <Notification
-            className={stylesEventPage.notificationForTitle}
-            label={t(`event.form.notificationTitleLocation`)}
-            type="info"
-          >
-            <p>{t(`event.form.infoTextLocation1`)}</p>
-            <p>{t(`event.form.infoTextLocation2.${type}`)}</p>
-            <p>{t(`event.form.infoTextLocation3`)}</p>
-            <p>{t(`event.form.infoTextLocation4`)}</p>
-            <p
-              dangerouslySetInnerHTML={{
-                __html: t(`event.form.infoTextLocation5`, {
-                  openInNewTab: t('common.openInNewTab'),
-                }),
-              }}
-            />
-            <p>{t(`event.form.infoTextLocation6`)}</p>
-          </Notification>
+          showNotificationInstructions(user) ? (
+            <Notification
+              className={stylesEventPage.notificationForTitle}
+              label={t(`event.form.notificationTitleLocation`)}
+              type="info"
+            >
+              <LocationInstructions eventType={type} />
+            </Notification>
+          ) : undefined
         }
       >
         <FieldColumn>

--- a/src/domain/event/formSections/placeSection/__tests__/PlaceSection.test.tsx
+++ b/src/domain/event/formSections/placeSection/__tests__/PlaceSection.test.tsx
@@ -8,6 +8,7 @@ import {
   LE_DATA_LANGUAGES,
 } from '../../../../../constants';
 import { MultiLanguageObject } from '../../../../../types';
+import { mockAuthenticatedLoginState } from '../../../../../utils/mockLoginHooks';
 import {
   configure,
   mockString,
@@ -19,16 +20,26 @@ import {
   mockedPlacesResponse,
   mockedSortedPlacesResponse,
 } from '../../../../places/__mocks__/placesPage';
+import { mockedUserResponse } from '../../../../user/__mocks__/user';
 import { EVENT_FIELDS, EVENT_TYPE } from '../../../constants';
 import { publicEventSchema } from '../../../validation';
 import PlaceSection from '../PlaceSection';
 
 configure({ defaultHidden: true });
 
+afterEach(() => {
+  vi.resetAllMocks();
+});
+
+beforeEach(() => {
+  mockAuthenticatedLoginState();
+});
+
 const mocks = [
   mockedPlaceSelectorPlacesResponse,
   mockedSortedPlacesResponse,
   mockedPlacesResponse,
+  mockedUserResponse,
 ];
 
 const languages: LE_DATA_LANGUAGES[] = [LE_DATA_LANGUAGES.FI];

--- a/src/domain/event/formSections/placeSection/locationInstructions/LocationInstructions.tsx
+++ b/src/domain/event/formSections/placeSection/locationInstructions/LocationInstructions.tsx
@@ -1,0 +1,29 @@
+import { FC } from 'react';
+import { useTranslation } from 'react-i18next';
+
+export type LocationInstructionsProps = {
+  eventType: string;
+};
+
+const LocationInstructions: FC<LocationInstructionsProps> = ({ eventType }) => {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <p>{t(`event.form.infoTextLocation1`)}</p>
+      <p>{t(`event.form.infoTextLocation2.${eventType}`)}</p>
+      <p>{t(`event.form.infoTextLocation3`)}</p>
+      <p>{t(`event.form.infoTextLocation4`)}</p>
+      <p
+        dangerouslySetInnerHTML={{
+          __html: t(`event.form.infoTextLocation5`, {
+            openInNewTab: t('common.openInNewTab'),
+          }),
+        }}
+      />
+      <p>{t(`event.form.infoTextLocation6`)}</p>
+    </>
+  );
+};
+
+export default LocationInstructions;

--- a/src/domain/event/formSections/priceSection/PriceSection.tsx
+++ b/src/domain/event/formSections/priceSection/PriceSection.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 import Fieldset from '../../../../common/components/fieldset/Fieldset';
 import CheckboxField from '../../../../common/components/formFields/checkboxField/CheckboxField';
 import FormGroup from '../../../../common/components/formGroup/FormGroup';
+import HeadingWithTooltip from '../../../../common/components/headingWithTooltip/HeadingWithTooltip';
 import { EventFieldsFragment } from '../../../../generated/graphql';
 import { featureFlagUtils } from '../../../../utils/featureFlags';
 import FormRow from '../../../admin/layout/formRow/FormRow';
@@ -15,9 +16,13 @@ import { PriceGroupOption } from '../../../priceGroup/types';
 import VatPercentageField from '../../../registration/formSections/priceGroups/vatPercentageField/VatPercentageField';
 import useUser from '../../../user/hooks/useUser';
 import { EVENT_FIELDS } from '../../constants';
-import { shouldShowRegistrationPriceGroupFields } from '../../utils';
+import {
+  shouldShowRegistrationPriceGroupFields,
+  showTooltipInstructions,
+} from '../../utils';
 import FreeEventFields from './freeEventFields/FreeEventFields';
 import Offers from './offers/Offers';
+import PriceInstructions from './priceInstructions/PriceInstructions';
 import ValidationError from './validationError/ValidationError';
 
 interface Props {
@@ -56,7 +61,14 @@ const PriceSection: React.FC<Props> = ({ event, isEditingAllowed }) => {
 
   return (
     <Fieldset heading={t('event.form.sections.price')} hideLegend>
-      <h3>{t(`event.form.titlePriceInfo.${type}`)}</h3>
+      <HeadingWithTooltip
+        heading={t(`event.form.titlePriceInfo.${type}`)}
+        showTooltip={showTooltipInstructions(user)}
+        tag="h3"
+        tooltipContent={<PriceInstructions eventType={type} />}
+        tooltipLabel={t(`event.form.titlePriceInfo.${type}`)}
+      />
+
       <FieldRow>
         <FieldColumn>
           <FormGroup>

--- a/src/domain/event/formSections/priceSection/offers/offer/Offer.tsx
+++ b/src/domain/event/formSections/priceSection/offers/offer/Offer.tsx
@@ -5,11 +5,18 @@ import { useTranslation } from 'react-i18next';
 import DeleteButton from '../../../../../../common/components/deleteButton/DeleteButton';
 import MultiLanguageField from '../../../../../../common/components/formFields/multiLanguageField/MultiLanguageField';
 import FormGroup from '../../../../../../common/components/formGroup/FormGroup';
+import HeadingWithTooltip from '../../../../../../common/components/headingWithTooltip/HeadingWithTooltip';
 import { featureFlagUtils } from '../../../../../../utils/featureFlags';
 import FieldRow from '../../../../../app/layout/fieldRow/FieldRow';
+import useUser from '../../../../../user/hooks/useUser';
 import { EVENT_FIELDS, EVENT_OFFER_FIELDS } from '../../../../constants';
 import styles from '../../../../eventPage.module.scss';
 import FieldWithButton from '../../../../layout/FieldWithButton';
+import {
+  showNotificationInstructions,
+  showTooltipInstructions,
+} from '../../../../utils';
+import PriceInstructions from '../../priceInstructions/PriceInstructions';
 import PriceNotification from '../../priceNotification/PriceNotification';
 import OfferPriceGroups from './offerPriceGroups/OfferPriceGroups';
 
@@ -32,6 +39,7 @@ const Offer: React.FC<Props> = ({
   showRegistrationPriceGroupFields,
 }) => {
   const { t } = useTranslation();
+  const { user } = useUser();
 
   const [{ value: type }] = useField({ name: EVENT_FIELDS.TYPE });
   const [{ value: eventInfoLanguages }] = useField({
@@ -42,7 +50,9 @@ const Offer: React.FC<Props> = ({
     <>
       <FieldRow
         notification={
-          <PriceNotification className={styles.secondNotification} />
+          showNotificationInstructions(user) ? (
+            <PriceNotification className={styles.secondNotification} />
+          ) : undefined
         }
       >
         <FieldWithButton
@@ -58,7 +68,14 @@ const Offer: React.FC<Props> = ({
         >
           <>
             <FormGroup>
-              <h3>{t('event.form.titleOfferPrice')}</h3>
+              <HeadingWithTooltip
+                heading={t('event.form.titleOfferPrice')}
+                showTooltip={showTooltipInstructions(user)}
+                tag="h3"
+                tooltipContent={<PriceInstructions eventType={type} />}
+                tooltipLabel={t(`event.form.titlePriceInfo.${type}`)}
+              />
+
               <MultiLanguageField
                 disabled={!isEditingAllowed}
                 labelKey={`event.form.labelOfferPrice`}

--- a/src/domain/event/formSections/priceSection/priceInstructions/PriceInstructions.tsx
+++ b/src/domain/event/formSections/priceSection/priceInstructions/PriceInstructions.tsx
@@ -1,0 +1,24 @@
+import { FC } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { featureFlagUtils } from '../../../../../utils/featureFlags';
+
+export type PriceInstructionsProps = {
+  eventType: string;
+};
+
+const PriceInstructions: FC<PriceInstructionsProps> = ({ eventType }) => {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <p>{t(`event.form.infoTextOffers1.${eventType}`)}</p>
+      <p>{t(`event.form.infoTextOffers2.${eventType}`)}</p>
+      {featureFlagUtils.isFeatureEnabled('WEB_STORE_INTEGRATION') && (
+        <p>{t(`event.form.infoTextOffers3.${eventType}`)}</p>
+      )}
+    </>
+  );
+};
+
+export default PriceInstructions;

--- a/src/domain/event/formSections/priceSection/priceNotification/PriceNotification.tsx
+++ b/src/domain/event/formSections/priceSection/priceNotification/PriceNotification.tsx
@@ -3,8 +3,8 @@ import { FC } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import Notification from '../../../../../common/components/notification/Notification';
-import { featureFlagUtils } from '../../../../../utils/featureFlags';
 import { EVENT_FIELDS } from '../../../constants';
+import PriceInstructions from '../priceInstructions/PriceInstructions';
 
 type PriceNotificationProps = {
   className?: string;
@@ -20,11 +20,7 @@ const PriceNotification: FC<PriceNotificationProps> = ({ className }) => {
       label={t(`event.form.notificationTitleOffers`)}
       type="info"
     >
-      <p>{t(`event.form.infoTextOffers1.${type}`)}</p>
-      <p>{t(`event.form.infoTextOffers2.${type}`)}</p>
-      {featureFlagUtils.isFeatureEnabled('WEB_STORE_INTEGRATION') && (
-        <p>{t(`event.form.infoTextOffers3.${type}`)}</p>
-      )}
+      <PriceInstructions eventType={type} />
     </Notification>
   );
 };

--- a/src/domain/event/formSections/responsibilitiesSection/ResponsibilitiesSection.tsx
+++ b/src/domain/event/formSections/responsibilitiesSection/ResponsibilitiesSection.tsx
@@ -14,6 +14,10 @@ import FieldRow from '../../../app/layout/fieldRow/FieldRow';
 import useUser from '../../../user/hooks/useUser';
 import useUserOrganizations from '../../../user/hooks/useUserOrganizations';
 import { EVENT_FIELDS } from '../../constants';
+import {
+  showNotificationInstructions,
+  showTooltipInstructions,
+} from '../../utils';
 
 export interface ResponsibilitiesSectionProps {
   isEditingAllowed: boolean;
@@ -61,12 +65,14 @@ const ResponsibilitiesSection: React.FC<ResponsibilitiesSectionProps> = ({
     <Fieldset heading={t('event.form.sections.responsibilities')} hideLegend>
       <FieldRow
         notification={
-          <Notification
-            label={t(`event.form.notificationTitlePublisher.${type}`)}
-            type="info"
-          >
-            <p>{t(`event.form.infoTextPublisher.${type}`)}</p>
-          </Notification>
+          showNotificationInstructions(user) ? (
+            <Notification
+              label={t(`event.form.notificationTitlePublisher.${type}`)}
+              type="info"
+            >
+              <p>{t(`event.form.infoTextPublisher.${type}`)}</p>
+            </Notification>
+          ) : undefined
         }
       >
         <FieldColumn>
@@ -78,18 +84,27 @@ const ResponsibilitiesSection: React.FC<ResponsibilitiesSectionProps> = ({
             label={t(`event.form.labelPublisher.${type}`)}
             name={EVENT_FIELDS.PUBLISHER}
             publisher={savedEvent?.publisher}
+            {...(showTooltipInstructions(user)
+              ? {
+                  tooltipButtonLabel: t('common.showInstructions'),
+                  tooltipLabel: t(`event.form.labelPublisher.${type}`),
+                  tooltipText: t(`event.form.infoTextPublisher.${type}`),
+                }
+              : {})}
           />
         </FieldColumn>
       </FieldRow>
 
       <FieldRow
         notification={
-          <Notification
-            label={t(`event.form.notificationTitleProvider.${type}`)}
-            type="info"
-          >
-            <p>{t(`event.form.infoTextProvider.${type}`)}</p>
-          </Notification>
+          showNotificationInstructions(user) ? (
+            <Notification
+              label={t(`event.form.notificationTitleProvider.${type}`)}
+              type="info"
+            >
+              <p>{t(`event.form.infoTextProvider.${type}`)}</p>
+            </Notification>
+          ) : undefined
         }
       >
         <FieldColumn>
@@ -107,6 +122,17 @@ const ResponsibilitiesSection: React.FC<ResponsibilitiesSectionProps> = ({
               undefined
             )}
             required={isExternalUser}
+            {...(showTooltipInstructions(user)
+              ? {
+                  tooltipButtonLabel: t('common.showInstructions'),
+                  tooltipLabel:
+                    /* istanbul ignore next */
+                    isExternalUser
+                      ? 'event.form.labelProvider.other'
+                      : `event.form.labelProvider.${type}`,
+                  tooltipText: t(`event.form.infoTextProvider.${type}`),
+                }
+              : {})}
           />
         </FieldColumn>
       </FieldRow>

--- a/src/domain/event/formSections/timeSection/eventTimeTab/EventTimeTab.tsx
+++ b/src/domain/event/formSections/timeSection/eventTimeTab/EventTimeTab.tsx
@@ -4,8 +4,9 @@ import { useTranslation } from 'react-i18next';
 import Fieldset from '../../../../../common/components/fieldset/Fieldset';
 import FieldColumn from '../../../../app/layout/fieldColumn/FieldColumn';
 import FieldRow from '../../../../app/layout/fieldRow/FieldRow';
+import useUser from '../../../../user/hooks/useUser';
 import { EventTime } from '../../../types';
-import { isRecurringEvent } from '../../../utils';
+import { isRecurringEvent, showNotificationInstructions } from '../../../utils';
 import AddEventTimeForm from '../addEventTimeForm/AddEventTimeForm';
 import EventTimesSummary from '../eventTimesSummary/EventTimesSummary';
 import useTimeSectionContext from '../hooks/useTimeSectionContext';
@@ -15,6 +16,7 @@ import ValidationError from '../validationError/ValidationError';
 
 const EventTimeTab: React.FC = () => {
   const { t } = useTranslation();
+  const { user } = useUser();
   const {
     events,
     eventTimes,
@@ -44,7 +46,13 @@ const EventTimeTab: React.FC = () => {
       hideLegend
     >
       <h3>{t(`event.form.titleEnterEventTime.${eventType}`)}</h3>
-      <FieldRow notification={<TimeSectionNotification />}>
+      <FieldRow
+        notification={
+          showNotificationInstructions(user) ? (
+            <TimeSectionNotification />
+          ) : undefined
+        }
+      >
         <FieldColumn>
           <AddEventTimeForm addEventTime={addEventTime} />
           <ValidationError />

--- a/src/domain/event/formSections/timeSection/recurringEventTab/RecurringEventTab.tsx
+++ b/src/domain/event/formSections/timeSection/recurringEventTab/RecurringEventTab.tsx
@@ -4,8 +4,9 @@ import { useTranslation } from 'react-i18next';
 import Fieldset from '../../../../../common/components/fieldset/Fieldset';
 import FieldColumn from '../../../../app/layout/fieldColumn/FieldColumn';
 import FieldRow from '../../../../app/layout/fieldRow/FieldRow';
+import useUser from '../../../../user/hooks/useUser';
 import { RecurringEventSettings } from '../../../types';
-import { isRecurringEvent } from '../../../utils';
+import { isRecurringEvent, showNotificationInstructions } from '../../../utils';
 import AddRecurringEventForm from '../addRecurringEventForm/AddRecurringEventForm';
 import EventTimesSummary from '../eventTimesSummary/EventTimesSummary';
 import useTimeSectionContext from '../hooks/useTimeSectionContext';
@@ -15,6 +16,7 @@ import ValidationError from '../validationError/ValidationError';
 
 const RecurringEventTab: React.FC = () => {
   const { t } = useTranslation();
+  const { user } = useUser();
   const {
     events,
     eventTimes,
@@ -40,7 +42,13 @@ const RecurringEventTab: React.FC = () => {
   return (
     <Fieldset heading={t(`event.form.titleRecurringEvent`)} hideLegend>
       <h3>{t('event.form.titleRecurringEvent')}</h3>
-      <FieldRow notification={<TimeSectionNotification />}>
+      <FieldRow
+        notification={
+          showNotificationInstructions(user) ? (
+            <TimeSectionNotification />
+          ) : undefined
+        }
+      >
         <FieldColumn>
           <AddRecurringEventForm onSubmit={addRecurringEvent} />
           <ValidationError />

--- a/src/domain/event/formSections/timeSection/timeInstructions/TimeInstructions.tsx
+++ b/src/domain/event/formSections/timeSection/timeInstructions/TimeInstructions.tsx
@@ -1,0 +1,21 @@
+import { FC } from 'react';
+import { useTranslation } from 'react-i18next';
+
+export type TimeInstructionsProps = {
+  eventType: string;
+};
+const TimeInstructions: FC<TimeInstructionsProps> = ({ eventType }) => {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <p>{t(`event.form.infoTextEventTimes1.${eventType}`)}</p>
+      <p>{t(`event.form.infoTextEventTimes2.${eventType}`)}</p>
+      <p>{t(`event.form.infoTextEventTimes3.${eventType}`)}</p>
+      <p>{t(`event.form.infoTextEventTimes4.${eventType}`)}</p>
+      <p>{t(`event.form.infoTextEventTimes5`)}</p>
+    </>
+  );
+};
+
+export default TimeInstructions;

--- a/src/domain/event/formSections/timeSection/timeSectionNotification/TimeSectionNotification.tsx
+++ b/src/domain/event/formSections/timeSection/timeSectionNotification/TimeSectionNotification.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import Notification from '../../../../../common/components/notification/Notification';
 import styles from '../../../eventPage.module.scss';
 import useTimeSectionContext from '../hooks/useTimeSectionContext';
+import TimeInstructions from '../timeInstructions/TimeInstructions';
 
 const TimeSectionNotification: React.FC = () => {
   const { t } = useTranslation();
@@ -15,11 +16,7 @@ const TimeSectionNotification: React.FC = () => {
       label={t(`event.form.notificationTitleEventTimes.${eventType}`)}
       type="info"
     >
-      <p>{t(`event.form.infoTextEventTimes1.${eventType}`)}</p>
-      <p>{t(`event.form.infoTextEventTimes2.${eventType}`)}</p>
-      <p>{t(`event.form.infoTextEventTimes3.${eventType}`)}</p>
-      <p>{t(`event.form.infoTextEventTimes4.${eventType}`)}</p>
-      <p>{t(`event.form.infoTextEventTimes5`)}</p>
+      <TimeInstructions eventType={eventType} />
     </Notification>
   );
 };

--- a/src/domain/event/formSections/typeSection/TypeSection.tsx
+++ b/src/domain/event/formSections/typeSection/TypeSection.tsx
@@ -2,15 +2,14 @@
 import { Field, useField } from 'formik';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link } from 'react-router-dom';
 
 import Fieldset from '../../../../common/components/fieldset/Fieldset';
 import CheckboxField from '../../../../common/components/formFields/checkboxField/CheckboxField';
 import RadioButtonGroupField from '../../../../common/components/formFields/radioButtonGroupField/RadioButtonGroupField';
 import UmbrellaEventSelectorField from '../../../../common/components/formFields/umbrellaEventSelectorField/UmbrellaEventSelectorField';
 import FormGroup from '../../../../common/components/formGroup/FormGroup';
+import HeadingWithTooltip from '../../../../common/components/headingWithTooltip/HeadingWithTooltip';
 import Notification from '../../../../common/components/notification/Notification';
-import { ROUTES } from '../../../../constants';
 import {
   EventFieldsFragment,
   SuperEventType,
@@ -18,11 +17,19 @@ import {
 import useLocale from '../../../../hooks/useLocale';
 import FieldColumn from '../../../app/layout/fieldColumn/FieldColumn';
 import FieldRow from '../../../app/layout/fieldRow/FieldRow';
+import useUser from '../../../user/hooks/useUser';
 import { EVENT_FIELDS, EVENT_TYPE } from '../../constants';
 import styles from '../../eventPage.module.scss';
 import useEventTypeOptions from '../../hooks/useEventTypeOptions';
 import { EventTime, RecurringEventSettings } from '../../types';
-import { getEventFields, isRecurringEvent } from '../../utils';
+import {
+  getEventFields,
+  isRecurringEvent,
+  showNotificationInstructions,
+  showTooltipInstructions,
+} from '../../utils';
+import TypeInstructions from './typeInstructions/TypeInstructions';
+import UmbrellaEventInstructions from './umbrellaEventInstructions/UmbrellaEventInstructions';
 
 export interface TypeSectionProps {
   isEditingAllowed: boolean;
@@ -38,6 +45,7 @@ const TypeSection: React.FC<TypeSectionProps> = ({
   const { t } = useTranslation();
   const locale = useLocale();
   const typeOptions = useEventTypeOptions();
+  const { user } = useUser();
 
   const [{ value: type }] = useField<EVENT_TYPE>({ name: EVENT_FIELDS.TYPE });
   const [{ value: hasUmbrella }] = useField({
@@ -58,7 +66,6 @@ const TypeSection: React.FC<TypeSectionProps> = ({
     ? getEventFields(savedEvent, locale)
     : { superEventAtId: null, superEventType: null };
   const superEventSuperEventType = savedEvent?.superEvent?.superEventType;
-  const superEventId = savedEvent?.superEvent?.id;
 
   const getDisabled = (
     name: EVENT_FIELDS.HAS_UMBRELLA | EVENT_FIELDS.IS_UMBRELLA
@@ -106,17 +113,27 @@ const TypeSection: React.FC<TypeSectionProps> = ({
 
   return (
     <Fieldset heading={t('event.form.sections.type')} hideLegend>
-      <h3>{t('event.form.titleEventType')}</h3>
+      <HeadingWithTooltip
+        heading={t('event.form.titleEventType')}
+        showTooltip={showTooltipInstructions(user)}
+        tag="h3"
+        tooltipContent={<TypeInstructions />}
+        tooltipLabel={t('event.form.sections.type')}
+      ></HeadingWithTooltip>
+
       <FieldRow
         notification={
-          <Notification
-            className={styles.notificationForTitle}
-            label={t('event.form.notificationTitleType')}
-            type="info"
-          >
-            <p>{t('event.form.infoTextType1')}</p>
-            <p>{t('event.form.infoTextType2')}</p>
-          </Notification>
+          <>
+            {showNotificationInstructions(user) && (
+              <Notification
+                className={styles.notificationForTitle}
+                label={t('event.form.notificationTitleType')}
+                type="info"
+              >
+                <TypeInstructions />
+              </Notification>
+            )}
+          </>
         }
       >
         <FieldColumn>
@@ -132,31 +149,24 @@ const TypeSection: React.FC<TypeSectionProps> = ({
         </FieldColumn>
       </FieldRow>
 
-      <h3>{t('event.form.titleUmrellaEvent')}</h3>
+      <HeadingWithTooltip
+        heading={t('event.form.titleUmrellaEvent')}
+        showTooltip={showTooltipInstructions(user)}
+        tag="h3"
+        tooltipContent={<UmbrellaEventInstructions savedEvent={savedEvent} />}
+        tooltipLabel={t('event.form.notificationTitleUmrellaEvent')}
+      ></HeadingWithTooltip>
       <FieldRow
         notification={
-          <Notification
-            className={styles.notificationForTitle}
-            label={t('event.form.notificationTitleUmrellaEvent')}
-            type="info"
-          >
-            <p>{t('event.form.infoTextUmrellaEvent1')}</p>
-            <p>{t('event.form.infoTextUmrellaEvent2')}</p>
-            {superEventId &&
-              superEventSuperEventType === SuperEventType.Recurring && (
-                <p>
-                  {t('event.form.infoTextUmbrellaSubEvent')}{' '}
-                  <Link
-                    to={`/${locale}${ROUTES.EDIT_EVENT.replace(
-                      ':id',
-                      superEventId
-                    )}`}
-                  >
-                    {t('event.form.infoTextUmbrellaSubEventLink')}.
-                  </Link>
-                </p>
-              )}
-          </Notification>
+          showNotificationInstructions(user) ? (
+            <Notification
+              className={styles.notificationForTitle}
+              label={t('event.form.notificationTitleUmrellaEvent')}
+              type="info"
+            >
+              <UmbrellaEventInstructions savedEvent={savedEvent} />
+            </Notification>
+          ) : undefined
         }
       >
         <FieldColumn>

--- a/src/domain/event/formSections/typeSection/__tests__/TypeSection.test.tsx
+++ b/src/domain/event/formSections/typeSection/__tests__/TypeSection.test.tsx
@@ -3,7 +3,9 @@ import React from 'react';
 
 import { SuperEventType } from '../../../../../generated/graphql';
 import { fakeEvent } from '../../../../../utils/mockDataUtils';
+import { mockAuthenticatedLoginState } from '../../../../../utils/mockLoginHooks';
 import { configure, render, screen } from '../../../../../utils/testUtils';
+import { mockedUserResponse } from '../../../../user/__mocks__/user';
 import { mockedUmbrellaEventsResponse } from '../../../__mocks__/createEventPage';
 import { EVENT_FIELDS, EVENT_TYPE } from '../../../constants';
 import { EventTime, RecurringEventSettings } from '../../../types';
@@ -13,7 +15,15 @@ configure({ defaultHidden: true });
 
 const type = EVENT_TYPE.General;
 
-const mocks = [mockedUmbrellaEventsResponse];
+afterEach(() => {
+  vi.resetAllMocks();
+});
+
+beforeEach(() => {
+  mockAuthenticatedLoginState();
+});
+
+const mocks = [mockedUserResponse, mockedUmbrellaEventsResponse];
 
 type InitialValues = {
   [EVENT_FIELDS.EVENT_TIMES]: EventTime[];

--- a/src/domain/event/formSections/typeSection/typeInstructions/TypeInstructions.tsx
+++ b/src/domain/event/formSections/typeSection/typeInstructions/TypeInstructions.tsx
@@ -1,0 +1,15 @@
+import { FC } from 'react';
+import { useTranslation } from 'react-i18next';
+
+const TypeInstructions: FC = () => {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <p>{t('event.form.infoTextType1')}</p>
+      <p>{t('event.form.infoTextType2')}</p>
+    </>
+  );
+};
+
+export default TypeInstructions;

--- a/src/domain/event/formSections/typeSection/umbrellaEventInstructions/UmbrellaEventInstructions.tsx
+++ b/src/domain/event/formSections/typeSection/umbrellaEventInstructions/UmbrellaEventInstructions.tsx
@@ -1,0 +1,43 @@
+import { FC } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
+
+import { ROUTES } from '../../../../../constants';
+import {
+  EventFieldsFragment,
+  SuperEventType,
+} from '../../../../../generated/graphql';
+import useLocale from '../../../../../hooks/useLocale';
+
+export type UmbrellaEventInstructionsProps = {
+  savedEvent?: EventFieldsFragment | null;
+};
+
+const UmbrellaEventInstructions: FC<UmbrellaEventInstructionsProps> = ({
+  savedEvent,
+}) => {
+  const { t } = useTranslation();
+  const locale = useLocale();
+
+  const typeOfSuperEvent = savedEvent?.superEvent?.superEventType;
+  const superEventId = savedEvent?.superEvent?.id;
+
+  return (
+    <>
+      <p>{t('event.form.infoTextUmrellaEvent1')}</p>
+      <p>{t('event.form.infoTextUmrellaEvent2')}</p>
+      {superEventId && typeOfSuperEvent === SuperEventType.Recurring && (
+        <p>
+          {t('event.form.infoTextUmbrellaSubEvent')}{' '}
+          <Link
+            to={`/${locale}${ROUTES.EDIT_EVENT.replace(':id', superEventId)}`}
+          >
+            {t('event.form.infoTextUmbrellaSubEventLink')}.
+          </Link>
+        </p>
+      )}
+    </>
+  );
+};
+
+export default UmbrellaEventInstructions;

--- a/src/domain/event/formSections/videoSection/__tests__/VideoSection.test.tsx
+++ b/src/domain/event/formSections/videoSection/__tests__/VideoSection.test.tsx
@@ -1,6 +1,7 @@
 import { Formik } from 'formik';
 import React from 'react';
 
+import { mockAuthenticatedLoginState } from '../../../../../utils/mockLoginHooks';
 import {
   configure,
   render,
@@ -8,6 +9,7 @@ import {
   userEvent,
   waitFor,
 } from '../../../../../utils/testUtils';
+import { mockedUserResponse } from '../../../../user/__mocks__/user';
 import {
   EVENT_FIELDS,
   EVENT_INITIAL_VALUES,
@@ -26,6 +28,16 @@ const defaultInitialValue = {
   [EVENT_FIELDS.VIDEOS]: EVENT_INITIAL_VALUES.videos,
 };
 
+afterEach(() => {
+  vi.resetAllMocks();
+});
+
+beforeEach(() => {
+  mockAuthenticatedLoginState();
+});
+
+const mocks = [mockedUserResponse];
+
 const renderVideoSection = (initialValues?: Partial<EventFormFields>) =>
   render(
     <Formik
@@ -37,7 +49,8 @@ const renderVideoSection = (initialValues?: Partial<EventFormFields>) =>
       validationSchema={publicEventSchema}
     >
       <VideoSection isEditingAllowed={true} />
-    </Formik>
+    </Formik>,
+    { mocks }
   );
 
 const getElement = (

--- a/src/domain/event/formSections/videoSection/video/Video.tsx
+++ b/src/domain/event/formSections/videoSection/video/Video.tsx
@@ -5,11 +5,18 @@ import { useTranslation } from 'react-i18next';
 import DeleteButton from '../../../../../common/components/deleteButton/DeleteButton';
 import TextInputField from '../../../../../common/components/formFields/textInputField/TextInputField';
 import FormGroup from '../../../../../common/components/formGroup/FormGroup';
+import HeadingWithTooltip from '../../../../../common/components/headingWithTooltip/HeadingWithTooltip';
 import Notification from '../../../../../common/components/notification/Notification';
 import FieldRow from '../../../../app/layout/fieldRow/FieldRow';
+import useUser from '../../../../user/hooks/useUser';
 import { VIDEO_DETAILS_FIELDS } from '../../../constants';
 import styles from '../../../eventPage.module.scss';
 import FieldWithButton from '../../../layout/FieldWithButton';
+import {
+  showNotificationInstructions,
+  showTooltipInstructions,
+} from '../../../utils';
+import VideoInstructions from '../videoInstructions/VideoInstructions';
 
 type Props = {
   canDelete: boolean;
@@ -32,6 +39,7 @@ const Video: React.FC<Props> = ({
   videoPath,
 }) => {
   const { t } = useTranslation();
+  const { user } = useUser();
 
   const fieldNames = React.useMemo(
     () => ({
@@ -59,17 +67,23 @@ const Video: React.FC<Props> = ({
 
   return (
     <>
-      <h3>{t(`event.form.titleVideo.${type}`)}</h3>
+      <HeadingWithTooltip
+        heading={t(`event.form.titleVideo.${type}`)}
+        showTooltip={showTooltipInstructions(user)}
+        tag="h3"
+        tooltipContent={<VideoInstructions eventType={type} />}
+        tooltipLabel={t(`event.form.notificationTitleVideo.${type}`)}
+      />
+
       <FieldRow
         notification={
-          showInstructions ? (
+          showInstructions && showNotificationInstructions(user) ? (
             <Notification
               className={styles.notificationForTitle}
               label={t(`event.form.notificationTitleVideo.${type}`)}
               type="info"
             >
-              <p>{t(`event.form.infoTextVideo1.${type}`)}</p>
-              <p>{t(`event.form.infoTextVideo2`)}</p>
+              <VideoInstructions eventType={type} />
             </Notification>
           ) : undefined
         }

--- a/src/domain/event/formSections/videoSection/videoInstructions/VideoInstructions.tsx
+++ b/src/domain/event/formSections/videoSection/videoInstructions/VideoInstructions.tsx
@@ -1,0 +1,19 @@
+import { FC } from 'react';
+import { useTranslation } from 'react-i18next';
+
+export type VideoInstructionsProps = {
+  eventType: string;
+};
+
+const VideoInstructions: FC<VideoInstructionsProps> = ({ eventType }) => {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <p>{t(`event.form.infoTextVideo1.${eventType}`)}</p>
+      <p>{t(`event.form.infoTextVideo2`)}</p>
+    </>
+  );
+};
+
+export default VideoInstructions;

--- a/src/domain/event/utils.ts
+++ b/src/domain/event/utils.ts
@@ -1577,3 +1577,10 @@ export const shouldShowRegistrationPriceGroupFields = ({
     !isRegistrationPlanned
   );
 };
+
+export const showTooltipInstructions = (user?: UserFieldsFragment): boolean =>
+  !!user?.adminOrganizations.length || !!user?.isSuperuser;
+
+export const showNotificationInstructions = (
+  user?: UserFieldsFragment
+): boolean => !showTooltipInstructions(user);


### PR DESCRIPTION
## Description
Hide instruction notifications from admin users. Instead show tooltip instructions for them.

Note that it's intentional to display "Julkaisu" instruction for all the users.

## Closes
[LINK-2051](https://helsinkisolutionoffice.atlassian.net/browse/LINK-2051)

## Screenshot
<img width="1336" alt="Screenshot 2024-06-13 at 17 01 25" src="https://github.com/City-of-Helsinki/linkedcomponents-ui/assets/24706814/e716cdb8-bc1d-4c48-99a6-24caada67960">

<img width="1317" alt="Screenshot 2024-06-13 at 16 59 49" src="https://github.com/City-of-Helsinki/linkedcomponents-ui/assets/24706814/5ec4b90a-23c5-44ec-8711-be7f399f57bf">



[LINK-2051]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-2051?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ