### PR TITLE
fix: use ubi9/nginx-120

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -108,7 +108,7 @@ RUN yarn generate-robots
 RUN yarn compress
 
 # =============================
-FROM registry.access.redhat.com/ubi8/nginx-120 AS production
+FROM registry.access.redhat.com/ubi9/nginx-120 AS production
 # =============================
 USER root
 


### PR DESCRIPTION
ubi8/nginx-120 has been deprecated long time ago. ubi9/nginx-120 is actively maintained.

refs: LINK-2221
