### PR TITLE
LINK-2089 | Prevent to delete signup or signup group with payment cancellation/refund

### DIFF
--- a/src/domain/signup/__tests__/permissions.test.ts
+++ b/src/domain/signup/__tests__/permissions.test.ts
@@ -6,6 +6,7 @@ import {
   fakePaymentRefund,
   fakeRegistration,
   fakeSignup,
+  fakeSignupGroup,
   fakeUser,
 } from '../../../utils/mockDataUtils';
 import { TEST_PUBLISHER_ID } from '../../organization/constants';
@@ -93,11 +94,41 @@ describe('getSignupActionWarning function', () => {
     ).toBe('Osallistujan maksua perutaan eikä osallistujaa voi poistaa.');
   });
 
+  it('should return correct warning when trying to delete signup with signup group with payment cancellation', () => {
+    expect(
+      getSignupActionWarning({
+        authenticated: true,
+        signup: fakeSignup(),
+        signupGroup: fakeSignupGroup({
+          paymentCancellation: fakePaymentCancellation(),
+        }),
+        t: i18n.t.bind(i18n),
+        userCanDoAction: true,
+        action: SIGNUP_ACTIONS.DELETE,
+      })
+    ).toBe('Osallistujan maksua perutaan eikä osallistujaa voi poistaa.');
+  });
+
   it('should return correct warning when trying to delete signup with payment refund', () => {
     expect(
       getSignupActionWarning({
         authenticated: true,
         signup: fakeSignup({
+          paymentRefund: fakePaymentRefund(),
+        }),
+        t: i18n.t.bind(i18n),
+        userCanDoAction: true,
+        action: SIGNUP_ACTIONS.DELETE,
+      })
+    ).toBe('Osallistujan maksua hyvitetään eikä osallistujaa voi poistaa.');
+  });
+
+  it('should return correct warning when trying to delete signup with signup group with payment refund', () => {
+    expect(
+      getSignupActionWarning({
+        authenticated: true,
+        signup: fakeSignup(),
+        signupGroup: fakeSignupGroup({
           paymentRefund: fakePaymentRefund(),
         }),
         t: i18n.t.bind(i18n),

--- a/src/domain/signup/editSignupButtonPanel/EditSignupButtonPanel.tsx
+++ b/src/domain/signup/editSignupButtonPanel/EditSignupButtonPanel.tsx
@@ -10,6 +10,7 @@ import { ROUTES } from '../../../constants';
 import {
   RegistrationFieldsFragment,
   SignupFieldsFragment,
+  useSignupGroupQuery,
 } from '../../../generated/graphql';
 import useGoBack from '../../../hooks/useGoBack';
 import getValue from '../../../utils/getValue';
@@ -45,6 +46,12 @@ const EditSignupButtonPanel: React.FC<EditSignupButtonPanelProps> = ({
   const publisher = getValue(registration.publisher, '');
   const { organizationAncestors } = useOrganizationAncestors(publisher);
 
+  const { data: signupGroupData } = useSignupGroupQuery({
+    skip: !signup.signupGroup,
+    variables: { id: signup.signupGroup as string },
+  });
+  const signupGroup = signupGroupData?.signupGroup;
+
   const goBack = useGoBack<SignupsLocationState>({
     defaultReturnPath: ROUTES.REGISTRATION_SIGNUPS.replace(
       ':registrationId',
@@ -67,6 +74,7 @@ const EditSignupButtonPanel: React.FC<EditSignupButtonPanelProps> = ({
       organizationAncestors,
       registration,
       signup,
+      signupGroup,
       t,
       user,
     });

--- a/src/domain/signup/permissions.ts
+++ b/src/domain/signup/permissions.ts
@@ -5,6 +5,7 @@ import {
   OrganizationFieldsFragment,
   RegistrationFieldsFragment,
   SignupFieldsFragment,
+  SignupGroupFieldsFragment,
   UserFieldsFragment,
 } from '../../generated/graphql';
 import { Editability } from '../../types';
@@ -61,12 +62,14 @@ export const getSignupActionWarning = ({
   action,
   authenticated,
   signup,
+  signupGroup,
   t,
   userCanDoAction,
 }: {
   action: SIGNUP_ACTIONS;
   authenticated: boolean;
   signup?: SignupFieldsFragment;
+  signupGroup?: SignupGroupFieldsFragment;
   t: TFunction;
   userCanDoAction: boolean;
 }): string => {
@@ -84,10 +87,10 @@ export const getSignupActionWarning = ({
         return t('signupsPage.warningNoRightsToEdit');
     }
   } else if (action === SIGNUP_ACTIONS.DELETE) {
-    if (signup?.paymentCancellation) {
+    if (signup?.paymentCancellation || signupGroup?.paymentCancellation) {
       return t('signupsPage.warningHasPaymentCancellation');
     }
-    if (signup?.paymentRefund) {
+    if (signup?.paymentRefund || signupGroup?.paymentRefund) {
       return t('signupsPage.warningHasPaymentRefund');
     }
   }
@@ -101,6 +104,7 @@ export const checkIsSignupActionAllowed = ({
   organizationAncestors,
   registration,
   signup,
+  signupGroup,
   t,
   user,
 }: {
@@ -109,6 +113,7 @@ export const checkIsSignupActionAllowed = ({
   organizationAncestors: OrganizationFieldsFragment[];
   registration: RegistrationFieldsFragment;
   signup?: SignupFieldsFragment;
+  signupGroup?: SignupGroupFieldsFragment;
   t: TFunction;
   user?: UserFieldsFragment;
 }): Editability => {
@@ -123,6 +128,7 @@ export const checkIsSignupActionAllowed = ({
     action,
     authenticated,
     signup,
+    signupGroup,
     t,
     userCanDoAction,
   });
@@ -137,6 +143,7 @@ export const getSignupActionButtonProps = ({
   organizationAncestors,
   registration,
   signup,
+  signupGroup,
   t,
   user,
 }: {
@@ -146,6 +153,7 @@ export const getSignupActionButtonProps = ({
   organizationAncestors: OrganizationFieldsFragment[];
   registration: RegistrationFieldsFragment;
   signup?: SignupFieldsFragment;
+  signupGroup?: SignupGroupFieldsFragment;
   t: TFunction;
   user?: UserFieldsFragment;
 }): MenuItemOptionProps => {
@@ -155,6 +163,7 @@ export const getSignupActionButtonProps = ({
     organizationAncestors,
     registration,
     signup,
+    signupGroup,
     t,
     user,
   });

--- a/src/domain/signupGroup/__tests__/permissions.test.ts
+++ b/src/domain/signupGroup/__tests__/permissions.test.ts
@@ -78,6 +78,7 @@ describe('getSignupGroupActionWarning function', () => {
         authenticated: true,
         signupGroup: fakeSignupGroup({
           signups: [
+            fakeSignup({ paymentCancellation: null }),
             fakeSignup({ paymentCancellation: fakePaymentCancellation() }),
           ],
         }),
@@ -95,7 +96,10 @@ describe('getSignupGroupActionWarning function', () => {
       getSignupGroupActionWarning({
         authenticated: true,
         signupGroup: fakeSignupGroup({
-          signups: [fakeSignup({ paymentRefund: fakePaymentRefund() })],
+          signups: [
+            fakeSignup({ paymentRefund: null }),
+            fakeSignup({ paymentRefund: fakePaymentRefund() }),
+          ],
         }),
         t: i18n.t.bind(i18n),
         userCanDoAction: true,

--- a/src/domain/signupGroup/__tests__/permissions.test.ts
+++ b/src/domain/signupGroup/__tests__/permissions.test.ts
@@ -5,6 +5,7 @@ import {
   fakePaymentCancellation,
   fakePaymentRefund,
   fakeRegistration,
+  fakeSignup,
   fakeSignupGroup,
   fakeUser,
 } from '../../../utils/mockDataUtils';
@@ -70,6 +71,40 @@ describe('getSignupGroupActionWarning function', () => {
       ).toBe(warning);
     }
   );
+
+  it('should return correct warning when trying to delete signup group with signup with payment cancellation', () => {
+    expect(
+      getSignupGroupActionWarning({
+        authenticated: true,
+        signupGroup: fakeSignupGroup({
+          signups: [
+            fakeSignup({ paymentCancellation: fakePaymentCancellation() }),
+          ],
+        }),
+        t: i18n.t.bind(i18n),
+        userCanDoAction: true,
+        action: SIGNUP_GROUP_ACTIONS.DELETE,
+      })
+    ).toBe(
+      'Osallistujaryhmän maksua perutaan eikä osallistujaryhmää voi poistaa.'
+    );
+  });
+
+  it('should return correct warning when trying to delete signup group with signup with with payment refund', () => {
+    expect(
+      getSignupGroupActionWarning({
+        authenticated: true,
+        signupGroup: fakeSignupGroup({
+          signups: [fakeSignup({ paymentRefund: fakePaymentRefund() })],
+        }),
+        t: i18n.t.bind(i18n),
+        userCanDoAction: true,
+        action: SIGNUP_GROUP_ACTIONS.DELETE,
+      })
+    ).toBe(
+      'Osallistujaryhmän maksua hyvitetään eikä osallistujaryhmää voi poistaa.'
+    );
+  });
 
   it('should return correct warning when trying to delete signup group with payment cancellation', () => {
     expect(

--- a/src/domain/signupGroup/permissions.ts
+++ b/src/domain/signupGroup/permissions.ts
@@ -116,10 +116,16 @@ export const getSignupGroupActionWarning = ({
         return t('signupGroup.warnings.noRightsToEdit');
     }
   } else if (action === SIGNUP_GROUP_ACTIONS.DELETE) {
-    if (signupGroup?.paymentCancellation) {
+    if (
+      signupGroup?.paymentCancellation ||
+      signupGroup?.signups?.some((signup) => signup?.paymentCancellation)
+    ) {
       return t('signupGroup.warnings.hasPaymentCancellation');
     }
-    if (signupGroup?.paymentRefund) {
+    if (
+      signupGroup?.paymentRefund ||
+      signupGroup?.signups?.some((signup) => signup?.paymentRefund)
+    ) {
       return t('signupGroup.warnings.hasPaymentRefund');
     }
   }

--- a/src/domain/signups/signupActionsDropdown/SignupActionsDropdown.tsx
+++ b/src/domain/signups/signupActionsDropdown/SignupActionsDropdown.tsx
@@ -9,6 +9,7 @@ import { ROUTES } from '../../../constants';
 import {
   RegistrationFieldsFragment,
   SignupFieldsFragment,
+  SignupGroupFieldsFragment,
 } from '../../../generated/graphql';
 import useLocale from '../../../hooks/useLocale';
 import useResetPageParamAndGoToPage from '../../../hooks/useResetPageParam';
@@ -31,12 +32,14 @@ export interface SignupActionsDropdownProps {
   className?: string;
   registration: RegistrationFieldsFragment;
   signup: SignupFieldsFragment;
+  signupGroup?: SignupGroupFieldsFragment;
 }
 
 const SignupActionsDropdown: React.FC<SignupActionsDropdownProps> = ({
   className,
   registration,
   signup,
+  signupGroup,
 }) => {
   const { t } = useTranslation();
   const { resetPageParamAndGoToPage } = useResetPageParamAndGoToPage();
@@ -87,6 +90,7 @@ const SignupActionsDropdown: React.FC<SignupActionsDropdownProps> = ({
       organizationAncestors,
       registration,
       signup,
+      signupGroup,
       t,
       user,
     });

--- a/src/domain/signups/signupsTable/SignupsTable.tsx
+++ b/src/domain/signups/signupsTable/SignupsTable.tsx
@@ -194,6 +194,30 @@ const AttendeeStatusColumn: FC<ColumnProps> = ({ registration, signup }) => {
   );
 };
 
+const SignupActionsDropdownColumn: FC<ColumnProps> = ({
+  registration,
+  signup,
+}) => {
+  const { data: signupGroupData, loading } = useSignupGroupQuery({
+    skip: !signup.signupGroup,
+    variables: { id: signup.signupGroup as string },
+  });
+
+  return (
+    <LoadingSpinner
+      className={styles.columnLoadingSpinner}
+      isLoading={loading}
+      small
+    >
+      <SignupActionsDropdown
+        registration={registration}
+        signup={signup}
+        signupGroup={signupGroupData?.signupGroup}
+      />
+    </LoadingSpinner>
+  );
+};
+
 export interface SignupsTableProps {
   caption: string;
   countKey: string;
@@ -308,9 +332,12 @@ const SignupsTable: React.FC<SignupsTableProps> = ({
     [registration]
   );
 
-  const MemoizedSignupActionsDropdown = React.useCallback(
+  const MemoizedSignupActionsDropdownColumn = React.useCallback(
     (signup: SignupFieldsFragment) => (
-      <SignupActionsDropdown registration={registration} signup={signup} />
+      <SignupActionsDropdownColumn
+        registration={registration}
+        signup={signup}
+      />
     ),
     [registration]
   );
@@ -355,7 +382,7 @@ const SignupsTable: React.FC<SignupsTableProps> = ({
           {
             key: 'actionButtons',
             headerName: t('common.actions'),
-            transform: MemoizedSignupActionsDropdown,
+            transform: MemoizedSignupActionsDropdownColumn,
           },
         ]}
         hasActionButtons


### PR DESCRIPTION
## Description
Don't allow to delete signup group if it has at least 1 signup which has a payment cancellation or refund
Don't allow to delete signup if it's part of signup group which has a payment cancellation or refund

## Closes
[LINK-2089](https://helsinkisolutionoffice.atlassian.net/browse/LINK-2089)

[LINK-2089]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-2089?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ