### PR TITLE
fix: avoid circular reference on sentry calls LINK-2332

### DIFF
--- a/src/domain/app/sentry/__tests__/utils.test.ts
+++ b/src/domain/app/sentry/__tests__/utils.test.ts
@@ -34,6 +34,7 @@ const originalData = {
   ],
   arrayOfStrings: [safe],
   object: { c: safe, userEmail: sensitive, userName: sensitive },
+  referenceObject: {},
 };
 
 const cleanedData = {
@@ -41,6 +42,7 @@ const cleanedData = {
   arrayOfObjects: [{ a: safe }, { b: safe }],
   arrayOfStrings: [safe],
   object: { c: safe },
+  referenceObject: {},
 };
 
 describe('beforeSend', () => {
@@ -64,6 +66,12 @@ describe('beforeSendTransaction', () => {
 
 describe('cleanSensitiveData', () => {
   it('should clear sensitive data', () => {
+    expect(cleanSensitiveData(originalData)).toEqual(cleanedData);
+  });
+
+  it('should handle circular references without throwing an error', () => {
+    originalData['referenceObject'] = originalData;
+    cleanedData['referenceObject'] = cleanedData;
     expect(cleanSensitiveData(originalData)).toEqual(cleanedData);
   });
 });

--- a/src/domain/app/sentry/utils.ts
+++ b/src/domain/app/sentry/utils.ts
@@ -71,7 +71,16 @@ const SENTRY_DENYLIST = [
   'zipcode',
 ];
 
-export const cleanSensitiveData = (data: Record<string, unknown>) => {
+export const cleanSensitiveData = (
+  data: Record<string, unknown>,
+  visited = new Set<unknown>()
+) => {
+  // To avoid infinite recursion for circular references
+  if (visited.has(data)) {
+    return data;
+  }
+  visited.add(data);
+
   Object.entries(data).forEach(([key, value]) => {
     if (
       SENTRY_DENYLIST.includes(key) ||
@@ -81,11 +90,11 @@ export const cleanSensitiveData = (data: Record<string, unknown>) => {
     } else if (Array.isArray(value)) {
       data[key] = value.map((item) =>
         isObject(item)
-          ? cleanSensitiveData(item as Record<string, unknown>)
+          ? cleanSensitiveData(item as Record<string, unknown>, visited)
           : item
       );
     } else if (isObject(value)) {
-      data[key] = cleanSensitiveData(value as Record<string, unknown>);
+      data[key] = cleanSensitiveData(value as Record<string, unknown>, visited);
     }
   });
 


### PR DESCRIPTION
## Description :sparkles:

Fix circular reference errors from Sentry calls

## Issues :bug:

### Closes :no_good_woman:

**[LINK-2332](https://helsinkisolutionoffice.atlassian.net/browse/LINK-2332):**

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

I made a test case for this

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
