### PR TITLE
test: fix flaky combobox test

### DIFF
--- a/src/domain/event/formSections/classificationSection/__tests__/ClassificationSection.test.tsx
+++ b/src/domain/event/formSections/classificationSection/__tests__/ClassificationSection.test.tsx
@@ -4,6 +4,7 @@ import { Formik } from 'formik';
 import getValue from '../../../../../utils/getValue';
 import { mockAuthenticatedLoginState } from '../../../../../utils/mockLoginHooks';
 import {
+  cleanup,
   configure,
   render,
   screen,
@@ -46,6 +47,7 @@ import ClassificationSection from '../ClassificationSection';
 configure({ defaultHidden: true });
 
 afterEach(() => {
+  cleanup();
   vi.resetAllMocks();
 });
 
@@ -263,12 +265,16 @@ test('should change keyword', async () => {
   await user.click(keywordOption);
   await user.keyboard('{Escape}');
 
-  await screen.findByRole('button', {
-    name: new RegExp(
-      `1 valittu vaihtoehto.*${getValue(keyword?.name?.fi, '')}`,
-      'i'
-    ),
-  });
+  await screen.findByRole(
+    'button',
+    {
+      name: new RegExp(
+        `1 valittu vaihtoehto.*${getValue(keyword?.name?.fi, '')}`,
+        'i'
+      ),
+    },
+    { timeout: 5000 }
+  );
 });
 
 test('should show correct validation error if none main category is selected', async () => {


### PR DESCRIPTION
Refs: LINK-2581

## Description :sparkles:

Hopefully now fixes the combobox test which failed often in CI.

## Issues :bug:

### Closes :no_good_woman:

**[LINK-2581](https://helsinkisolutionoffice.atlassian.net/browse/LINK-2581):**

[LINK-2581]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-2581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by ensuring React Testing Library cleanup runs after each test.
  * Updated the selected-keyword UI assertion to wait for the option button to appear asynchronously (with a longer timeout), while preserving the existing verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->