### PR TITLE
LINK-2030 | scrub sensitive data from Sentry requests

### DIFF
--- a/src/domain/app/sentry/__tests__/utils.test.ts
+++ b/src/domain/app/sentry/__tests__/utils.test.ts
@@ -1,0 +1,69 @@
+import {
+  beforeSend,
+  beforeSendTransaction,
+  cleanSensitiveData,
+} from '../utils';
+
+const sensitive = 'sensitive';
+const safe = 'safe';
+
+const originalData = {
+  a: safe,
+  access_code: sensitive,
+  accessCode: sensitive,
+  city: sensitive,
+  dateOfBirth: sensitive,
+  email: sensitive,
+  extraInfo: sensitive,
+  firstName: sensitive,
+  lastName: sensitive,
+  membershipNumber: sensitive,
+  nativeLanguage: sensitive,
+  phoneNumber: sensitive,
+  postalCode: sensitive,
+  serviceLanguage: sensitive,
+  session: sensitive,
+  streetAddress: sensitive,
+  userEmail: sensitive,
+  userName: sensitive,
+  userPhoneNumber: sensitive,
+  zipcode: sensitive,
+  arrayOfObjects: [
+    { a: safe, accessCode: sensitive },
+    { b: safe, accessCode: sensitive },
+  ],
+  arrayOfStrings: [safe],
+  object: { c: safe, userEmail: sensitive, userName: sensitive },
+};
+
+const cleanedData = {
+  a: safe,
+  arrayOfObjects: [{ a: safe }, { b: safe }],
+  arrayOfStrings: [safe],
+  object: { c: safe },
+};
+
+describe('beforeSend', () => {
+  it('should clear sensitive data', () => {
+    expect(
+      beforeSend({ extra: { data: originalData }, type: undefined })
+    ).toEqual({ extra: { data: cleanedData } });
+  });
+});
+
+describe('beforeSendTransaction', () => {
+  it('should clear sensitive data', () => {
+    expect(
+      beforeSendTransaction({
+        extra: { data: originalData },
+        type: 'transaction',
+      })
+    ).toEqual({ extra: { data: cleanedData }, type: 'transaction' });
+  });
+});
+
+describe('cleanSensitiveData', () => {
+  it('should clear sensitive data', () => {
+    expect(cleanSensitiveData(originalData)).toEqual(cleanedData);
+  });
+});

--- a/src/domain/app/sentry/utils.ts
+++ b/src/domain/app/sentry/utils.ts
@@ -1,7 +1,108 @@
 import * as Sentry from '@sentry/react';
+import { ErrorEvent, TransactionEvent } from '@sentry/types';
 import * as H from 'history';
+import isObject from 'lodash/isObject';
+import snakeCase from 'lodash/snakeCase';
 
 import { UserFieldsFragment } from '../../../generated/graphql';
+
+// https://github.com/getsentry/sentry-python/blob/8094c9e4462c7af4d73bfe3b6382791f9949e7f0/sentry_sdk/scrubber.py#L14
+const DEFAULT_DENYLIST = [
+  // stolen from relay
+  'password',
+  'passwd',
+  'secret',
+  'api_key',
+  'apikey',
+  'auth',
+  'credentials',
+  'mysql_pwd',
+  'privatekey',
+  'private_key',
+  'token',
+  'ip_address',
+  'session',
+  // django
+  'csrftoken',
+  'sessionid',
+  // wsgi
+  'remote_addr',
+  'x_csrftoken',
+  'x_forwarded_for',
+  'set_cookie',
+  'cookie',
+  'authorization',
+  'x_api_key',
+  'x_forwarded_for',
+  'x_real_ip',
+  // other common names used in the wild
+  'aiohttp_session', // aiohttp
+  'connect.sid', // Express
+  'csrf_token', // Pyramid
+  'csrf', // (this is a cookie name used in accepted answers on stack overflow)
+  '_csrf', // Express
+  '_csrf_token', // Bottle
+  'PHPSESSID', // PHP
+  '_session', // Sanic
+  'symfony', // Symfony
+  'user_session', // Vue
+  '_xsrf', // Tornado
+  'XSRF-TOKEN', // Angular, Laravel
+];
+
+const SENTRY_DENYLIST = [
+  ...DEFAULT_DENYLIST,
+  'access_code',
+  'city',
+  'date_of_birth',
+  'email',
+  'extra_info',
+  'first_name',
+  'last_name',
+  'membership_number',
+  'native_language',
+  'phone_number',
+  'postal_code',
+  'service_language',
+  'street_address',
+  'user_email',
+  'user_name',
+  'user_phone_number',
+  'zipcode',
+];
+
+export const cleanSensitiveData = (data: Record<string, unknown>) => {
+  Object.entries(data).forEach(([key, value]) => {
+    if (
+      SENTRY_DENYLIST.includes(key) ||
+      SENTRY_DENYLIST.includes(snakeCase(key))
+    ) {
+      delete data[key];
+    } else if (Array.isArray(value)) {
+      data[key] = value.map((item) =>
+        isObject(item)
+          ? cleanSensitiveData(item as Record<string, unknown>)
+          : item
+      );
+    } else if (isObject(value)) {
+      data[key] = cleanSensitiveData(value as Record<string, unknown>);
+    }
+  });
+
+  return data;
+};
+
+export const beforeSend = (event: ErrorEvent): ErrorEvent =>
+  cleanSensitiveData(
+    event as unknown as Record<string, unknown>
+  ) as unknown as ErrorEvent;
+
+export const beforeSendTransaction = (
+  event: TransactionEvent
+): TransactionEvent =>
+  cleanSensitiveData(
+    event as unknown as Record<string, unknown>
+  ) as unknown as TransactionEvent;
 
 const reportError = ({
   data,

--- a/src/hooks/useHandleError.ts
+++ b/src/hooks/useHandleError.ts
@@ -1,6 +1,6 @@
 import { useLocation } from 'react-router';
 
-import { reportError } from '../domain/app/sentry/utils';
+import { cleanSensitiveData, reportError } from '../domain/app/sentry/utils';
 import useUser from '../domain/user/hooks/useUser';
 import { MutationCallbacks } from '../types';
 
@@ -53,7 +53,7 @@ function useHandleError<
     reportError({
       data: {
         error,
-        payloadAsString: payload && JSON.stringify(payload),
+        payloadAsString: payload && JSON.stringify(cleanSensitiveData(payload)),
         object,
       },
       location,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,9 +8,12 @@ import React from 'react';
 import { createRoot } from 'react-dom/client';
 
 import App from './domain/app/App';
+import { beforeSend, beforeSendTransaction } from './domain/app/sentry/utils';
 
 if (import.meta.env.REACT_APP_SENTRY_ENVIRONMENT) {
   Sentry.init({
+    beforeSend,
+    beforeSendTransaction: beforeSendTransaction,
     dsn: import.meta.env.REACT_APP_SENTRY_DSN,
     environment: import.meta.env.REACT_APP_SENTRY_ENVIRONMENT,
     ignoreErrors: [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -64,7 +64,6 @@ export default defineConfig({
         'src/domain/app/apollo/utils.ts',
         'src/domain/app/hooks/usePageSettings.ts',
         'src/domain/app/i18n/i18nInit.ts',
-        'src/domain/app/sentry/utils.ts',
         'src/domain/app/theme/Theme.tsx',
         'src/domain/auth/hooks/useAuth.ts',
         'src/domain/auth/oidcCallback/OidcCallback.tsx',


### PR DESCRIPTION
## Description
Adds `beforeSend` and `beforeSendTransaction` functions to Sentry client to scrub sensitive information before it is sent to the Sentry server.

## Closes
[LINK-2030](https://helsinkisolutionoffice.atlassian.net/browse/LINK-2030)

[LINK-2030]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-2030?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ