### PR TITLE
fix: only admin can see add registration checkbox LINK-2257

### DIFF
--- a/src/domain/event/eventForm/EventForm.tsx
+++ b/src/domain/event/eventForm/EventForm.tsx
@@ -541,6 +541,7 @@ const EventForm: React.FC<EventFormProps> = ({
                 <PriceSection
                   event={event}
                   isEditingAllowed={isEditingAllowed}
+                  isAdminUser={isAdminUser}
                 />
               </Section>
               <Section title={t(`event.form.sections.channels.${values.type}`)}>

--- a/src/domain/event/formSections/priceSection/PriceSection.tsx
+++ b/src/domain/event/formSections/priceSection/PriceSection.tsx
@@ -28,9 +28,14 @@ import ValidationError from './validationError/ValidationError';
 interface Props {
   event?: EventFieldsFragment | null;
   isEditingAllowed: boolean;
+  isAdminUser: boolean;
 }
 
-const PriceSection: React.FC<Props> = ({ event, isEditingAllowed }) => {
+const PriceSection: React.FC<Props> = ({
+  event,
+  isEditingAllowed,
+  isAdminUser,
+}) => {
   const { t } = useTranslation();
   const { user } = useUser();
 
@@ -79,14 +84,15 @@ const PriceSection: React.FC<Props> = ({ event, isEditingAllowed }) => {
               name={EVENT_FIELDS.HAS_PRICE}
             />
           </FormGroup>
-          {featureFlagUtils.isFeatureEnabled('WEB_STORE_INTEGRATION') && (
-            <Field
-              component={CheckboxField}
-              disabled={!isEditingAllowed || !hasPrice}
-              label={t(`event.form.labelIsRegistrationPlanned.${type}`)}
-              name={EVENT_FIELDS.IS_REGISTRATION_PLANNED}
-            />
-          )}
+          {featureFlagUtils.isFeatureEnabled('WEB_STORE_INTEGRATION') &&
+            isAdminUser && (
+              <Field
+                component={CheckboxField}
+                disabled={!isEditingAllowed || !hasPrice}
+                label={t(`event.form.labelIsRegistrationPlanned.${type}`)}
+                name={EVENT_FIELDS.IS_REGISTRATION_PLANNED}
+              />
+            )}
 
           <ValidationError />
         </FieldColumn>

--- a/src/domain/event/formSections/priceSection/__tests__/PriceSection.test.tsx
+++ b/src/domain/event/formSections/priceSection/__tests__/PriceSection.test.tsx
@@ -37,6 +37,9 @@ beforeEach(() => {
   mockAuthenticatedLoginState();
 });
 
+const registrationCheckboxName =
+  'Tapahtumalle luodaan Linked Events -ilmoittautuminen';
+
 type InitialValues = {
   [EVENT_FIELDS.EVENT_INFO_LANGUAGES]: string[];
   [EVENT_FIELDS.HAS_PRICE]: boolean;
@@ -122,7 +125,7 @@ const getElement = (
       });
     case 'isRegistrationPlannedCheckbox':
       return screen.getByRole('checkbox', {
-        name: 'Tapahtumalle luodaan Linked Events -ilmoittautuminen',
+        name: registrationCheckboxName,
       });
     case 'priceGroupSelectButton':
       return screen.getByRole('button', { name: /Asiakasryhmä/ });
@@ -268,7 +271,7 @@ test('should not show registration checkbox to non admin user', async () => {
 
   expect(
     screen.queryByRole('checkbox', {
-      name: 'Tapahtumalle luodaan Linked Events -ilmoittautuminen',
+      name: registrationCheckboxName,
     })
   ).not.toBeInTheDocument();
 });

--- a/src/domain/event/formSections/priceSection/__tests__/PriceSection.test.tsx
+++ b/src/domain/event/formSections/priceSection/__tests__/PriceSection.test.tsx
@@ -68,7 +68,7 @@ const renderPriceSection = ({
       onSubmit={vi.fn()}
       validationSchema={publicEventSchema}
     >
-      <PriceSection isEditingAllowed={true} />
+      <PriceSection isEditingAllowed={true} isAdminUser={true} />
     </Formik>,
     { mocks }
   );

--- a/src/domain/event/formSections/priceSection/__tests__/PriceSection.test.tsx
+++ b/src/domain/event/formSections/priceSection/__tests__/PriceSection.test.tsx
@@ -58,9 +58,11 @@ const defaultMocks = [mockedFreePriceGroupsResponse, mockedUserResponse];
 const renderPriceSection = ({
   initialValues,
   mocks = defaultMocks,
+  isAdminUser = true,
 }: {
   initialValues?: Partial<InitialValues>;
   mocks?: MockedResponse[];
+  isAdminUser?: boolean;
 } = {}) =>
   render(
     <Formik
@@ -68,7 +70,7 @@ const renderPriceSection = ({
       onSubmit={vi.fn()}
       validationSchema={publicEventSchema}
     >
-      <PriceSection isEditingAllowed={true} isAdminUser={true} />
+      <PriceSection isEditingAllowed={true} isAdminUser={isAdminUser} />
     </Formik>,
     { mocks }
   );
@@ -254,4 +256,19 @@ test('should add and remove price group', async () => {
   expect(screen.getAllByRole('button', { name: /Asiakasryhmä/ })).toHaveLength(
     1
   );
+});
+
+test('should not show registration checkbox to non admin user', async () => {
+  const user = userEvent.setup();
+  renderPriceSection({
+    isAdminUser: false,
+  });
+
+  await user.click(getElement('hasPriceCheckbox'));
+
+  expect(
+    screen.queryByRole('checkbox', {
+      name: 'Tapahtumalle luodaan Linked Events -ilmoittautuminen',
+    })
+  ).not.toBeInTheDocument();
 });


### PR DESCRIPTION
## Description :sparkles:

## Issues :bug:

### Closes :no_good_woman:

**[LINK-2257](https://helsinkisolutionoffice.atlassian.net/browse/LINK-2257):**

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:
Admin user sees this:
<img width="570" height="279" alt="Screenshot 2025-09-03 at 14 21 41" src="https://github.com/user-attachments/assets/280562b6-dc5f-4146-aeb2-ed0c11d84cc4" />
<img width="519" height="270" alt="Screenshot 2025-09-04 at 13 31 23" src="https://github.com/user-attachments/assets/caadec3c-879f-47b9-993d-81b39efde249" />
Non admin sees this:
<img width="520" height="281" alt="Screenshot 2025-09-04 at 13 29 04" src="https://github.com/user-attachments/assets/8bb91175-0f70-4ff5-99d1-d6001af3c038" />


## Additional notes :spiral_notepad:


[LINK-2257]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-2257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ