### PR TITLE
fix: price group logic for external events Ref: LINK-2403

### DIFF
--- a/src/domain/event/utils.ts
+++ b/src/domain/event/utils.ts
@@ -608,12 +608,16 @@ export const getEventBasePayload = (
           isFree: false,
           ...(featureFlagUtils.isFeatureEnabled('WEB_STORE_INTEGRATION')
             ? {
-                offerPriceGroups: offer.offerPriceGroups.map((pg) => ({
-                  id: pg.id ?? undefined,
-                  price: pg.price,
-                  priceGroup: Number(pg.priceGroup),
-                  vatPercentage: offersVatPercentage,
-                })),
+                offerPriceGroups: offer.offerPriceGroups
+                  .filter(
+                    (pg) => Boolean(pg.price) && Boolean(offersVatPercentage)
+                  )
+                  .map((pg) => ({
+                    id: pg.id ?? undefined,
+                    price: pg.price,
+                    priceGroup: Number(pg.priceGroup),
+                    vatPercentage: offersVatPercentage,
+                  })),
               }
             : /* istanbul ignore next */
               {}),


### PR DESCRIPTION
## Description :sparkles:
External user should be able to create events with offers, but then offer price groups should not be included. Filtering out the base price groups if price or vat percentage values don't exist.
## Issues :bug:

### Closes :no_good_woman:

**[LINK-2403](https://helsinkisolutionoffice.atlassian.net/browse/LINK-2403):**

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[LINK-2403]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-2403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ