### PR TITLE
Fix a flaky test

### DIFF
--- a/src/domain/event/formSections/classificationSection/__tests__/ClassificationSection.test.tsx
+++ b/src/domain/event/formSections/classificationSection/__tests__/ClassificationSection.test.tsx
@@ -261,6 +261,7 @@ test('should change keyword', async () => {
 
   const keywordOption = await findElement('keywordOption');
   await user.click(keywordOption);
+  await user.keyboard('{Escape}');
 
   await screen.findByRole('button', {
     name: new RegExp(


### PR DESCRIPTION
Tests sometimes fail like https://github.com/City-of-Helsinki/linkedcomponents-ui/actions/runs/27411014606/job/81012001126

Fix: close keyword dropdown after selection so onClose is triggered, updating the formik value and selectedKeywords state, which allows the "1 valittu vaihtoehto" button assertion to reliably pass. This matches the pattern already used in other tests in the codebase.

Refs: LINK-2581


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test validation for keyword selection in the classification section to ensure proper handling of keyboard interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->