### PR TITLE
deps: bump @ckeditor/ckeditor5-build-classic to 43.1.1 LINK-2191

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@apollo/client": "^3.9.8",
-    "@ckeditor/ckeditor5-build-classic": "41.2.1",
+    "@ckeditor/ckeditor5-build-classic": "43.1.1",
     "@ckeditor/ckeditor5-react": "^6.2.0",
     "@datapunt/matomo-tracker-react": "^0.5.1",
     "@emotion/react": "^11.11.4",

--- a/src/common/components/textEditor/__tests__/TextEditor.test.tsx
+++ b/src/common/components/textEditor/__tests__/TextEditor.test.tsx
@@ -31,7 +31,9 @@ test('should call onChange', async () => {
   const onChange = vi.fn();
   renderComponent({ onChange });
 
-  const editor = await screen.findByLabelText(/editorin muokkausalue: main/i);
+  const editor = await screen.findByLabelText(
+    /tekstimuotoilueditori. muokkausalue: main/i
+  );
 
   pasteToTextEditor(editor, 'test');
 

--- a/src/domain/event/__tests__/CreateEventPage.test.tsx
+++ b/src/domain/event/__tests__/CreateEventPage.test.tsx
@@ -161,7 +161,9 @@ const findElement = (
 ) => {
   switch (key) {
     case 'description':
-      return screen.findByLabelText(/editorin muokkausalue: main/i);
+      return screen.findByLabelText(
+        /tekstimuotoilueditori. muokkausalue: main/i
+      );
     case 'name':
       return screen.findByLabelText(/tapahtuman otsikko suomeksi/i);
     case 'nameSv':

--- a/src/domain/event/formSections/descriptionSection/__tests__/DescriptionSection.test.tsx
+++ b/src/domain/event/formSections/descriptionSection/__tests__/DescriptionSection.test.tsx
@@ -106,7 +106,7 @@ const renderComponent = (
 };
 
 const findDescriptionFiInput = () =>
-  screen.findByLabelText(/editorin muokkausalue: main/i);
+  screen.findByLabelText(/tekstimuotoilueditori. muokkausalue: main/i);
 
 const getElement = (
   key: 'fiButton' | 'nameFi' | 'shortDescriptionFi' | 'svButton'

--- a/src/domain/signup/__tests__/EditSignupPage.test.tsx
+++ b/src/domain/signup/__tests__/EditSignupPage.test.tsx
@@ -194,7 +194,7 @@ test('should send message to participant', async () => {
   );
   const subjectInput = withinModal.getByLabelText(/Otsikko/i);
   const messageInput = await withinModal.findByLabelText(
-    /editorin muokkausalue: main/i
+    /tekstimuotoilueditori. muokkausalue: main/i
   );
   fireEvent.change(subjectInput, {
     target: { value: sendMessageValues.subject },

--- a/src/domain/signup/modals/sendMessageModal/__tests__/SendMessageModal.test.tsx
+++ b/src/domain/signup/modals/sendMessageModal/__tests__/SendMessageModal.test.tsx
@@ -29,7 +29,7 @@ const getModalElements = async () => {
   });
   const subjectInput = screen.getByLabelText(/Otsikko/i);
   const messageInput = await screen.findByLabelText(
-    /editorin muokkausalue: main/i
+    /tekstimuotoilueditori. muokkausalue: main/i
   );
   return {
     messageInput,

--- a/src/domain/signupGroup/__tests__/EditSignupGroupPage.test.tsx
+++ b/src/domain/signupGroup/__tests__/EditSignupGroupPage.test.tsx
@@ -130,7 +130,7 @@ test('should send message to signup group', async () => {
   );
   const subjectInput = withinModal.getByLabelText(/Otsikko/i);
   const messageInput = await withinModal.findByLabelText(
-    /editorin muokkausalue: main/i
+    /tekstimuotoilueditori. muokkausalue: main/i
   );
   fireEvent.change(subjectInput, {
     target: { value: sendMessageValues.subject },

--- a/src/domain/signups/__tests__/SignupsPage.test.tsx
+++ b/src/domain/signups/__tests__/SignupsPage.test.tsx
@@ -204,7 +204,7 @@ test('should send message to participants', async () => {
   );
   const subjectInput = withinModal.getByLabelText(/Otsikko/i);
   const messageInput = await withinModal.findByLabelText(
-    /editorin muokkausalue: main/i
+    /tekstimuotoilueditori. muokkausalue: main/i
   );
   fireEvent.change(subjectInput, {
     target: { value: sendMessageValues.subject },

--- a/src/domain/signups/signupActionsDropdown/__tests__/SignupActionsDropdown.test.tsx
+++ b/src/domain/signups/signupActionsDropdown/__tests__/SignupActionsDropdown.test.tsx
@@ -158,7 +158,7 @@ test('should send message to participant when clicking send message button', asy
   );
   const subjectInput = withinModal.getByLabelText(/Otsikko/i);
   const messageInput = await withinModal.findByLabelText(
-    /editorin muokkausalue: main/i
+    /tekstimuotoilueditori. muokkausalue: main/i
   );
   fireEvent.change(subjectInput, {
     target: { value: sendMessageValues.subject },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1202,205 +1202,486 @@
     "@babel/helper-validator-identifier" "^7.22.20"
     to-fast-properties "^2.0.0"
 
-"@ckeditor/ckeditor5-adapter-ckfinder@41.2.1":
-  version "41.2.1"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-adapter-ckfinder/-/ckeditor5-adapter-ckfinder-41.2.1.tgz#a2bfe3f527f24230bbf51d3662f4c251d2852ebe"
-  integrity sha512-TpbJ1eflEQEkp3gaReEUoBP8rYoByhyJ4sgKamSr8/V5fDM4tqWllN/5IFXCfd8FQFa/PhKQTfZlQI/+wu8Ggw==
+"@ckeditor/ckeditor5-adapter-ckfinder@43.1.1":
+  version "43.1.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-adapter-ckfinder/-/ckeditor5-adapter-ckfinder-43.1.1.tgz#f2e55874b5264cd735e1d10d93e083bfe2e6ab14"
+  integrity sha512-DCR98QdQKCYCQFT23CwR6PFLPLT3rlh89++hFIhUpykDz2pljEDC8uFNWjKY+b/5/P/jkTICLtt8+DlF8aN+/Q==
   dependencies:
-    ckeditor5 "41.2.1"
+    "@ckeditor/ckeditor5-core" "43.1.1"
+    "@ckeditor/ckeditor5-upload" "43.1.1"
+    ckeditor5 "43.1.1"
 
-"@ckeditor/ckeditor5-autoformat@41.2.1":
-  version "41.2.1"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-autoformat/-/ckeditor5-autoformat-41.2.1.tgz#7395da15b43309f798bd01bb1c9d38e835e4c873"
-  integrity sha512-PG+qu+qSzEpH69S6pcSOLO1nTqyTG2JqQLFrs+BlGfX7fryXeoZrLfIP5OQLZjQb1NMcPuzHSBSH1FgSXNTolw==
+"@ckeditor/ckeditor5-alignment@43.1.1":
+  version "43.1.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-alignment/-/ckeditor5-alignment-43.1.1.tgz#f7e5408b87f6c6fff4c0f9bb56ba1358358789ee"
+  integrity sha512-mjQPDmfPgKbMQp8JCR7Vg7MpRax44tSrtyoofSl/oMKDh2bXtwEnMKJlv501scl95S8VN2Pfnxj5+31N89j0Xg==
   dependencies:
-    ckeditor5 "41.2.1"
+    "@ckeditor/ckeditor5-core" "43.1.1"
+    "@ckeditor/ckeditor5-ui" "43.1.1"
+    "@ckeditor/ckeditor5-utils" "43.1.1"
+    ckeditor5 "43.1.1"
 
-"@ckeditor/ckeditor5-basic-styles@41.2.1":
-  version "41.2.1"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-basic-styles/-/ckeditor5-basic-styles-41.2.1.tgz#0af728105cafa6f5e77bebb8344fb22e5ef534a3"
-  integrity sha512-noOO9j3zyFbyEC96hwxk7vPSKruxIc5vBtKPwrn5kx9KNYJOO0l/tzAi+FmYww1W64nX5/V1g26FcLDQlb814A==
+"@ckeditor/ckeditor5-autoformat@43.1.1":
+  version "43.1.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-autoformat/-/ckeditor5-autoformat-43.1.1.tgz#9b1aac22e269c6b713576bf329f7a5228f4ff5b6"
+  integrity sha512-/NP29+d5y+AcffZEBJqH42Bj/M76OuBPG3DNEz9XEBbF9ADC9jqb2pYzDgiit/9VukNDtoLJjQ6HGxjdwzdLfg==
   dependencies:
-    ckeditor5 "41.2.1"
+    "@ckeditor/ckeditor5-core" "43.1.1"
+    "@ckeditor/ckeditor5-engine" "43.1.1"
+    "@ckeditor/ckeditor5-typing" "43.1.1"
+    "@ckeditor/ckeditor5-utils" "43.1.1"
+    ckeditor5 "43.1.1"
 
-"@ckeditor/ckeditor5-block-quote@41.2.1":
-  version "41.2.1"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-block-quote/-/ckeditor5-block-quote-41.2.1.tgz#77fe17021f1c2d940192150529e24a5f51434367"
-  integrity sha512-47dOvlnwgZcoYpOtyOypIAdH4WJaQyK93jTroJJyTrj6WNhz0BxvyWcJ4lWg0rBioQz7B9In4L4cfVkOjoSQFA==
+"@ckeditor/ckeditor5-autosave@43.1.1":
+  version "43.1.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-autosave/-/ckeditor5-autosave-43.1.1.tgz#fe946917b417a8b869c5c3c1acea970a31b981a7"
+  integrity sha512-GYeEF0NL0KLS33lZ4Uc4R2hAofTH+EE/Pulzg1V0rSIPghLNULsvMRiqe6PnzYDKtD5et1YpaIZRp55DGzJ/gQ==
   dependencies:
-    ckeditor5 "41.2.1"
+    "@ckeditor/ckeditor5-core" "43.1.1"
+    "@ckeditor/ckeditor5-utils" "43.1.1"
+    ckeditor5 "43.1.1"
+    lodash-es "4.17.21"
 
-"@ckeditor/ckeditor5-build-classic@41.2.1":
-  version "41.2.1"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-build-classic/-/ckeditor5-build-classic-41.2.1.tgz#2a706a6af4e48195d13f72c116796018dc039e5b"
-  integrity sha512-j3xe/JhjHmhvnrv3QYsCvxAPe7cligkovoH3SDBC0lkvawJW34IRNp77kBh2o7C9hlKjuuE7k9e8IE/fGBkR/g==
+"@ckeditor/ckeditor5-basic-styles@43.1.1":
+  version "43.1.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-basic-styles/-/ckeditor5-basic-styles-43.1.1.tgz#4e252f92f15822a8d840e83f6f1869fca4dc88ef"
+  integrity sha512-xFfL6JaVkkNRnFET/ld6MGvbifFxJY8bv3zvAAlphXsCBxNDH9cZWzG605PF6SYTucCUXD4dtW0teLMmdzklaQ==
   dependencies:
-    "@ckeditor/ckeditor5-adapter-ckfinder" "41.2.1"
-    "@ckeditor/ckeditor5-autoformat" "41.2.1"
-    "@ckeditor/ckeditor5-basic-styles" "41.2.1"
-    "@ckeditor/ckeditor5-block-quote" "41.2.1"
-    "@ckeditor/ckeditor5-ckbox" "41.2.1"
-    "@ckeditor/ckeditor5-ckfinder" "41.2.1"
-    "@ckeditor/ckeditor5-cloud-services" "41.2.1"
-    "@ckeditor/ckeditor5-easy-image" "41.2.1"
-    "@ckeditor/ckeditor5-editor-classic" "41.2.1"
-    "@ckeditor/ckeditor5-essentials" "41.2.1"
-    "@ckeditor/ckeditor5-heading" "41.2.1"
-    "@ckeditor/ckeditor5-image" "41.2.1"
-    "@ckeditor/ckeditor5-indent" "41.2.1"
-    "@ckeditor/ckeditor5-link" "41.2.1"
-    "@ckeditor/ckeditor5-list" "41.2.1"
-    "@ckeditor/ckeditor5-media-embed" "41.2.1"
-    "@ckeditor/ckeditor5-paragraph" "41.2.1"
-    "@ckeditor/ckeditor5-paste-from-office" "41.2.1"
-    "@ckeditor/ckeditor5-table" "41.2.1"
-    "@ckeditor/ckeditor5-typing" "41.2.1"
+    "@ckeditor/ckeditor5-core" "43.1.1"
+    "@ckeditor/ckeditor5-typing" "43.1.1"
+    "@ckeditor/ckeditor5-ui" "43.1.1"
+    ckeditor5 "43.1.1"
 
-"@ckeditor/ckeditor5-ckbox@41.2.1":
-  version "41.2.1"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-ckbox/-/ckeditor5-ckbox-41.2.1.tgz#e8bd4f590955e53f6faf688db786c2a1e5bb6325"
-  integrity sha512-Te/DK88vF+uaGf1uOkaU/qIChqEHOnf2XwylgE0JGwxUaeVfhCtFe79xlZwXLYze299CINqAAdVC54/pL8uT2g==
+"@ckeditor/ckeditor5-block-quote@43.1.1":
+  version "43.1.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-block-quote/-/ckeditor5-block-quote-43.1.1.tgz#c7dd939f5579e470048bfa519c506a6a58089673"
+  integrity sha512-VYZlQisRptiiqVRnMVBcwc3yRilpSoFTKiMXTzrYukUZLhPL6fiWVeMe/N9ygtdtGp3oYF/rSNv9H/8e6nNVYw==
   dependencies:
+    "@ckeditor/ckeditor5-core" "43.1.1"
+    "@ckeditor/ckeditor5-enter" "43.1.1"
+    "@ckeditor/ckeditor5-typing" "43.1.1"
+    "@ckeditor/ckeditor5-ui" "43.1.1"
+    "@ckeditor/ckeditor5-utils" "43.1.1"
+    ckeditor5 "43.1.1"
+
+"@ckeditor/ckeditor5-build-classic@43.1.1":
+  version "43.1.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-build-classic/-/ckeditor5-build-classic-43.1.1.tgz#5f21da30c9c9d1b448ce0a88b732922cf23182de"
+  integrity sha512-yCg+5u2ihdunYxieHsgHWACXbTMQZajy23wtGAuED7Tv+Uf41XPmBmQLoXSY43LyQOeSNvgEFdb6lUrl5Gi05w==
+  dependencies:
+    "@ckeditor/ckeditor5-adapter-ckfinder" "43.1.1"
+    "@ckeditor/ckeditor5-autoformat" "43.1.1"
+    "@ckeditor/ckeditor5-basic-styles" "43.1.1"
+    "@ckeditor/ckeditor5-block-quote" "43.1.1"
+    "@ckeditor/ckeditor5-ckbox" "43.1.1"
+    "@ckeditor/ckeditor5-ckfinder" "43.1.1"
+    "@ckeditor/ckeditor5-cloud-services" "43.1.1"
+    "@ckeditor/ckeditor5-easy-image" "43.1.1"
+    "@ckeditor/ckeditor5-editor-classic" "43.1.1"
+    "@ckeditor/ckeditor5-essentials" "43.1.1"
+    "@ckeditor/ckeditor5-heading" "43.1.1"
+    "@ckeditor/ckeditor5-image" "43.1.1"
+    "@ckeditor/ckeditor5-indent" "43.1.1"
+    "@ckeditor/ckeditor5-link" "43.1.1"
+    "@ckeditor/ckeditor5-list" "43.1.1"
+    "@ckeditor/ckeditor5-media-embed" "43.1.1"
+    "@ckeditor/ckeditor5-paragraph" "43.1.1"
+    "@ckeditor/ckeditor5-paste-from-office" "43.1.1"
+    "@ckeditor/ckeditor5-table" "43.1.1"
+    "@ckeditor/ckeditor5-typing" "43.1.1"
+
+"@ckeditor/ckeditor5-ckbox@43.1.1":
+  version "43.1.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-ckbox/-/ckeditor5-ckbox-43.1.1.tgz#3b16cb4d130da8b67833322471ce77a2bfb881d6"
+  integrity sha512-2suCDhe5HlutZz52iBXRaVAcht/E4wBdZsF6ZL+hELNuqvYM2PCb2/FZTtxQb50mDlWtJtLidRc49COAr0k1QA==
+  dependencies:
+    "@ckeditor/ckeditor5-core" "43.1.1"
+    "@ckeditor/ckeditor5-engine" "43.1.1"
+    "@ckeditor/ckeditor5-ui" "43.1.1"
+    "@ckeditor/ckeditor5-upload" "43.1.1"
+    "@ckeditor/ckeditor5-utils" "43.1.1"
     blurhash "2.0.5"
-    ckeditor5 "41.2.1"
+    ckeditor5 "43.1.1"
     lodash-es "4.17.21"
 
-"@ckeditor/ckeditor5-ckfinder@41.2.1":
-  version "41.2.1"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-ckfinder/-/ckeditor5-ckfinder-41.2.1.tgz#4e6259d14af6de8c454b79a034f05b7342a4032a"
-  integrity sha512-qAUmlnNaX/nXieHCIHDH7EfU0TzRjFKKsQbPGIC9WCBtO6SEKrZRIaE4FGnBq4HQkacfnPK6gFPWzY8Kx2Bvug==
+"@ckeditor/ckeditor5-ckfinder@43.1.1":
+  version "43.1.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-ckfinder/-/ckeditor5-ckfinder-43.1.1.tgz#a2070ce26e852864e24fade16468d6852b31e505"
+  integrity sha512-f5N9FtJTSRfEUaJqr0LpekoSAIMktyiwbWeGQhbYseCCV0+Qsw6W/wzuWMFNe5GELg0R/0tG0H59/2m1wTFFbw==
   dependencies:
-    ckeditor5 "41.2.1"
+    "@ckeditor/ckeditor5-core" "43.1.1"
+    "@ckeditor/ckeditor5-ui" "43.1.1"
+    "@ckeditor/ckeditor5-utils" "43.1.1"
+    ckeditor5 "43.1.1"
 
-"@ckeditor/ckeditor5-clipboard@41.2.1":
-  version "41.2.1"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-41.2.1.tgz#c085f13c2d093759f53ad7332e98555d8544a84b"
-  integrity sha512-ZhmkwxFd+wDK5Wa+uqfHsMzXHnAvJWjGNNggbHcA2sxPQEifTVQaA06Ritmm37qCkDdIxcriDBx2OL5ATkMxGQ==
+"@ckeditor/ckeditor5-clipboard@43.1.1":
+  version "43.1.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-43.1.1.tgz#4df3e73d0bb138f3c56c83348fc1eeba45b98531"
+  integrity sha512-QF0zyq/NhLFm8V/VBBn+RWjiaAd5eyeCKz7zQKyBcSW27IaazAnG0+HHZeydZkT4vntad71t6bi6ZWzL/MJxwg==
   dependencies:
-    "@ckeditor/ckeditor5-core" "41.2.1"
-    "@ckeditor/ckeditor5-engine" "41.2.1"
-    "@ckeditor/ckeditor5-ui" "41.2.1"
-    "@ckeditor/ckeditor5-utils" "41.2.1"
-    "@ckeditor/ckeditor5-widget" "41.2.1"
+    "@ckeditor/ckeditor5-core" "43.1.1"
+    "@ckeditor/ckeditor5-engine" "43.1.1"
+    "@ckeditor/ckeditor5-ui" "43.1.1"
+    "@ckeditor/ckeditor5-utils" "43.1.1"
+    "@ckeditor/ckeditor5-widget" "43.1.1"
     lodash-es "4.17.21"
 
-"@ckeditor/ckeditor5-cloud-services@41.2.1":
-  version "41.2.1"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-cloud-services/-/ckeditor5-cloud-services-41.2.1.tgz#e251de546e8abd59b29c6e802d47a0da8cb28d6a"
-  integrity sha512-kfTQKTQQxTUxhb87ckFLV9aMrH5Tn+JswzI1q9M0I8MZQVPq7anMXYbfGrY2eRNo8Fi55MbvCwf2dlJXCbZkKg==
+"@ckeditor/ckeditor5-cloud-services@43.1.1":
+  version "43.1.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-cloud-services/-/ckeditor5-cloud-services-43.1.1.tgz#142ea611e8c53ace1dd956eafdc0b8327424bf3b"
+  integrity sha512-YprETdoRcu/2yxVCuoOrY+f4G0Qus0hIMfMuRZ9jbFWDDwZgHiXrFXvE0W9o9N51rKffWnTbs0GljsaXVit1+g==
   dependencies:
-    ckeditor5 "41.2.1"
+    "@ckeditor/ckeditor5-core" "43.1.1"
+    "@ckeditor/ckeditor5-utils" "43.1.1"
+    ckeditor5 "43.1.1"
 
-"@ckeditor/ckeditor5-core@41.2.1":
-  version "41.2.1"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-core/-/ckeditor5-core-41.2.1.tgz#908e04b5c933539c7a5edcaaa6e464bf0c405292"
-  integrity sha512-h75yyYy17a8Zj7SayWcNCevzD/JKosHGDIeGQht4R0HxfT+/108AGxRA8ELpAaiPTvb9uoOLSQg5DiM/hPjHuQ==
+"@ckeditor/ckeditor5-code-block@43.1.1":
+  version "43.1.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-code-block/-/ckeditor5-code-block-43.1.1.tgz#a17d4b30e746e4f37d28a5fc8a29d840d202c15c"
+  integrity sha512-Nil+MNeirroHop5Onj23L2v17Jokgc6wvJYqzH+85OvlrJeEsfFauxlW+S6TI3ypZT04yLJ0zdpaZ/FYC5+NxA==
   dependencies:
-    "@ckeditor/ckeditor5-engine" "41.2.1"
-    "@ckeditor/ckeditor5-utils" "41.2.1"
+    "@ckeditor/ckeditor5-clipboard" "43.1.1"
+    "@ckeditor/ckeditor5-core" "43.1.1"
+    "@ckeditor/ckeditor5-engine" "43.1.1"
+    "@ckeditor/ckeditor5-enter" "43.1.1"
+    "@ckeditor/ckeditor5-ui" "43.1.1"
+    "@ckeditor/ckeditor5-utils" "43.1.1"
+    ckeditor5 "43.1.1"
+
+"@ckeditor/ckeditor5-core@43.1.1":
+  version "43.1.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-core/-/ckeditor5-core-43.1.1.tgz#b5cfe4cd75f400043416da8299e610cea9a9be82"
+  integrity sha512-qtbnD+24dK+ANVUgs+unZ0qX64NA0eG6k344q8fhXuHdPRKk55BDkjdmpv/Fh9Y0beo9EDqUPE/P7agv8lucBg==
+  dependencies:
+    "@ckeditor/ckeditor5-engine" "43.1.1"
+    "@ckeditor/ckeditor5-utils" "43.1.1"
+    "@ckeditor/ckeditor5-watchdog" "43.1.1"
     lodash-es "4.17.21"
 
-"@ckeditor/ckeditor5-easy-image@41.2.1":
-  version "41.2.1"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-easy-image/-/ckeditor5-easy-image-41.2.1.tgz#7ea356ec3715ae33e58a25983c17c3274ea69bba"
-  integrity sha512-m4GKKtkipdnh0tGf1TOZJVRkaH3h6Zeq6jaq2JJ1BGmUbdX0TtHrTPhdzm/3xfyJF8HcF685NqYSi1jnl1Zl4g==
+"@ckeditor/ckeditor5-easy-image@43.1.1":
+  version "43.1.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-easy-image/-/ckeditor5-easy-image-43.1.1.tgz#a1d1a7871e6e9842eaa3b247722bf24b7165c4ee"
+  integrity sha512-BSiqxe6rFzNIROz7uny8SyGndQX070hlktJT5sQNO46lB+tsyFScUVXjzduSlm2fCG/2PFA83skR3/7cTAkBbg==
   dependencies:
-    ckeditor5 "41.2.1"
+    "@ckeditor/ckeditor5-core" "43.1.1"
+    "@ckeditor/ckeditor5-upload" "43.1.1"
+    "@ckeditor/ckeditor5-utils" "43.1.1"
+    ckeditor5 "43.1.1"
 
-"@ckeditor/ckeditor5-editor-classic@41.2.1":
-  version "41.2.1"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-editor-classic/-/ckeditor5-editor-classic-41.2.1.tgz#5c9156bd75a5abd6bd0774563e11a8bac237ea94"
-  integrity sha512-csja7Iy2fEtiuTyLp6GJuJW087XTu2azqGGnZzjQFkKIOWCEYlffStvWDb8vZfYasfltME8pSbGw4UYvWLeWfw==
+"@ckeditor/ckeditor5-editor-balloon@43.1.1":
+  version "43.1.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-editor-balloon/-/ckeditor5-editor-balloon-43.1.1.tgz#c2572b0776872b87d56faa4a473da187c96e76f8"
+  integrity sha512-hIfocf3a/zXj1SLElF58LIVXOP3GphpajrsNXysSxccb4LNUQjvqMqwYaHDkib0Oh4AznsCwfBE3CJ3grUiI4g==
   dependencies:
-    ckeditor5 "41.2.1"
+    "@ckeditor/ckeditor5-core" "43.1.1"
+    "@ckeditor/ckeditor5-engine" "43.1.1"
+    "@ckeditor/ckeditor5-ui" "43.1.1"
+    "@ckeditor/ckeditor5-utils" "43.1.1"
+    ckeditor5 "43.1.1"
     lodash-es "4.17.21"
 
-"@ckeditor/ckeditor5-engine@41.2.1":
-  version "41.2.1"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-41.2.1.tgz#e385298975b607feb9600c55d270ad0d06dbb36a"
-  integrity sha512-p2XtuSL7TGzgKHWPV/N8M0bX0I/ygmBTZ+D90TwqgW8cKCNYCTluQvceAleoRJAuovPK/KAi8OeDj/TjXXkakA==
+"@ckeditor/ckeditor5-editor-classic@43.1.1":
+  version "43.1.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-editor-classic/-/ckeditor5-editor-classic-43.1.1.tgz#96e6f1acbe33697360cf578fcd5ce85aa83d66ac"
+  integrity sha512-8/yuGbTtY/BF4Oi5wDd9/NHNmIvtb+f5YvqSkG7ZtWy0M+uHru8xM7hhUqUKwrG2jVxB2MFRcDGAE0YlVqs98Q==
   dependencies:
-    "@ckeditor/ckeditor5-utils" "41.2.1"
+    "@ckeditor/ckeditor5-core" "43.1.1"
+    "@ckeditor/ckeditor5-engine" "43.1.1"
+    "@ckeditor/ckeditor5-ui" "43.1.1"
+    "@ckeditor/ckeditor5-utils" "43.1.1"
+    ckeditor5 "43.1.1"
     lodash-es "4.17.21"
 
-"@ckeditor/ckeditor5-enter@41.2.1":
-  version "41.2.1"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-41.2.1.tgz#1c6a4a1750cbba2518ac98073b74e2c1d7f02c55"
-  integrity sha512-3YUmf3Vd5xMfA8MUau97tvmNCMH5Kbmqz44gq0ekAF8BATVGxA5c8OJR6ZxaTarZJX7mY1WaPeP3Vifre3no5w==
+"@ckeditor/ckeditor5-editor-decoupled@43.1.1":
+  version "43.1.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-editor-decoupled/-/ckeditor5-editor-decoupled-43.1.1.tgz#37b89fdef5d13b4c49b751da6850a965fb122b71"
+  integrity sha512-Vs7yVUjOM+QiwnS6v987YGen0xwku07pQyhl+ihW6cphJymaJ/kPNvkR2ZCfE5e/Av0ckz14DQj4vOmotx+Vxg==
   dependencies:
-    "@ckeditor/ckeditor5-core" "41.2.1"
-    "@ckeditor/ckeditor5-engine" "41.2.1"
-    "@ckeditor/ckeditor5-utils" "41.2.1"
-
-"@ckeditor/ckeditor5-essentials@41.2.1":
-  version "41.2.1"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-essentials/-/ckeditor5-essentials-41.2.1.tgz#576ccb347c93adb73bfb55abc03fc052b73c60bf"
-  integrity sha512-EQIuOI593YmmaZxwSSSkiE9J95VJS3aoGVv4mWohltKzuG/ayVWYqV2Y+KdRRyubAKPQ4YiFkrBIzcnS4ND0ng==
-  dependencies:
-    ckeditor5 "41.2.1"
-
-"@ckeditor/ckeditor5-heading@41.2.1":
-  version "41.2.1"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-heading/-/ckeditor5-heading-41.2.1.tgz#84ed4778b41ef413156aeea9a8601181488fe377"
-  integrity sha512-Y9mVFvgWGfTU/kCTY8WLKnDzUYV3KlkmxvVp8DCi8zcdh5gMOSd5u/hnO5Z0EB5A0Y8JLzVFtKv6L24MEXDkhg==
-  dependencies:
-    ckeditor5 "41.2.1"
-
-"@ckeditor/ckeditor5-image@41.2.1":
-  version "41.2.1"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-image/-/ckeditor5-image-41.2.1.tgz#fdc63eafc2d1cac1ca73ecf4465aff642684abbf"
-  integrity sha512-zls7WGvP1nQ2Qh8cj9TcqBoPW4ELIMizw1PyJQcG7lqymMEHDb21bwICk1eSAEqp0o16mAFBdNKKNzOd17CIgg==
-  dependencies:
-    "@ckeditor/ckeditor5-ui" "41.2.1"
-    ckeditor5 "41.2.1"
+    "@ckeditor/ckeditor5-core" "43.1.1"
+    "@ckeditor/ckeditor5-engine" "43.1.1"
+    "@ckeditor/ckeditor5-ui" "43.1.1"
+    "@ckeditor/ckeditor5-utils" "43.1.1"
+    ckeditor5 "43.1.1"
     lodash-es "4.17.21"
 
-"@ckeditor/ckeditor5-indent@41.2.1":
-  version "41.2.1"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-indent/-/ckeditor5-indent-41.2.1.tgz#9f6115ba8b07b19f738fc473624f8e11c50935c4"
-  integrity sha512-3kFrufnqt2nRCID+up6iy+Fp2OJgXkrtbKMbqYd4fHD0wuhD8MxqMvo5AmFBNXhlhO7YXns8Gmpps38WfD7UrA==
+"@ckeditor/ckeditor5-editor-inline@43.1.1":
+  version "43.1.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-editor-inline/-/ckeditor5-editor-inline-43.1.1.tgz#364cab7ab8aefa88876b282dfd2c8ba2db013a88"
+  integrity sha512-6rNUJPG23c0Nm4cbb5ReYiARhBk8crdpkYig6sR+8m//ah9SzO0H4H/brHtYHsV6FxOYDwxEJdaMSDP7rWUwkQ==
   dependencies:
-    ckeditor5 "41.2.1"
-
-"@ckeditor/ckeditor5-link@41.2.1":
-  version "41.2.1"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-link/-/ckeditor5-link-41.2.1.tgz#4159e4ed4282ef253d68d20841ebce3300f6e63f"
-  integrity sha512-rbYvzFQMD9hnYl+n21bO1/Vjgkj1S9vhv6WKukYOphHb45+g/7hcaQSjbEjcPMUu/qQYAOqK2SvrEGvFW9582Q==
-  dependencies:
-    "@ckeditor/ckeditor5-ui" "41.2.1"
-    ckeditor5 "41.2.1"
+    "@ckeditor/ckeditor5-core" "43.1.1"
+    "@ckeditor/ckeditor5-engine" "43.1.1"
+    "@ckeditor/ckeditor5-ui" "43.1.1"
+    "@ckeditor/ckeditor5-utils" "43.1.1"
+    ckeditor5 "43.1.1"
     lodash-es "4.17.21"
 
-"@ckeditor/ckeditor5-list@41.2.1":
-  version "41.2.1"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-list/-/ckeditor5-list-41.2.1.tgz#5c325216a588ec41f460fe3b857e8ef05d4abf7d"
-  integrity sha512-KM/B2osFTUi3I8ONyyJdhPd6sygBeplZt1IW5W/3QmDp+LDJqGg1pNDroo1ePIDlf6e67+OfW82pAuvtxmB11Q==
+"@ckeditor/ckeditor5-editor-multi-root@43.1.1":
+  version "43.1.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-editor-multi-root/-/ckeditor5-editor-multi-root-43.1.1.tgz#a762735d38555f9b48c760f01b6ded5829cc9c29"
+  integrity sha512-M1NBPFLZZAVJt22Ipy/JYTeOPPGCRDy3nWnCoBR2U79/FkEQNRyUtkR58EA4dLHdaeAiaWX8w7z2DrLKxOUltw==
   dependencies:
-    ckeditor5 "41.2.1"
+    "@ckeditor/ckeditor5-core" "43.1.1"
+    "@ckeditor/ckeditor5-engine" "43.1.1"
+    "@ckeditor/ckeditor5-ui" "43.1.1"
+    "@ckeditor/ckeditor5-utils" "43.1.1"
+    ckeditor5 "43.1.1"
+    lodash-es "4.17.21"
 
-"@ckeditor/ckeditor5-media-embed@41.2.1":
-  version "41.2.1"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-media-embed/-/ckeditor5-media-embed-41.2.1.tgz#ab42ac2d7b4d35e14b26cc5e55a0b2008e1402e6"
-  integrity sha512-L1EFVVMiJ0yrGJFrzJAdAxOJJaGVlj5D3ZJD8aE++M/keRGCq5xOmiG5LTRRIhqgF22Hwq6xsMxqT5b132ZqFQ==
+"@ckeditor/ckeditor5-engine@43.1.1":
+  version "43.1.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-43.1.1.tgz#4dd8c0d66559b5ca3a77531867d9328525f2d77b"
+  integrity sha512-gOqbGwEqbJDgbSRM0Dv3ArQRGTmX2pySNdQIseLnENVaq9r5FUu9T2moKYJbGl8t/DIqBAxOtdHQPafrXtk7yg==
   dependencies:
-    "@ckeditor/ckeditor5-ui" "41.2.1"
-    ckeditor5 "41.2.1"
+    "@ckeditor/ckeditor5-utils" "43.1.1"
+    lodash-es "4.17.21"
 
-"@ckeditor/ckeditor5-paragraph@41.2.1":
-  version "41.2.1"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-paragraph/-/ckeditor5-paragraph-41.2.1.tgz#8a4da3459795a924ada3491c3ab4e67aa249899a"
-  integrity sha512-j6OdPBFlA7BzU5wSmYFNfTuQbr64kq1uuTyDwXUvfQQvUqTAiA05sqWEzV1hc14Kc6uqVfoCFsYFI7xUEaaNvw==
+"@ckeditor/ckeditor5-enter@43.1.1":
+  version "43.1.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-43.1.1.tgz#c3674da120149b089b240393bd422a3594eacfd7"
+  integrity sha512-7JjNCe4qVtiLgnGC8P5WJzcDGTOXzgpos8nPSR52vsqNANNZQ/iAByDoPP7WCIijJHHjeFoBk0ytk2qfXppjkw==
   dependencies:
-    "@ckeditor/ckeditor5-core" "41.2.1"
-    "@ckeditor/ckeditor5-ui" "41.2.1"
-    "@ckeditor/ckeditor5-utils" "41.2.1"
+    "@ckeditor/ckeditor5-core" "43.1.1"
+    "@ckeditor/ckeditor5-engine" "43.1.1"
+    "@ckeditor/ckeditor5-utils" "43.1.1"
 
-"@ckeditor/ckeditor5-paste-from-office@41.2.1":
-  version "41.2.1"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-paste-from-office/-/ckeditor5-paste-from-office-41.2.1.tgz#7e94b09fd02cfbcae2d085cdae53096a812a5de4"
-  integrity sha512-grT0W/ammC9PNa6u/9vPY9u5BX4y3ZpHAAgziirvZNaFNswzeXBNEIBGzTS0qK+7111eBEy255O+T4S6okBmCQ==
+"@ckeditor/ckeditor5-essentials@43.1.1":
+  version "43.1.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-essentials/-/ckeditor5-essentials-43.1.1.tgz#8f6664b801f409b69e1fc836c81a0436da02b9fc"
+  integrity sha512-qbo080qotWmq19SnUkFspT9swHy2160nHFOdtx4LrQtGPbjSzS2EBFNHmkf31gUmEcNZCbegSIl0UT5IvIIV8g==
   dependencies:
-    ckeditor5 "41.2.1"
+    "@ckeditor/ckeditor5-clipboard" "43.1.1"
+    "@ckeditor/ckeditor5-core" "43.1.1"
+    "@ckeditor/ckeditor5-enter" "43.1.1"
+    "@ckeditor/ckeditor5-select-all" "43.1.1"
+    "@ckeditor/ckeditor5-typing" "43.1.1"
+    "@ckeditor/ckeditor5-ui" "43.1.1"
+    "@ckeditor/ckeditor5-undo" "43.1.1"
+    ckeditor5 "43.1.1"
+
+"@ckeditor/ckeditor5-find-and-replace@43.1.1":
+  version "43.1.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-find-and-replace/-/ckeditor5-find-and-replace-43.1.1.tgz#18126d4a369645a540620c3a60771417a1c00300"
+  integrity sha512-BmSwyTsL5fAo4I2gRq7gzbU+WNAoaxWOPZCip/cGNdqzV9Utl6kTLx/DdxAhh8B4KTj8Rqv8Cmg1862HMkfKkw==
+  dependencies:
+    "@ckeditor/ckeditor5-core" "43.1.1"
+    "@ckeditor/ckeditor5-ui" "43.1.1"
+    "@ckeditor/ckeditor5-utils" "43.1.1"
+    ckeditor5 "43.1.1"
+    lodash-es "4.17.21"
+
+"@ckeditor/ckeditor5-font@43.1.1":
+  version "43.1.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-font/-/ckeditor5-font-43.1.1.tgz#3badff6838b6cdc818e7508be90f8a1cc74ff59b"
+  integrity sha512-QQrLf3zWp1T0QttKdFoC/fbEF69hzsHxNzmOeGVwAavgW0qpbpSEvTT5kRHm1tYlGeSR8N6/SVXgb4xHUxwvHg==
+  dependencies:
+    "@ckeditor/ckeditor5-core" "43.1.1"
+    "@ckeditor/ckeditor5-engine" "43.1.1"
+    "@ckeditor/ckeditor5-ui" "43.1.1"
+    "@ckeditor/ckeditor5-utils" "43.1.1"
+    ckeditor5 "43.1.1"
+
+"@ckeditor/ckeditor5-heading@43.1.1":
+  version "43.1.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-heading/-/ckeditor5-heading-43.1.1.tgz#4884a625c7bd8312c4760e60d1b69764c2d989d1"
+  integrity sha512-Gr4rxChoamevxNf/6DKRYltOcLuCqrqFOCWrOO00JRHN8dHW81TgMJVGf4xeM4bAlFbMSqM3Y2vRCPhtdTAarA==
+  dependencies:
+    "@ckeditor/ckeditor5-core" "43.1.1"
+    "@ckeditor/ckeditor5-engine" "43.1.1"
+    "@ckeditor/ckeditor5-paragraph" "43.1.1"
+    "@ckeditor/ckeditor5-ui" "43.1.1"
+    "@ckeditor/ckeditor5-utils" "43.1.1"
+    ckeditor5 "43.1.1"
+
+"@ckeditor/ckeditor5-highlight@43.1.1":
+  version "43.1.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-highlight/-/ckeditor5-highlight-43.1.1.tgz#8bad3eec647e693e5cb2d94ecd8fc9256f847428"
+  integrity sha512-hrzzTQ1tAHIUGdNingpyMsrBeb3herfSMXOGylkkTqg/SqtnUlVJbPZ8NVUrmlw6hQQMl7HDqBJGdHoesvB8TA==
+  dependencies:
+    "@ckeditor/ckeditor5-core" "43.1.1"
+    "@ckeditor/ckeditor5-ui" "43.1.1"
+    ckeditor5 "43.1.1"
+
+"@ckeditor/ckeditor5-horizontal-line@43.1.1":
+  version "43.1.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-horizontal-line/-/ckeditor5-horizontal-line-43.1.1.tgz#4ea8dd16e1c449adfaf55a59cb42d1fe60333848"
+  integrity sha512-FLTTPShC+/E/fAUYAxyMHOLDYCYAAuB3eXHonPekXjiAdkhchPibkIz0c3DgdjRGFhfGE4/XQ4PyU5oa5BKt5w==
+  dependencies:
+    "@ckeditor/ckeditor5-core" "43.1.1"
+    "@ckeditor/ckeditor5-ui" "43.1.1"
+    "@ckeditor/ckeditor5-widget" "43.1.1"
+    ckeditor5 "43.1.1"
+
+"@ckeditor/ckeditor5-html-embed@43.1.1":
+  version "43.1.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-html-embed/-/ckeditor5-html-embed-43.1.1.tgz#7919f714c5edeaf38ce228a61f5a4d6d2c587277"
+  integrity sha512-ggOFwmpNAiT0nwm/++GZR/9V256mHxA0l7riL422l9YOSToGf5kukemsc7PIifuNoBXCzFrkNipr53ctxZkomA==
+  dependencies:
+    "@ckeditor/ckeditor5-core" "43.1.1"
+    "@ckeditor/ckeditor5-ui" "43.1.1"
+    "@ckeditor/ckeditor5-utils" "43.1.1"
+    "@ckeditor/ckeditor5-widget" "43.1.1"
+    ckeditor5 "43.1.1"
+
+"@ckeditor/ckeditor5-html-support@43.1.1":
+  version "43.1.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-html-support/-/ckeditor5-html-support-43.1.1.tgz#cd28a123b260d6aca98ef8e0ea8c5eb023d0d395"
+  integrity sha512-eF2eZU6sbU0ml+z8nSd7cDhk3ihrV9R7gih/bWOGvWa94bpaNVOd4c7e3F0ZPQVlxfwT1X99Y7aDNSNcbWs53A==
+  dependencies:
+    "@ckeditor/ckeditor5-core" "43.1.1"
+    "@ckeditor/ckeditor5-engine" "43.1.1"
+    "@ckeditor/ckeditor5-enter" "43.1.1"
+    "@ckeditor/ckeditor5-utils" "43.1.1"
+    "@ckeditor/ckeditor5-widget" "43.1.1"
+    ckeditor5 "43.1.1"
+    lodash-es "4.17.21"
+
+"@ckeditor/ckeditor5-image@43.1.1":
+  version "43.1.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-image/-/ckeditor5-image-43.1.1.tgz#47ed8c6966ce6fec870ec07f98fb69ade0082976"
+  integrity sha512-6xOJsG9nYIIpwf/Kj0MARts5KK+eZ+awpAvljYgx+xjII4KEAO1dKSKjX5Fmx3zjDWieJelbLit9tvQTcqyq8A==
+  dependencies:
+    "@ckeditor/ckeditor5-clipboard" "43.1.1"
+    "@ckeditor/ckeditor5-core" "43.1.1"
+    "@ckeditor/ckeditor5-engine" "43.1.1"
+    "@ckeditor/ckeditor5-typing" "43.1.1"
+    "@ckeditor/ckeditor5-ui" "43.1.1"
+    "@ckeditor/ckeditor5-undo" "43.1.1"
+    "@ckeditor/ckeditor5-upload" "43.1.1"
+    "@ckeditor/ckeditor5-utils" "43.1.1"
+    "@ckeditor/ckeditor5-widget" "43.1.1"
+    ckeditor5 "43.1.1"
+    lodash-es "4.17.21"
+
+"@ckeditor/ckeditor5-indent@43.1.1":
+  version "43.1.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-indent/-/ckeditor5-indent-43.1.1.tgz#ac1055eee6682f93141939001277c35f307bcb0f"
+  integrity sha512-8UjEX0TlnQgxzRkIAwJMcrc4rQSrpFuxUmo4b4xWIuzTg2p/+XdmDebi1p0AekB14ZW9J4UjB0U8NTWJQ++NyA==
+  dependencies:
+    "@ckeditor/ckeditor5-core" "43.1.1"
+    "@ckeditor/ckeditor5-engine" "43.1.1"
+    "@ckeditor/ckeditor5-ui" "43.1.1"
+    "@ckeditor/ckeditor5-utils" "43.1.1"
+    ckeditor5 "43.1.1"
+
+"@ckeditor/ckeditor5-language@43.1.1":
+  version "43.1.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-language/-/ckeditor5-language-43.1.1.tgz#7ef62001c3a3780352c70b20d848609d7cdfb845"
+  integrity sha512-lNqZn3rTmGDPEvZwAZZF6R1CkhnAh0cPXU4kuIs0+sshUcWGTQTO1l38Qzr4BGLrH1u7S2OilDe5GwfujF2vaA==
+  dependencies:
+    "@ckeditor/ckeditor5-core" "43.1.1"
+    "@ckeditor/ckeditor5-ui" "43.1.1"
+    "@ckeditor/ckeditor5-utils" "43.1.1"
+    ckeditor5 "43.1.1"
+
+"@ckeditor/ckeditor5-link@43.1.1":
+  version "43.1.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-link/-/ckeditor5-link-43.1.1.tgz#1165ae83e9e07df25ec2bf91e3151d123ae5e44e"
+  integrity sha512-pk/ginodZGD8H5ezH9uhPjV7bK2wKkx80Eno9pt/c05+rsrHOjcibrS+SXBQ6qbK/W6Zo9ZUFwWC9HyNIiCwqA==
+  dependencies:
+    "@ckeditor/ckeditor5-clipboard" "43.1.1"
+    "@ckeditor/ckeditor5-core" "43.1.1"
+    "@ckeditor/ckeditor5-engine" "43.1.1"
+    "@ckeditor/ckeditor5-typing" "43.1.1"
+    "@ckeditor/ckeditor5-ui" "43.1.1"
+    "@ckeditor/ckeditor5-utils" "43.1.1"
+    "@ckeditor/ckeditor5-widget" "43.1.1"
+    ckeditor5 "43.1.1"
+    lodash-es "4.17.21"
+
+"@ckeditor/ckeditor5-list@43.1.1":
+  version "43.1.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-list/-/ckeditor5-list-43.1.1.tgz#22a048f229f5e55003deee7c1f02608907796223"
+  integrity sha512-hH9Ny4TRH87Iz7WDw8eVKHFFmY4sOrlbPcXutcZCfYGuiDGAvRaeinAwitnWwy+bs5mAdQcw/araWAgMoVbEpw==
+  dependencies:
+    "@ckeditor/ckeditor5-clipboard" "43.1.1"
+    "@ckeditor/ckeditor5-core" "43.1.1"
+    "@ckeditor/ckeditor5-engine" "43.1.1"
+    "@ckeditor/ckeditor5-enter" "43.1.1"
+    "@ckeditor/ckeditor5-typing" "43.1.1"
+    "@ckeditor/ckeditor5-ui" "43.1.1"
+    "@ckeditor/ckeditor5-utils" "43.1.1"
+    ckeditor5 "43.1.1"
+
+"@ckeditor/ckeditor5-markdown-gfm@43.1.1":
+  version "43.1.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-markdown-gfm/-/ckeditor5-markdown-gfm-43.1.1.tgz#a603309805cd4980c14e87202b440b132e2c6923"
+  integrity sha512-7hnOEZdow1/aR69RXqTPoTczyAeIkjwYxgXbvt+pWgtJinuGtW97pc2X6ZSivsq+SWa+6UCe3TnzbyUrIdcqzA==
+  dependencies:
+    "@ckeditor/ckeditor5-clipboard" "43.1.1"
+    "@ckeditor/ckeditor5-core" "43.1.1"
+    "@ckeditor/ckeditor5-engine" "43.1.1"
+    ckeditor5 "43.1.1"
+    marked "4.0.12"
+    turndown "7.2.0"
+    turndown-plugin-gfm "1.0.2"
+
+"@ckeditor/ckeditor5-media-embed@43.1.1":
+  version "43.1.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-media-embed/-/ckeditor5-media-embed-43.1.1.tgz#c7c3b89d8f0386df1eaebdcfec60261d4e47c4ac"
+  integrity sha512-MEydmh/mNUpMpNNV6BDWK8pCC5qn++WPDyDMYSFi9bX8hr9EC7AufoNG+Lh46vEnPl49cAy18WZvlyoX7nCyCA==
+  dependencies:
+    "@ckeditor/ckeditor5-clipboard" "43.1.1"
+    "@ckeditor/ckeditor5-core" "43.1.1"
+    "@ckeditor/ckeditor5-engine" "43.1.1"
+    "@ckeditor/ckeditor5-typing" "43.1.1"
+    "@ckeditor/ckeditor5-ui" "43.1.1"
+    "@ckeditor/ckeditor5-undo" "43.1.1"
+    "@ckeditor/ckeditor5-utils" "43.1.1"
+    "@ckeditor/ckeditor5-widget" "43.1.1"
+    ckeditor5 "43.1.1"
+
+"@ckeditor/ckeditor5-mention@43.1.1":
+  version "43.1.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-mention/-/ckeditor5-mention-43.1.1.tgz#f36a5762739365f1fa0a96332a13aade2349add6"
+  integrity sha512-ErKPpapKx7HXTDgfGg6h3IRac70gCn6cwLIfuSiJ3bg8DSV5q7Rbi5UG8fRdOiT3mu/ZWI7gdP0ei6t/R6ddeA==
+  dependencies:
+    "@ckeditor/ckeditor5-core" "43.1.1"
+    "@ckeditor/ckeditor5-typing" "43.1.1"
+    "@ckeditor/ckeditor5-ui" "43.1.1"
+    "@ckeditor/ckeditor5-utils" "43.1.1"
+    ckeditor5 "43.1.1"
+    lodash-es "4.17.21"
+
+"@ckeditor/ckeditor5-minimap@43.1.1":
+  version "43.1.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-minimap/-/ckeditor5-minimap-43.1.1.tgz#3134581e7747324336a58eb8cd2fdd7194bdffac"
+  integrity sha512-igsONpmmJse/RY/3ZAbtp5mlUzFHHAnFvUaNDPpWVDZ67sSJfCurAJqkrA9zzz4+pErdpryms067c5TAp8H9OQ==
+  dependencies:
+    "@ckeditor/ckeditor5-core" "43.1.1"
+    "@ckeditor/ckeditor5-engine" "43.1.1"
+    "@ckeditor/ckeditor5-ui" "43.1.1"
+    "@ckeditor/ckeditor5-utils" "43.1.1"
+    ckeditor5 "43.1.1"
+
+"@ckeditor/ckeditor5-page-break@43.1.1":
+  version "43.1.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-page-break/-/ckeditor5-page-break-43.1.1.tgz#e76862fa559d4cc7520693a52bb06c088967d1d5"
+  integrity sha512-QuY6TYsgDZfeYWw4CZGgUs/3B2gHq4GmfSO4RuOMaQYPPnFOPFlyHEst9LDE6BbAa9ZWCdGlvUVxCfuAEDueww==
+  dependencies:
+    "@ckeditor/ckeditor5-core" "43.1.1"
+    "@ckeditor/ckeditor5-ui" "43.1.1"
+    "@ckeditor/ckeditor5-widget" "43.1.1"
+    ckeditor5 "43.1.1"
+
+"@ckeditor/ckeditor5-paragraph@43.1.1":
+  version "43.1.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-paragraph/-/ckeditor5-paragraph-43.1.1.tgz#46e26ac2ba3c8366e66e27aec3dc4dfc99ce1559"
+  integrity sha512-9ehs/b2K95W0KPDKwnfxDYHs4ypOtDNT4yB/ZGkJP96NV5XJGGQVBJIVmq0HrMGh4thdwJWofq7ZBIBjN3HMwQ==
+  dependencies:
+    "@ckeditor/ckeditor5-core" "43.1.1"
+    "@ckeditor/ckeditor5-ui" "43.1.1"
+    "@ckeditor/ckeditor5-utils" "43.1.1"
+
+"@ckeditor/ckeditor5-paste-from-office@43.1.1":
+  version "43.1.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-paste-from-office/-/ckeditor5-paste-from-office-43.1.1.tgz#c5e873936d768117e9516203192e83baebcc5430"
+  integrity sha512-dMftOM7eFMqFFZGdzo04PalimSQgNnbAp4adiVVSQDQ9reenWJD9iE1VCT4C5MnX3q4MXGAIBmqOubsqwfI84g==
+  dependencies:
+    "@ckeditor/ckeditor5-clipboard" "43.1.1"
+    "@ckeditor/ckeditor5-core" "43.1.1"
+    "@ckeditor/ckeditor5-engine" "43.1.1"
+    ckeditor5 "43.1.1"
 
 "@ckeditor/ckeditor5-react@^6.2.0":
   version "6.2.0"
@@ -1409,88 +1690,176 @@
   dependencies:
     prop-types "^15.7.2"
 
-"@ckeditor/ckeditor5-select-all@41.2.1":
-  version "41.2.1"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-41.2.1.tgz#b1e12437273d152576f7f69015e51eef279ed2f0"
-  integrity sha512-7or858oDDshJhGoNtyW8LGjFXlBsHKD+wR/ur1D+0DtKUfsznAWtvWPbKnirgmh3h6O0RZ+1X1GbgVnj0iZtnQ==
+"@ckeditor/ckeditor5-remove-format@43.1.1":
+  version "43.1.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-remove-format/-/ckeditor5-remove-format-43.1.1.tgz#106523911df021a9f25b3f2ef67a4d9811d1d0db"
+  integrity sha512-LhzNvdJ3SrynhCN0BwAmjG1wNcPFy0nYgraS6Nj+P57up64EzDMCsJZ5EY7SsDgtm1rCRZh8liHfbY/6DLz6Ng==
   dependencies:
-    "@ckeditor/ckeditor5-core" "41.2.1"
-    "@ckeditor/ckeditor5-ui" "41.2.1"
-    "@ckeditor/ckeditor5-utils" "41.2.1"
+    "@ckeditor/ckeditor5-core" "43.1.1"
+    "@ckeditor/ckeditor5-ui" "43.1.1"
+    "@ckeditor/ckeditor5-utils" "43.1.1"
+    ckeditor5 "43.1.1"
 
-"@ckeditor/ckeditor5-table@41.2.1":
-  version "41.2.1"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-table/-/ckeditor5-table-41.2.1.tgz#bb894036b54fc27c082a687874d9c145241b8473"
-  integrity sha512-6jg9QU3+rjKDdkMLJ9wwMyO8Aj+WFHKBbP1p/JNvYIiHIM5J3CC6i3LSGxaPM2T5eRMgduWKTu0+chraMsIDuA==
+"@ckeditor/ckeditor5-restricted-editing@43.1.1":
+  version "43.1.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-restricted-editing/-/ckeditor5-restricted-editing-43.1.1.tgz#dc2d9343bf4f4aa60d63fbf4afb3811df099d33b"
+  integrity sha512-QwDclw+HEYxJ3uLP0VNo+L0YMhv8uc/6RflEkh2E2w/keiPVrE41vzrAW/G0VD85MMVMdUrmYi98soDPsvZGVA==
   dependencies:
-    ckeditor5 "41.2.1"
+    "@ckeditor/ckeditor5-core" "43.1.1"
+    "@ckeditor/ckeditor5-engine" "43.1.1"
+    "@ckeditor/ckeditor5-ui" "43.1.1"
+    "@ckeditor/ckeditor5-utils" "43.1.1"
+    ckeditor5 "43.1.1"
+
+"@ckeditor/ckeditor5-select-all@43.1.1":
+  version "43.1.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-43.1.1.tgz#850dfb73b41b0d206c63edf8fd53ca152282f42d"
+  integrity sha512-NAxjt604pS6LcEsmH+yMHphrUAV6koACwauyj9llfZErd+VWlzsComiqgEN0ZbZ+iVCem4Fl+TT/82rTcGgtbg==
+  dependencies:
+    "@ckeditor/ckeditor5-core" "43.1.1"
+    "@ckeditor/ckeditor5-ui" "43.1.1"
+    "@ckeditor/ckeditor5-utils" "43.1.1"
+
+"@ckeditor/ckeditor5-show-blocks@43.1.1":
+  version "43.1.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-show-blocks/-/ckeditor5-show-blocks-43.1.1.tgz#ccc7f0903454c102891ffdea785fbcf3ba56227b"
+  integrity sha512-vb9FCIAnWZ0E161x7ulJPtLKtvxI+Rxv8qAikGNrbvLr6x9U9j0Y7WnLtmoYUozKIsRPQ2zFl7qciv1dPoeJTA==
+  dependencies:
+    "@ckeditor/ckeditor5-core" "43.1.1"
+    "@ckeditor/ckeditor5-ui" "43.1.1"
+    ckeditor5 "43.1.1"
+
+"@ckeditor/ckeditor5-source-editing@43.1.1":
+  version "43.1.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-source-editing/-/ckeditor5-source-editing-43.1.1.tgz#e743803918d0fbb944c7c69a7351fa0a62febbe8"
+  integrity sha512-NH5TSZJjroUk9u1eQBlGNSnHvcesednao+YeicZQzRBvPMqIV+6J+MdMj65hlqyfbEsbeHrIKCdMLo/H28+4ZA==
+  dependencies:
+    "@ckeditor/ckeditor5-core" "43.1.1"
+    "@ckeditor/ckeditor5-theme-lark" "43.1.1"
+    "@ckeditor/ckeditor5-ui" "43.1.1"
+    "@ckeditor/ckeditor5-utils" "43.1.1"
+    ckeditor5 "43.1.1"
+
+"@ckeditor/ckeditor5-special-characters@43.1.1":
+  version "43.1.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-special-characters/-/ckeditor5-special-characters-43.1.1.tgz#ad86c51a7ba8e479f3b5d369df2c844d631a66f3"
+  integrity sha512-PQ4E0Rn7dxftM/h6zRLFptrD2xgMHXUVRZJuV6iejK+C/fVAM51PWOOUGUAPKWH1tY2bryiqdxF3yNyU2fpC4w==
+  dependencies:
+    "@ckeditor/ckeditor5-core" "43.1.1"
+    "@ckeditor/ckeditor5-typing" "43.1.1"
+    "@ckeditor/ckeditor5-ui" "43.1.1"
+    "@ckeditor/ckeditor5-utils" "43.1.1"
+    ckeditor5 "43.1.1"
+
+"@ckeditor/ckeditor5-style@43.1.1":
+  version "43.1.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-style/-/ckeditor5-style-43.1.1.tgz#729bc2c123ce293a95ccd26373f7226d56307a6d"
+  integrity sha512-sDrM3lCNlx9QdZaEeRUjf/ukO3sIriRn3dNs/6n6+pGJThlzju3/ikryywJ5AfxzmpCK7CVx1H2x2R9krSV4PQ==
+  dependencies:
+    "@ckeditor/ckeditor5-core" "43.1.1"
+    "@ckeditor/ckeditor5-typing" "43.1.1"
+    "@ckeditor/ckeditor5-ui" "43.1.1"
+    "@ckeditor/ckeditor5-utils" "43.1.1"
+    ckeditor5 "43.1.1"
     lodash-es "4.17.21"
 
-"@ckeditor/ckeditor5-typing@41.2.1":
-  version "41.2.1"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-typing/-/ckeditor5-typing-41.2.1.tgz#2b44746431bfe74b1d841991b5900ca2b48630b7"
-  integrity sha512-jl90Ws7REa5StZXchF1uSCFvmnEGDuoJhIhDzPfzDRCd5ziyU3z325e0vs3V1CFebTlUAvfW9KC5jSVzketLqw==
+"@ckeditor/ckeditor5-table@43.1.1":
+  version "43.1.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-table/-/ckeditor5-table-43.1.1.tgz#488b7852493dd106e1a343f956d580b5959d4e53"
+  integrity sha512-rm7RcyYdhKlokBPxianNJSVdAQS7ng9T8UMbc7wJBVIEUXgqbqQ57nGm4IIX59FXSA7H9Dj/EFW4DT9YAaITvg==
   dependencies:
-    "@ckeditor/ckeditor5-core" "41.2.1"
-    "@ckeditor/ckeditor5-engine" "41.2.1"
-    "@ckeditor/ckeditor5-utils" "41.2.1"
+    "@ckeditor/ckeditor5-clipboard" "43.1.1"
+    "@ckeditor/ckeditor5-core" "43.1.1"
+    "@ckeditor/ckeditor5-engine" "43.1.1"
+    "@ckeditor/ckeditor5-ui" "43.1.1"
+    "@ckeditor/ckeditor5-utils" "43.1.1"
+    "@ckeditor/ckeditor5-widget" "43.1.1"
+    ckeditor5 "43.1.1"
     lodash-es "4.17.21"
 
-"@ckeditor/ckeditor5-ui@41.2.1":
-  version "41.2.1"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-41.2.1.tgz#2329847be01aa554bca24892abeffbe10013306a"
-  integrity sha512-HmLqVLX44q23LadZmmsh0et9mexnhSrOXkU+0VzHmT4wmO/wbYcMGTMWJF96i5eOjLywzxWGctIdlnJ9ElFPdg==
+"@ckeditor/ckeditor5-theme-lark@43.1.1":
+  version "43.1.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-theme-lark/-/ckeditor5-theme-lark-43.1.1.tgz#b9f0130bd73ea8d06dee638c28ac4623bb876cc6"
+  integrity sha512-7huWGsetISvNOzQurO1zqLL25YnGP3vgsOysKHz0qKgOi+UwXWxG8IYnzHi0qN4ox78vgyCR+nJvzjVz33gJEg==
   dependencies:
-    "@ckeditor/ckeditor5-core" "41.2.1"
-    "@ckeditor/ckeditor5-utils" "41.2.1"
+    "@ckeditor/ckeditor5-ui" "43.1.1"
+
+"@ckeditor/ckeditor5-typing@43.1.1":
+  version "43.1.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-typing/-/ckeditor5-typing-43.1.1.tgz#8e85691bd8d47632cac09d384dabebfc2d15edc2"
+  integrity sha512-2YB3IfGPWct1oIlYGCL5Z5JQ/g2dpn8zr9syVTQJ/fAPjqi8Ig53lTaCQvpftnq4I+jESXAl4Rr9bIosqDVjAQ==
+  dependencies:
+    "@ckeditor/ckeditor5-core" "43.1.1"
+    "@ckeditor/ckeditor5-engine" "43.1.1"
+    "@ckeditor/ckeditor5-utils" "43.1.1"
+    lodash-es "4.17.21"
+
+"@ckeditor/ckeditor5-ui@43.1.1":
+  version "43.1.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-43.1.1.tgz#902f18b237c7e67db71a766cbdb07d3c35801378"
+  integrity sha512-GNf0y56cT1HzgaG8wPyNsXlG4lZJMag+UKL6L3Y8uYg9/HurqJjJVnZcCJZ7T1t3D26fOvCIZ3KhW6AtRrnDrA==
+  dependencies:
+    "@ckeditor/ckeditor5-core" "43.1.1"
+    "@ckeditor/ckeditor5-engine" "43.1.1"
+    "@ckeditor/ckeditor5-utils" "43.1.1"
     color-convert "2.0.1"
     color-parse "1.4.2"
     lodash-es "4.17.21"
     vanilla-colorful "0.7.2"
 
-"@ckeditor/ckeditor5-undo@41.2.1":
-  version "41.2.1"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-41.2.1.tgz#b66f54c6c389de8ecef3280dc957369aef220032"
-  integrity sha512-NlM8TdPNO+ygOcyb361OfzJ7UGi0QTbTFBAUMaZeOdxygaTJki5eFR69y4PCwYQfR2s7fHXqFLKhflPvJ2PpyQ==
+"@ckeditor/ckeditor5-undo@43.1.1":
+  version "43.1.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-43.1.1.tgz#550d4b472193cff3f836e1f78619ad24408edd43"
+  integrity sha512-qX8jy5d8H4emWNCmA4EN2ZE/UGfBN1AqhMYtdX73EIxnDwVzT6Hd+GUaScDQoKn7Y81vO5dELPKFddaQN077Ew==
   dependencies:
-    "@ckeditor/ckeditor5-core" "41.2.1"
-    "@ckeditor/ckeditor5-engine" "41.2.1"
-    "@ckeditor/ckeditor5-ui" "41.2.1"
+    "@ckeditor/ckeditor5-core" "43.1.1"
+    "@ckeditor/ckeditor5-engine" "43.1.1"
+    "@ckeditor/ckeditor5-ui" "43.1.1"
 
-"@ckeditor/ckeditor5-upload@41.2.1":
-  version "41.2.1"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-41.2.1.tgz#0401e4eab96e78b1058041ca1ebd169f4a8ec134"
-  integrity sha512-41nwrJkuPy8cqXQaELxmdnwd88KPm9RKBxVAAfdpCAU62tRyYnUbX05yHbLBGpmOUf0FK4Zw7ygSG2VVVcTicg==
+"@ckeditor/ckeditor5-upload@43.1.1":
+  version "43.1.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-43.1.1.tgz#57508ee3087d62e390ae301af2a9cb8379d1238a"
+  integrity sha512-VIylGThmbwCKazx2XZBS8WYW7AYOgZzS8zQ1WDwT80tfOC3cjykNvg59eH7OACDeWud1LD47/idTj0wVC8gsIg==
   dependencies:
-    "@ckeditor/ckeditor5-core" "41.2.1"
-    "@ckeditor/ckeditor5-ui" "41.2.1"
-    "@ckeditor/ckeditor5-utils" "41.2.1"
+    "@ckeditor/ckeditor5-core" "43.1.1"
+    "@ckeditor/ckeditor5-utils" "43.1.1"
 
-"@ckeditor/ckeditor5-utils@41.2.1":
-  version "41.2.1"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-41.2.1.tgz#d6d1cfe786976b7dea3696e97ed28d40ceb606c9"
-  integrity sha512-yBtKU3QteYieEU3Wa8Wj1fea4CBFqmsemhesOIb7K5JYHFBs7xQ+efAaTWL+YTSOt/y50SEy2BCK+9mUkRohBg==
+"@ckeditor/ckeditor5-utils@43.1.1":
+  version "43.1.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-43.1.1.tgz#49a179d970004fe4bcbc16109824e151f0dfcca2"
+  integrity sha512-x7d1Iy2j6be74Nqv5MwWjBtVX8xv3lsbkUc0n/K26Edql5d2sk05MeA5kyBowHzqFEVDgDOUCj9Thl5KrJpb5w==
   dependencies:
     lodash-es "4.17.21"
 
-"@ckeditor/ckeditor5-watchdog@41.2.1":
-  version "41.2.1"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-watchdog/-/ckeditor5-watchdog-41.2.1.tgz#fe6448a626b28bca8cbdc71bcc6800f76bbc9cfe"
-  integrity sha512-3Y/PPS9dTzIL/TsGf23lz4QxW6Y8/up62afict7YLH2p4g85KMxyDWhZJui8QYsonALjoWy34vSlMTI/WbMM4w==
+"@ckeditor/ckeditor5-watchdog@43.1.1":
+  version "43.1.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-watchdog/-/ckeditor5-watchdog-43.1.1.tgz#a907d5ffacd1697fb8e5f0c10d3ec5b4f3540679"
+  integrity sha512-/IyxNGhYKzioxwzK+H5NbgzHPNOBHkNbUwnC3vM89OOLxu5g77edEn/kcSBsEABYweddUK8LrPrKKvTcYC+tuw==
   dependencies:
     lodash-es "4.17.21"
 
-"@ckeditor/ckeditor5-widget@41.2.1":
-  version "41.2.1"
-  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-41.2.1.tgz#c078b01fa92da96f47062b4e8fc0613ec08fda1d"
-  integrity sha512-ugBC38lRbqRlU1LRd/spGyyTlizsTtf3EOTtqXRwq96bfZ5ltnEAMe0FP5agsQBo4IoVFWMZnUiU66xRCBPiBg==
+"@ckeditor/ckeditor5-widget@43.1.1":
+  version "43.1.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-43.1.1.tgz#d6450f973d9947c1018e6b50a23c28349b5a1351"
+  integrity sha512-3S6T7bImVAX2OHkrKeTRRWn+WE5nJyvrRPNItPTXhxgDPrbAYRpvH3mtcoUjb24cw1dDfHRwolBTXRv1DxqAUw==
   dependencies:
-    "@ckeditor/ckeditor5-core" "41.2.1"
-    "@ckeditor/ckeditor5-engine" "41.2.1"
-    "@ckeditor/ckeditor5-enter" "41.2.1"
-    "@ckeditor/ckeditor5-typing" "41.2.1"
-    "@ckeditor/ckeditor5-ui" "41.2.1"
-    "@ckeditor/ckeditor5-utils" "41.2.1"
+    "@ckeditor/ckeditor5-core" "43.1.1"
+    "@ckeditor/ckeditor5-engine" "43.1.1"
+    "@ckeditor/ckeditor5-enter" "43.1.1"
+    "@ckeditor/ckeditor5-typing" "43.1.1"
+    "@ckeditor/ckeditor5-ui" "43.1.1"
+    "@ckeditor/ckeditor5-utils" "43.1.1"
+    lodash-es "4.17.21"
+
+"@ckeditor/ckeditor5-word-count@43.1.1":
+  version "43.1.1"
+  resolved "https://registry.yarnpkg.com/@ckeditor/ckeditor5-word-count/-/ckeditor5-word-count-43.1.1.tgz#e39ce0941a460bfb250e8a80bd3c36d236d52553"
+  integrity sha512-eMLf6iC/yH2ZSJtnfU9W/92J/JYwGhrU8AGsrffGqPkJkHSe9qbSUHhpEyae+Q+GTK6FMU1pEC6tAdlxOWmRcw==
+  dependencies:
+    "@ckeditor/ckeditor5-core" "43.1.1"
+    "@ckeditor/ckeditor5-ui" "43.1.1"
+    "@ckeditor/ckeditor5-utils" "43.1.1"
+    ckeditor5 "43.1.1"
     lodash-es "4.17.21"
 
 "@commitlint/cli@^19.2.2":
@@ -2689,6 +3058,11 @@
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/@kamilkisiela/fast-url-parser/-/fast-url-parser-1.1.4.tgz#9d68877a489107411b953c54ea65d0658b515809"
   integrity sha512-gbkePEBupNydxCelHCESvFSFM8XPh1Zs/OAVRW/rKpEqPAl5PbOM90Si8mv9bvnR53uPD2s/FiRxdvSejpRJew==
+
+"@mixmark-io/domino@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@mixmark-io/domino/-/domino-2.2.0.tgz#4e8ec69bf1afeb7a14f0628b7e2c0f35bdb336c3"
+  integrity sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==
 
 "@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1":
   version "5.1.1-v1"
@@ -4525,24 +4899,68 @@ check-error@^2.1.1:
   optionalDependencies:
     fsevents "~2.3.2"
 
-ckeditor5@41.2.1:
-  version "41.2.1"
-  resolved "https://registry.yarnpkg.com/ckeditor5/-/ckeditor5-41.2.1.tgz#e15773e78705b516acae6c4eac6392bb69cb312c"
-  integrity sha512-AroYD5VK79HHdAKGqQ4Cz0sxN1oM4qJGhx3CIHvb53IcHXdQQUMtwJ2L123ylWWtUHiwimTYU5qCeD7Al8MwFQ==
+ckeditor5@43.1.1:
+  version "43.1.1"
+  resolved "https://registry.yarnpkg.com/ckeditor5/-/ckeditor5-43.1.1.tgz#1f3cf46cf4af6d10e75858f318a907b4ddd0dbc6"
+  integrity sha512-/nVXYI81XT1xzE1SKrmgF5qViHYqf3hC+BhizC8r1RZ82SB28G9gRmahYSt2pMkpI6w165OwXCdWEoIVAtiYRg==
   dependencies:
-    "@ckeditor/ckeditor5-clipboard" "41.2.1"
-    "@ckeditor/ckeditor5-core" "41.2.1"
-    "@ckeditor/ckeditor5-engine" "41.2.1"
-    "@ckeditor/ckeditor5-enter" "41.2.1"
-    "@ckeditor/ckeditor5-paragraph" "41.2.1"
-    "@ckeditor/ckeditor5-select-all" "41.2.1"
-    "@ckeditor/ckeditor5-typing" "41.2.1"
-    "@ckeditor/ckeditor5-ui" "41.2.1"
-    "@ckeditor/ckeditor5-undo" "41.2.1"
-    "@ckeditor/ckeditor5-upload" "41.2.1"
-    "@ckeditor/ckeditor5-utils" "41.2.1"
-    "@ckeditor/ckeditor5-watchdog" "41.2.1"
-    "@ckeditor/ckeditor5-widget" "41.2.1"
+    "@ckeditor/ckeditor5-adapter-ckfinder" "43.1.1"
+    "@ckeditor/ckeditor5-alignment" "43.1.1"
+    "@ckeditor/ckeditor5-autoformat" "43.1.1"
+    "@ckeditor/ckeditor5-autosave" "43.1.1"
+    "@ckeditor/ckeditor5-basic-styles" "43.1.1"
+    "@ckeditor/ckeditor5-block-quote" "43.1.1"
+    "@ckeditor/ckeditor5-ckbox" "43.1.1"
+    "@ckeditor/ckeditor5-ckfinder" "43.1.1"
+    "@ckeditor/ckeditor5-clipboard" "43.1.1"
+    "@ckeditor/ckeditor5-cloud-services" "43.1.1"
+    "@ckeditor/ckeditor5-code-block" "43.1.1"
+    "@ckeditor/ckeditor5-core" "43.1.1"
+    "@ckeditor/ckeditor5-easy-image" "43.1.1"
+    "@ckeditor/ckeditor5-editor-balloon" "43.1.1"
+    "@ckeditor/ckeditor5-editor-classic" "43.1.1"
+    "@ckeditor/ckeditor5-editor-decoupled" "43.1.1"
+    "@ckeditor/ckeditor5-editor-inline" "43.1.1"
+    "@ckeditor/ckeditor5-editor-multi-root" "43.1.1"
+    "@ckeditor/ckeditor5-engine" "43.1.1"
+    "@ckeditor/ckeditor5-enter" "43.1.1"
+    "@ckeditor/ckeditor5-essentials" "43.1.1"
+    "@ckeditor/ckeditor5-find-and-replace" "43.1.1"
+    "@ckeditor/ckeditor5-font" "43.1.1"
+    "@ckeditor/ckeditor5-heading" "43.1.1"
+    "@ckeditor/ckeditor5-highlight" "43.1.1"
+    "@ckeditor/ckeditor5-horizontal-line" "43.1.1"
+    "@ckeditor/ckeditor5-html-embed" "43.1.1"
+    "@ckeditor/ckeditor5-html-support" "43.1.1"
+    "@ckeditor/ckeditor5-image" "43.1.1"
+    "@ckeditor/ckeditor5-indent" "43.1.1"
+    "@ckeditor/ckeditor5-language" "43.1.1"
+    "@ckeditor/ckeditor5-link" "43.1.1"
+    "@ckeditor/ckeditor5-list" "43.1.1"
+    "@ckeditor/ckeditor5-markdown-gfm" "43.1.1"
+    "@ckeditor/ckeditor5-media-embed" "43.1.1"
+    "@ckeditor/ckeditor5-mention" "43.1.1"
+    "@ckeditor/ckeditor5-minimap" "43.1.1"
+    "@ckeditor/ckeditor5-page-break" "43.1.1"
+    "@ckeditor/ckeditor5-paragraph" "43.1.1"
+    "@ckeditor/ckeditor5-paste-from-office" "43.1.1"
+    "@ckeditor/ckeditor5-remove-format" "43.1.1"
+    "@ckeditor/ckeditor5-restricted-editing" "43.1.1"
+    "@ckeditor/ckeditor5-select-all" "43.1.1"
+    "@ckeditor/ckeditor5-show-blocks" "43.1.1"
+    "@ckeditor/ckeditor5-source-editing" "43.1.1"
+    "@ckeditor/ckeditor5-special-characters" "43.1.1"
+    "@ckeditor/ckeditor5-style" "43.1.1"
+    "@ckeditor/ckeditor5-table" "43.1.1"
+    "@ckeditor/ckeditor5-theme-lark" "43.1.1"
+    "@ckeditor/ckeditor5-typing" "43.1.1"
+    "@ckeditor/ckeditor5-ui" "43.1.1"
+    "@ckeditor/ckeditor5-undo" "43.1.1"
+    "@ckeditor/ckeditor5-upload" "43.1.1"
+    "@ckeditor/ckeditor5-utils" "43.1.1"
+    "@ckeditor/ckeditor5-watchdog" "43.1.1"
+    "@ckeditor/ckeditor5-widget" "43.1.1"
+    "@ckeditor/ckeditor5-word-count" "43.1.1"
 
 classnames@^2.5.1:
   version "2.5.1"
@@ -7326,6 +7744,11 @@ map-cache@^0.2.0:
   resolved "https://registry.yarnpkg.com/map-cache/-/map-cache-0.2.2.tgz#c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf"
   integrity sha512-8y/eV9QQZCiyn1SprXSrCmqJN0yNRATe+PO8ztwqrvrbdRLA3eYJF0yaR0YayLWkMbsQSKWS9N2gPcGEc4UsZg==
 
+marked@4.0.12:
+  version "4.0.12"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-4.0.12.tgz#2262a4e6fd1afd2f13557726238b69a48b982f7d"
+  integrity sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==
+
 matcher@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/matcher/-/matcher-3.0.0.tgz#bd9060f4c5b70aa8041ccc6f80368760994f30ca"
@@ -8901,14 +9324,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@6.0.1, strip-ansi@^5.2.0, strip-ansi@^6.0.0, strip-ansi@^6.0.1, strip-ansi@^7.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@6.0.1, strip-ansi@^5.2.0, strip-ansi@^6.0.0, strip-ansi@^6.0.1, strip-ansi@^7.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -9179,6 +9595,18 @@ tsutils@^3.21.0:
   integrity sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==
   dependencies:
     tslib "^1.8.1"
+
+turndown-plugin-gfm@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/turndown-plugin-gfm/-/turndown-plugin-gfm-1.0.2.tgz#6f8678a361f35220b2bdf5619e6049add75bf1c7"
+  integrity sha512-vwz9tfvF7XN/jE0dGoBei3FXWuvll78ohzCZQuOb+ZjWrs3a0XhQVomJEb2Qh4VHTPNRO4GPZh0V7VRbiWwkRg==
+
+turndown@7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/turndown/-/turndown-7.2.0.tgz#67d614fe8371fb511079a93345abfd156c0ffcf4"
+  integrity sha512-eCZGBN4nNNqM9Owkv9HAtWRYfLA4h909E/WGAWWBpmB275ehNhZyk87/Tpvjbp0jjNl9XwCsbe6bm6CqFsgD+A==
+  dependencies:
+    "@mixmark-io/domino" "^2.2.0"
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
@@ -9663,16 +10091,7 @@ why-is-node-running@^2.3.0:
     siginfo "^2.0.0"
     stackback "0.0.2"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@7.0.0, wrap-ansi@^6.0.1, wrap-ansi@^6.2.0, wrap-ansi@^7.0.0, wrap-ansi@^8.1.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@7.0.0, wrap-ansi@^6.0.1, wrap-ansi@^6.2.0, wrap-ansi@^7.0.0, wrap-ansi@^8.1.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
## Description :sparkles:
Bump @ckeditor/ckeditor5-build-classic to 43.1.1. This fixes two vulnerabilities:
- https://github.com/City-of-Helsinki/linkedcomponents-ui/security/dependabot/149
- https://github.com/City-of-Helsinki/linkedcomponents-ui/security/dependabot/151

## Issues :bug:

### Closes :no_good_woman:

**[LINK-2191](https://helsinkisolutionoffice.atlassian.net/browse/LINK-2191):**

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[LINK-2191]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-2191?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ