### PR TITLE
fix: loginProvider use sessionPoller default settings LINK-2179

### DIFF
--- a/src/domain/auth/constants.ts
+++ b/src/domain/auth/constants.ts
@@ -22,5 +22,4 @@ export const loginProviderProps: LoginProviderProps = {
     },
     audiences: [import.meta.env.REACT_APP_OIDC_API_SCOPE],
   },
-  sessionPollerSettings: { pollIntervalInMs: 10000 },
 };

--- a/src/domain/event/eventForm/EventForm.tsx
+++ b/src/domain/event/eventForm/EventForm.tsx
@@ -657,7 +657,7 @@ const EventFormWrapper: React.FC<EventFormWrapperProps> = (props) => {
       validationSchema={validationSchema}
       validateOnMount
       validateOnBlur={true}
-      validateOnChange={true}
+      validateOnChange={false}
     >
       {({ setErrors, setTouched, values }) => {
         return (


### PR DESCRIPTION
## Description :sparkles:
- Use login provider session polling default setting (60s) instead of 10s.
- Don't validate event form on change, this makes filling the form heavy

## Issues :bug:

### Closes :no_good_woman:

**[LINK-2179](https://helsinkisolutionoffice.atlassian.net/browse/LINK-2179):**

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[LINK-2179]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-2179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ