### PR TITLE
fix: a11y make ButtonPanel not sticky LINK-1751

### DIFF
--- a/src/common/components/buttonPanel/buttonPanel.module.scss
+++ b/src/common/components/buttonPanel/buttonPanel.module.scss
@@ -3,14 +3,9 @@
 @import '../../../assets/styles/widths';
 
 .buttonPanel {
-  position: sticky;
-  bottom: 0;
-  left: 0;
-  right: 0;
   padding: var(--spacing-m) 0;
   background-color: var(--color-white);
   border-top: 1px solid var(--color-black-10);
-  z-index: 9;
 }
 
 .buttonsRow {


### PR DESCRIPTION
## Description :sparkles:

There is a issue when navigating pages with ButtonPanel on Windows & Chrome + NVDA combination where focus can get stuck underneath sticky positioned ButtonPanel. Removing sticky positioning will make sure this cannot happen.

## Issues :bug:

### Closes :no_good_woman:

**[LINK-1751](https://helsinkisolutionoffice.atlassian.net/browse/LINK-1751):**

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[LINK-1751]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-1751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ