### PR TITLE
fix: initial edu keywords empty array Ref: LINK-2388

### DIFF
--- a/src/domain/event/utils.ts
+++ b/src/domain/event/utils.ts
@@ -873,7 +873,7 @@ const getRecurringEventDate = (
 };
 
 const getKeywordIds = (keywords: Array<KeywordFieldsFragment | null>) =>
-  keywords && keywords.filter(skipFalsyType).map((keyword) => keyword.atId);
+  keywords ? keywords.filter(skipFalsyType).map((keyword) => keyword.atId) : [];
 
 export const getEventInitialValues = (
   event: EventFieldsFragment


### PR DESCRIPTION
## Description :sparkles:

Initial edu keywords should be an empty array if not defined. Currently this breaks saving copied event.

## Issues :bug:

### Closes :no_good_woman:

**[DEV-XXX](https://helsinkisolutionoffice.atlassian.net/browse/DEV-XXX):**

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:
