### PR TITLE
fix: price group validation only when vat exists Ref: LINK-2403

### DIFF
--- a/src/utils/validationUtils.ts
+++ b/src/utils/validationUtils.ts
@@ -269,6 +269,7 @@ export const showFormErrors = <Values = unknown>({
         set(acc, getValue(e.path, ''), e.errors[0]),
       {}
     );
+
     const touchedFields = error.inner.reduce(
       (acc, e: Yup.ValidationError) => set(acc, getValue(e.path, ''), true),
       {}


### PR DESCRIPTION
## Description :sparkles:
Continuation of https://github.com/City-of-Helsinki/linkedcomponents-ui/pull/513.
Fixing the validation rules so that we check that event re is planned and the vat percentage value exists.

## Issues :bug:

### Closes :no_good_woman:

**[LINK-2403](https://helsinkisolutionoffice.atlassian.net/browse/LINK-2403):**

### Related :handshake:

## Testing :alembic:

### Automated tests :gear:️

### Manual testing :construction_worker_man:

## Screenshots :camera_flash:

## Additional notes :spiral_notepad:


[LINK-2403]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-2403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ