### PR TITLE
fix: add support for inlining via ROLLUP_INLINE_DYNAMIC_IMPORTS

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,6 +14,14 @@ export default defineConfig({
   build: {
     outDir: './build',
     emptyOutDir: true,
+    rollupOptions: {
+      output: {
+        // inline dynamic imports, because rollup generates so many chunks it triggers
+        inlineDynamicImports:
+          process.env.ROLLUP_INLINE_DYNAMIC_IMPORTS === 'true',
+        experimentalMinChunkSize: 100_000, // try to avoid small chunks that are less than 100 kB
+      },
+    },
   },
   server: {
     host: true,


### PR DESCRIPTION
Setting ROLLUP_INLINE_DYNAMIC_IMPORTS=true will essentially create a single js and css file.

The reason for introducing this is that platta has implemented DDoS protection that gets easily upset because normal rollup build produces quite many js and css assets. This becomes very problematic with playwright tests that make a lot of repeated requests.

refs: LINK-2229

Co-PR: https://dev.azure.com/City-of-Helsinki/linkedevents/_git/linkedevents-pipelines/pullrequest/10597
