### PR TITLE
fix: sort attendees by id (from oldest to newest) instead of name

### DIFF
--- a/src/domain/attendanceList/attendeeList/AttendeeList.tsx
+++ b/src/domain/attendanceList/attendeeList/AttendeeList.tsx
@@ -33,7 +33,7 @@ const AttendeeList: React.FC<Props> = ({ registration }) => {
 
   const attendees = orderBy(
     getValue(registration.signups, []) as SignupFieldsFragment[],
-    ['firstName', 'lastName'],
+    ['id'],
     ['asc', 'desc']
   ).filter((signup) => signup.attendeeStatus === AttendeeStatus.Attending);
 


### PR DESCRIPTION
refs: LINK-2220

co-pr: https://github.com/City-of-Helsinki/linkedregistrations-ui/pull/207
