### PR TITLE
fix: event form isAdminUser always use latest publisher LINK-2384

### DIFF
--- a/src/domain/event/eventForm/EventForm.tsx
+++ b/src/domain/event/eventForm/EventForm.tsx
@@ -572,7 +572,8 @@ const EventForm: React.FC<EventFormProps> = ({
               </Section>
               {(isExternalUser ||
                 (isAdminUser &&
-                  event?.publisher === EXTERNAL_PUBLISHER_ID)) && (
+                  getValue(event?.publisher, values.publisher) ===
+                    EXTERNAL_PUBLISHER_ID)) && (
                 <Section title={t('event.form.sections.contact')}>
                   <ExternalUserContact
                     isEditingAllowed={isEditingAllowed && !isAdminUser}


### PR DESCRIPTION
## Description :sparkles:

Event form isAdminUser always get latest publisher from Formik values as a fallback.

## Issues :bug:

### Closes :no_good_woman:

**[LINK-2384](https://helsinkisolutionoffice.atlassian.net/browse/LINK-2384):**

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[LINK-2384]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-2384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ