### PR TITLE
test: fix flaky keyword selection in ClassificationSection

### DIFF
--- a/src/domain/event/formSections/classificationSection/__tests__/ClassificationSection.test.tsx
+++ b/src/domain/event/formSections/classificationSection/__tests__/ClassificationSection.test.tsx
@@ -6,6 +6,7 @@ import { mockAuthenticatedLoginState } from '../../../../../utils/mockLoginHooks
 import {
   cleanup,
   configure,
+  fireEvent,
   render,
   screen,
   setupUser,
@@ -52,6 +53,7 @@ afterEach(() => {
 });
 
 beforeEach(() => {
+  vi.useRealTimers();
   mockAuthenticatedLoginState();
 });
 
@@ -254,26 +256,24 @@ test('should change keyword', async () => {
   const user = setupUser();
   renderComponent();
 
-  const toggleButton = getElement('toggleButton');
-  await user.click(toggleButton);
+  const keywordName = getValue(keyword?.name?.fi, '');
+  const mainCategories = getElement('mainCategories');
 
-  expect(
-    await screen.findByRole('combobox', { name: /hae/i })
-  ).toBeInTheDocument();
+  await user.click(getElement('toggleButton'));
 
-  const keywordOption = await findElement('keywordOption');
-  await user.click(keywordOption);
-  await user.keyboard('{Escape}');
+  await screen.findByRole('combobox', { name: /hae/i });
 
-  await screen.findByRole(
-    'button',
-    {
-      name: new RegExp(
-        `1 valittu vaihtoehto.*${getValue(keyword?.name?.fi, '')}`,
-        'i'
-      ),
-    },
-    { timeout: 5000 }
+  const listbox = await screen.findByRole('listbox');
+  const keywordOption = await within(listbox).findByRole('option', {
+    name: keywordName,
+  });
+  fireEvent.click(keywordOption);
+  await user.click(document.body);
+
+  await waitFor(
+    () =>
+      expect(within(mainCategories).getByLabelText(keywordName)).toBeChecked(),
+    { timeout: 10000 }
   );
 });
 


### PR DESCRIPTION
## Description :sparkles:

Fix try no 3.

## Issues :bug:

### Closes :no_good_woman:

**[LINK-2581](https://helsinkisolutionoffice.atlassian.net/browse/LINK-2581):**


[LINK-2581]: https://helsinkisolutionoffice.atlassian.net/browse/LINK-2581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test cleanup and timer handling for more reliable test execution.
  * Updated keyword selection coverage to verify that the corresponding category checkbox is checked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->