### PR TITLE
fix: submit registration does nothing LINK-2178

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /node_modules
 /.pnp
 .pnp.js
+/.yarn
 
 # testing
 /coverage

--- a/src/domain/signupGroup/validation.ts
+++ b/src/domain/signupGroup/validation.ts
@@ -139,7 +139,6 @@ export const getSignupSchema = (registration: RegistrationFieldsFragment) => {
       Yup.date()
         .nullable()
         .typeError(VALIDATION_MESSAGE_KEYS.DATE)
-        .required(VALIDATION_MESSAGE_KEYS.DATE_REQUIRED)
         .test(
           'isAboveMinAge',
           () => ({


### PR DESCRIPTION
## Description :sparkles:

## Issues :bug:

### Closes :no_good_woman:

**[LINK-2178](https://helsinkisolutionoffice.atlassian.net/browse/LINK-2178):**



## Testing :alembic:




### Automated tests :gear:️

### Manual testing :construction_worker_man:
Tested with event that has no age limits and with event that does.

- make a new event + registration
- add participant via linkedevents

Can use this:
https://linkedevents.dev.hel.ninja/en/registrations/224/signup-group/create?text=jep&returnPath=%2Fregistrations&returnPath=%2Fregistrations%2F224%2Fsignups
and this: 
https://linkedevents.dev.hel.ninja/en/registrations/226/signup-group/create?text=jep&returnPath=%2Fregistrations&returnPath=%2Fregistrations%2F226%2Fsignups

## Screenshots :camera_flash:
With the bug this submit button does nothing.  When fixed it works.
![Screenshot 2024-09-27 at 13 38 44](https://github.com/user-attachments/assets/a400484c-e560-40e2-b9d3-da8541240244)


## Additional notes :spiral_notepad:


[LINK-2178]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-2178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ